### PR TITLE
Update package.json in preparation for publishing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1802,7 +1802,8 @@
     "@magicleap/prismatic": {
       "version": "0.17.5",
       "resolved": "https://registry.npmjs.org/@magicleap/prismatic/-/prismatic-0.17.5.tgz",
-      "integrity": "sha512-tnSru/ua7hzQSjI4nj0198BPNQBdj8Sn9yESFOFuNN3cbM6JfvPMOeTNXle7kJ7in9wE6j0WYoaJjratzm94Eg=="
+      "integrity": "sha512-tnSru/ua7hzQSjI4nj0198BPNQBdj8Sn9yESFOFuNN3cbM6JfvPMOeTNXle7kJ7in9wE6j0WYoaJjratzm94Eg==",
+      "dev": true
     },
     "@polymer/esm-amd-loader": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -2,26 +2,58 @@
   "name": "@google/model-viewer",
   "version": "0.0.1",
   "description": "Easily display interactive 3D models on the web and in AR!",
+  "repository": "https://github.com/GoogleWebComponents/model-viewer",
+  "bugs": {
+    "url": "https://github.com/GoogleWebComponents/model-viewer/issues"
+  },
+  "homepage": "https://github.com/GoogleWebComponents/model-viewer#readme",
+  "license": "Apache-2.0",
+  "contributors": [
+    "Jordan Santell <jsantell@google.com>",
+    "Chris Joel <cdata@google.com>",
+    "Ricardo Cabello <ricardocabello@google.com>",
+    "Matt Small <mbsmall@google.com>"
+  ],
   "main": "./lib/model-viewer-element.js",
+  "module": "./lib/model-viewer-element.js",
   "files": [
+    "src",
     "lib",
-    "dist"
+    "dist/model-viewer-element.js",
+    "dist/unit-tests.js",
+    "test.html",
+    "POLYFILLS.md",
+    "wct.conf.json"
   ],
   "scripts": {
     "clean": "rm -rf ./lib ./dist",
     "build": "tsc && rollup -c",
-    "prepare": "npm run build",
+    "prepublishOnly": "npm run build",
     "test": "npm run clean && npm run build && wct",
     "serve": "ws",
     "watch": "chokidar --initial src/*.js src/**/*.js -c \"npm run build\"",
     "dev": "concurrently \"npm run watch\" \"npm run serve\""
   },
-  "author": "Jordan Santell <jsantell@google.com>",
-  "license": "Apache-2.0",
+  "keywords": [
+    "ar",
+    "gltf",
+    "glb",
+    "webar",
+    "webvr",
+    "webxr",
+    "arcore",
+    "arkit",
+    "webaronarcore",
+    "webaronarkit",
+    "augmented reality",
+    "model-viewer",
+    "3d"
+  ],
   "devDependencies": {
     "@polymer/iron-demo-helpers": "^3.0.2",
     "@polymer/paper-button": "^3.0.1",
     "@webcomponents/webcomponentsjs": "^2.1.3",
+    "@magicleap/prismatic": "^0.17.5",
     "babel-eslint": "^8.2.3",
     "chai": "^4.1.2",
     "chokidar-cli": "^1.2.1",
@@ -40,22 +72,11 @@
     "wct-browser-legacy": "^1.0.1",
     "web-component-tester": "^6.9.0"
   },
-  "keywords": [
-    "webar",
-    "webvr",
-    "webxr",
-    "arcore",
-    "arkit",
-    "webaronarcore",
-    "webaronarkit",
-    "augmented reality",
-    "xr-model",
-    "3d"
-  ],
-  "repository": "https://github.com/GoogleWebComponents/model-viewer",
   "dependencies": {
-    "@magicleap/prismatic": "^0.17.5",
     "@polymer/lit-element": "^0.6.2",
     "three": "^0.94.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
NPM: https://www.npmjs.com/package/@google/model-viewer
Webcomponents.org: https://www.webcomponents.org/element/@google/model-viewer
Unpkg.com: https://unpkg.com/@google/model-viewer@0.0.1/

Unfortunately, Webcomponents.org picks up the elements that are defined in tests. I'm going to bug @samuelli about this next week to see if there is anything we can do.