### PR TITLE
minor changes to examples and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 
 `<model-viewer>` is a web component that makes rendering interactive 3D
 models - optionally in AR - easy to do, without writing any code, on as many
-browsers and devices as possible.
+browsers and devices as possible. This component will strive to have great
+defaults for rendering quality and performance.
 
 As new standards and APIs become available `<model-viewer>` will be improved
 to take advantage of them. If possible, fallbacks and polyfills will be

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
  [![NPM](https://img.shields.io/npm/v/@google/model-viewer.svg)](https://www.npmjs.com/package/@google/model-viewer)
 
 `<model-viewer>` is a web component that makes rendering interactive 3D
-models - optionally in AR - easy to do, without writing any code, on as many
-browsers and devices as possible. This component will strive to have great
-defaults for rendering quality and performance.
+models - optionally in AR - easy to do, on as many browsers and devices as possible.
+`<model-viewer>` strives to give you great defaults for rendering quality and
+performance.
 
 As new standards and APIs become available `<model-viewer>` will be improved
 to take advantage of them. If possible, fallbacks and polyfills will be

--- a/examples/index.html
+++ b/examples/index.html
@@ -56,7 +56,7 @@
             <li><a href="sources.html">sources.html</a>: Tests different configurations of loading model formats.</li>
             <li><a href="multiple-elements.html">multiple-elements.html</a>: Stress test of rendering 16 elements that require rendering on every frame, all in the view at once.</li>
             <li><a href="list.html">list.html</a>: Test of many elements on a page, and lazily rendering only when in view.</li>
-            <li><a href="pbr.html">pbr.html</a>: Showcase of high-resolution models with multiple textures and environment maps. <b>WARNING</b>: this page uses 50+MB of assets.</li>
+            <li><a href="pbr.html">pbr.html</a>: Showcase of high-resolution models with multiple textures and environment maps.</li>
         </ul>
 
         <demo-snippet>

--- a/examples/pbr.html
+++ b/examples/pbr.html
@@ -48,7 +48,7 @@
 
         <lazy-inject>
             <div class="heavy-bandwidth-warning">
-                <p>These examples use 50MB+ of assets. A local web server or landline connection is recommended.</p>
+                <p>These examples use 16MB+ of assets. A local web server or landline connection is recommended.</p>
                 <paper-button raised id="load-examples">Load examples</paper-button>
             </div>
             <template slot="lazy">


### PR DESCRIPTION
I'm not 100% happy with the README text, but I wanted to capture something like that.

With @jsantell's changes to async load the `pbr.html` examples, I don't think we need the warning in `index.html`, so I removed that (and updated the size to reflect the removal of the Flight Helmet sample).