### PR TITLE
Fix texture memory leak

### DIFF
--- a/examples/background-image.html
+++ b/examples/background-image.html
@@ -92,8 +92,6 @@
             </template>
         </demo-snippet>
 
-        <!-- Disable demo due to memory leak @TODO #138 -->
-        <!--
         <demo-snippet>
             <h2>Cycling background image</h2>
             <template>
@@ -102,11 +100,10 @@
                     const images = ['assets/equirectangular.png', 'does-not-exist.png', ''];
                     let i = 0;
                     setInterval(() =>
-                        $('#toggle-image').setAttribute('background-image', images[i++ % 3]), 1000);
+                        $('#toggle-image').setAttribute('background-image', images[i++ % 3]), 2000);
                 </script>
             </template>
         </demo-snippet>
-        -->
 
         <div class="attribution">
           Astronaut by <a href="https://poly.google.com/user/4aEd8rQgKu2">Poly</a>,

--- a/src/three-components/EnvMapGenerator.js
+++ b/src/three-components/EnvMapGenerator.js
@@ -13,14 +13,15 @@
  * limitations under the License.
  */
 
-import {BackSide, CubeCamera, Mesh, MeshBasicMaterial, PlaneBufferGeometry, PointLight, Scene, Vector3} from 'three';
+import {BackSide, CubeCamera, EventDispatcher, Mesh, MeshBasicMaterial, PlaneBufferGeometry, PointLight, Scene, Vector3} from 'three';
 
 import Sky from '../third_party/three/Sky.js';
 
 const SKYSPHERE_SIZE = 10000;
 
-export default class EnvMapGenerator {
+export default class EnvMapGenerator extends EventDispatcher {
   constructor(renderer) {
+    super();
     this.renderer = renderer;
     this.scene = new Scene();
 
@@ -46,6 +47,8 @@ export default class EnvMapGenerator {
     this.sky.material.uniforms.mieDirectionalG.value = 0.8;
     this.sky.material.uniforms.sunPosition.value = sunPosition;
     this.scene.add(this.sky);
+
+    this.camera = new CubeCamera(1, SKYSPHERE_SIZE * 3, this.maxMapSize);
   }
 
   /**
@@ -55,7 +58,7 @@ export default class EnvMapGenerator {
    */
   generate(mapSize) {
     mapSize = Math.min(mapSize, this.maxMapSize);
-    this.camera = new CubeCamera(1, SKYSPHERE_SIZE * 3, mapSize);
+    this.camera.renderTarget.setSize(mapSize, mapSize);
     this.camera.clear(this.renderer);
     this.camera.update(this.renderer, this.scene);
 

--- a/src/three-components/Renderer.js
+++ b/src/three-components/Renderer.js
@@ -18,6 +18,7 @@ import {EventDispatcher, WebGLRenderer} from 'three';
 import {IS_AR_CANDIDATE} from '../constants.js';
 import {$tick} from '../model-viewer-element-base.js';
 
+import TextureUtils from './TextureUtils.js';
 import {ARRenderer} from './ARRenderer.js';
 
 const GAMMA_FACTOR = 2.2;
@@ -58,6 +59,7 @@ export default class Renderer extends EventDispatcher {
     this.renderer.gammaFactor = GAMMA_FACTOR;
 
     this[$arRenderer] = ARRenderer.fromInlineRenderer(this);
+    this.textureUtils = new TextureUtils(this.renderer);
 
     this.scenes = new Set();
     this.scenesRendered = 0;
@@ -160,5 +162,11 @@ export default class Renderer extends EventDispatcher {
       this.scenesRendered++;
     }
     this.lastTick = t;
+  }
+
+  dispose() {
+    super.dispose();
+    this.textureUtils.dispose();
+    this.textureUtils = null;
   }
 }

--- a/src/three-components/TextureUtils.js
+++ b/src/three-components/TextureUtils.js
@@ -13,48 +13,96 @@
  * limitations under the License.
  */
 
-import {TextureLoader} from 'three';
+import {EventDispatcher, TextureLoader} from 'three';
+
 import EquirectangularToCubemap from '../third_party/three.equirectangular-to-cubemap/EquirectangularToCubemap.js';
 
-const CUBE_MAP_SIZE = 1024;
+import EnvMapGenerator from './EnvMapGenerator.js';
+
 const loader = new TextureLoader();
+const defaultConfig = {
+  cubemapSize: 1024,
+  synthesizedEnvmapSize: 512,
+};
 
-export const loadTexture = (url) =>
-    new Promise((res, rej) => loader.load(url, res, undefined, rej));
+export default class TextureManager extends EventDispatcher {
+  /**
+   * @param {THREE.WebGLRenderer} renderer
+   * @param {?number} config.cubemapSize [1024]
+   * @param {?number} config.synthesizedEnvmapSize [512]
+   */
+  constructor(renderer, config = {}) {
+    super();
+    this.config = {...defaultConfig, ...config};
+    this.renderer = renderer;
+    this.cubemapGenerator = new EquirectangularToCubemap(this.renderer);
+    this.envMapGenerator = new EnvMapGenerator(this.renderer);
+  }
 
-/**
- * The texture returned here is from a WebGLRenderCubeTarget,
- * which is not the same as a THREE.CubeTexture, and just what
- * the current THREE.CubeCamera uses, and has the same effect
- * when being used as an environment map.
- *
- * @param {THREE.Renderer} renderer
- * @param {THREE.Texture} texture
- * @return {THREE.Texture}
- */
-export const equirectangularToCubemap =
-    async function(renderer, texture) {
-  const equiToCube = new EquirectangularToCubemap(renderer);
-  const cubemap = equiToCube.convert(texture, CUBE_MAP_SIZE);
-  return cubemap;
-}
+  /**
+   * @param {string} url
+   * @return {Promise<THREE.Texture>}
+   */
+  load(url) {
+    return new Promise(
+        (resolve, reject) => loader.load(url, resolve, undefined, reject));
+  }
 
-/**
- * Returns a { equirect, cubemap } object with the textures
- * accordingly, or null if cannot generate a texture from
- * the URL.
- *
- * @see equirectangularToCubemap with regard to the THREE types.
- * @param {THREE.Renderer} renderer
- * @param {string} url
- * @return {object}
- */
-export const toCubemapAndEquirect = async (renderer, url) => {
-  try {
-    const equirect = await loadTexture(url);
-    const cubemap = await equirectangularToCubemap(renderer, equirect);
-    return {equirect, cubemap};
-  } catch (e) {
-    return null;
+  /**
+   * @param {?number} size
+   * @return {THREE.Texture}
+   */
+  generateDefaultEnvMap(size) {
+    const mapSize = size || this.config.synthesizedEnvmapSize;
+    return this.envMapGenerator.generate(mapSize);
+  }
+
+  /**
+   * The texture returned here is from a WebGLRenderCubeTarget,
+   * which is not the same as a THREE.CubeTexture, and just what
+   * the current THREE.CubeCamera uses, and has the same effect
+   * when being used as an environment map.
+   *
+   * @param {THREE.Texture} texture
+   * @param {?number} size
+   * @return {THREE.Texture}
+   */
+  equirectangularToCubemap(texture, size) {
+    const mapSize = size || this.config.cubemapSize;
+    const cubemap = this.cubemapGenerator.convert(texture, mapSize);
+    return cubemap;
+  }
+
+  /**
+   * Returns a { equirect, cubemap } object with the textures
+   * accordingly, or null if cannot generate a texture from
+   * the URL.
+   *
+   * @see equirectangularToCubemap with regard to the THREE types.
+   * @param {string} url
+   * @return {Promise<Object|null>}
+   */
+  async toCubemapAndEquirect(url) {
+    let equirect, cubemap;
+    try {
+      equirect = await this.load(url);
+      cubemap = await this.equirectangularToCubemap(equirect);
+      return {equirect, cubemap};
+    } catch (e) {
+      if (equirect) {
+        equirect.dispose();
+      }
+      if (cubemap) {
+        cubemap.dispose();
+      }
+      return null;
+    }
+  }
+
+  dispose() {
+    this.cubemapGenerator.camera.renderTarget.dispose();
+    this.envMapGenerator.camera.renderTarget.dispose();
+    this.cubemapGenerator = null;
+    this.envMapGenerator = null;
   }
 }


### PR DESCRIPTION
Convert TextureUtils to TextureManager such that the renderer owns themanager so new texture helper instances do not need to be created, and properly dispose of textures that are no longer being used. Fixes #138, memory leak introduced by textures.