### PR TITLE
Flip skysphere's X axis so that it matches the orientation of the environment map applied on models

### DIFF
--- a/src/test/three-components/ModelScene-spec.js
+++ b/src/test/three-components/ModelScene-spec.js
@@ -27,9 +27,9 @@ function invertPad(vec3) {
 
 // Checks that the skysphere is within the camera's far plane
 function ensureSkysphereVisible(scene) {
-  expect(scene.skysphere.scale.x).to.be.equal(scene.skysphere.scale.y);
+  expect(-1 * scene.skysphere.scale.x).to.be.equal(scene.skysphere.scale.y);
   expect(scene.skysphere.scale.y).to.be.equal(scene.skysphere.scale.z);
-  expect(scene.skysphere.scale.x).to.be.lessThan(scene.camera.far);
+  expect(-1 * scene.skysphere.scale.x).to.be.lessThan(scene.camera.far);
 }
 
 function ensureRoomFitsAspect(roomBox, aspect) {
@@ -156,7 +156,7 @@ suite('ModelScene', () => {
       const size = new Vector3();
       scene.roomBox.getSize(size);
 
-      expect(scene.skysphere.scale.x).to.be.greaterThan(size.x);
+      expect(-1 * scene.skysphere.scale.x).to.be.greaterThan(size.x);
       expect(scene.skysphere.scale.y).to.be.greaterThan(size.y);
       expect(scene.skysphere.scale.z).to.be.greaterThan(size.z);
       ensureSkysphereVisible(scene);

--- a/src/three-components/ModelScene.js
+++ b/src/three-components/ModelScene.js
@@ -194,6 +194,7 @@ export default class ModelScene extends Scene {
     const skysphereSize =
         Math.max(this.roomSize.x, this.roomSize.y, this.roomSize.z) * 2;
     this.skysphere.scale.setScalar(skysphereSize);
+    this.skysphere.scale.x *= -1;
 
     this.updateStaticShadow();
   }


### PR DESCRIPTION
see the examples in http://localhost:8000/examples/background-image.html and you'll see the skysphere does not match the environment map. This is now fixed:

![screenshot from 2018-11-11 09-31-24](https://user-images.githubusercontent.com/641267/48316158-b76b8e80-e594-11e8-8416-7bfbcc72e0d4.png)
