### PR TITLE
Include error message with model load error

### DIFF
--- a/src/three-components/ModelScene.js
+++ b/src/three-components/ModelScene.js
@@ -131,7 +131,7 @@ export default class ModelScene extends Scene {
     try {
       await this.model.setSource(source);
     } catch (e) {
-      console.error(`Could not set model source: ${source}`);
+      console.error(`Could not set model source: ${source}: ${e.message}`);
     }
   }
 


### PR DESCRIPTION
I wasn't able to tell what the issue was with loading models (it was `THREE.GLTFLoader: Unsupported asset. glTF versions >=2.0 are supported. Use LegacyGLTFLoader instead.`). This change helped me debug the error more effectively in the console.
