### PR TITLE
Render fixes

### DIFF
--- a/examples/background-image.html
+++ b/examples/background-image.html
@@ -92,6 +92,8 @@
             </template>
         </demo-snippet>
 
+        <!-- Disable demo due to memory leak @TODO #138 -->
+        <!--
         <demo-snippet>
             <h2>Cycling background image</h2>
             <template>
@@ -104,6 +106,7 @@
                 </script>
             </template>
         </demo-snippet>
+        -->
 
         <div class="attribution">
           Astronaut by <a href="https://poly.google.com/user/4aEd8rQgKu2">Poly</a>,

--- a/src/features/environment.js
+++ b/src/features/environment.js
@@ -15,7 +15,6 @@
 
 import {Color} from 'three';
 
-import {$needsRender, $onModelLoad, $renderer, $scene} from '../model-viewer-element-base.js';
 import {$needsRender, $onModelLoad, $renderer, $scene, $tick} from '../model-viewer-element-base.js';
 import EnvMapGenerator from '../three-components/EnvMapGenerator.js';
 import {toCubemapAndEquirect} from '../three-components/TextureUtils.js';
@@ -74,8 +73,8 @@ export const EnvironmentMixin = (ModelViewerElement) => {
         }
 
         if (textures) {
-          textures.equirect.name = backgroundImage;
           textures.cubemap.name = backgroundImage;
+          textures.equirect.name = backgroundImage;
           this[$setEnvironmentImage](textures.equirect, textures.cubemap);
           return;
         }
@@ -127,8 +126,8 @@ export const EnvironmentMixin = (ModelViewerElement) => {
       this[$scene].skysphere.material.needsUpdate = true;
 
       // TODO can cache this per renderer and color
-      this[$currentCubemap] =
-          this[$envMapGenerator].generate(DEFAULT_ENVMAP_SIZE);
+      const cubemap = this[$envMapGenerator].generate(DEFAULT_ENVMAP_SIZE);
+      this[$currentCubemap] = cubemap;
       this[$scene].model.applyEnvironmentMap(this[$currentCubemap]);
 
       this[$needsRender]();

--- a/src/three-components/CachingGLTFLoader.js
+++ b/src/three-components/CachingGLTFLoader.js
@@ -37,6 +37,23 @@ export class CachingGLTFLoader {
 
     const gltf = await cache.get(url);
 
-    return gltf.scene ? gltf.scene.clone(true) : null;
+    const model = gltf.scene ? gltf.scene.clone(true) : null;
+
+    // Materials aren't cloned when cloning meshes; geometry
+    // and materials are copied by reference. This is necessary
+    // for the same model to be used twice with different
+    // environment maps.
+    if (model) {
+      model.traverse(object => {
+        // Set a high renderOrder while we're here to ensure the model
+        // always renders on top of the skysphere
+        object.renderOrder = 1000;
+        if (object.material) {
+          object.material = object.material.clone();
+        }
+      });
+    }
+
+    return model;
   }
 }

--- a/src/three-components/ModelScene.js
+++ b/src/three-components/ModelScene.js
@@ -91,6 +91,9 @@ export default class ModelScene extends Scene {
     const skysphereMat = new MeshBasicMaterial(
         {side: BackSide, color: 0xffffff, depthTest: false, depthWrite: false});
     this.skysphere = new Mesh(skysphereGeo, skysphereMat);
+    // Ensure the skysphere is rendered before anything else due to
+    // depthTest=false
+    this.skysphere.renderOrder = 1;
 
     this.add(this.pivot);
     this.add(this.light);


### PR DESCRIPTION
* Broken out from #133
* Fixes #101, #120 render glitches from #94/skysphere depth test change. I think this fixes all the weird rendering issues I've seen.
* Fixes CachedGLTFLoader instances sharing materials (and environment maps) resulting in race conditions to determine what envmap is displayed