### PR TITLE
Introduce types for Web XR API

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,13 +1,12 @@
 // NOTE(cdata): The HAS_WEBXR_* constants can be enabled in Chrome by turning on
 // the appropriate flags. However, just because we have the API does not
 // guarantee that AR will work.
-
 export const HAS_WEBXR_DEVICE_API = navigator.xr != null &&
     window.XRSession != null && window.XRDevice != null &&
     window.XRDevice.prototype.supportsSession != null;
 
 export const HAS_WEBXR_HIT_TEST_API =
-    HAS_WEBXR_DEVICE_API && window.XRSession.prototype.requestHitTest;
+    HAS_WEBXR_DEVICE_API && window.XRSession!.prototype.requestHitTest;
 
 export const HAS_FULLSCREEN_API = document.documentElement != null &&
     document.documentElement.requestFullscreen != null;
@@ -15,7 +14,8 @@ export const HAS_FULLSCREEN_API = document.documentElement != null &&
 export const IS_AR_CANDIDATE = HAS_WEBXR_HIT_TEST_API && HAS_FULLSCREEN_API;
 
 export const IS_MOBILE = (() => {
-  const userAgent = navigator.userAgent || navigator.vendor || window.opera;
+  const userAgent =
+      navigator.userAgent || navigator.vendor || (window as any).opera;
   let check = false;
   // eslint-disable-next-line
   if (/(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino/i
@@ -28,14 +28,12 @@ export const IS_MOBILE = (() => {
 })();
 
 export const IS_IOS =
-    /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
+    /iPad|iPhone|iPod/.test(navigator.userAgent) && !(window as any).MSStream;
 
 export const IS_AR_QUICKLOOK_CANDIDATE = (() => {
-    const tempAnchor = document.createElement('a');
+  const tempAnchor = document.createElement('a');
 
-    return Boolean(
-        tempAnchor.relList &&
-        tempAnchor.relList.supports &&
-        tempAnchor.relList.supports('ar')
-    );
+  return Boolean(
+      tempAnchor.relList && tempAnchor.relList.supports &&
+      tempAnchor.relList.supports('ar'));
 })();

--- a/src/types/webxr.d.ts
+++ b/src/types/webxr.d.ts
@@ -1,0 +1,64 @@
+type Constructor<T = object> = {
+  new (...args: any[]): T,
+  prototype: T
+};
+
+type XRFrameOfReferenceType = 'head-model'|'eye-level'|'stage';
+
+interface XRFrameOfReferenceOptions {
+  disableStageEmulation?: boolean;
+  stageEmulationHeight?: number;
+}
+
+interface XRCoordinateSystem extends EventTarget {
+  getTransformTo(other: XRCoordinateSystem): Float32Array;
+}
+
+interface XRStageBounds {
+  readonly geometry: DOMPointReadOnly[];
+}
+
+interface XRFrameOfReference extends XRCoordinateSystem {
+  readonly bounds?: XRStageBounds;
+  readonly emulatedHeight: number;
+
+  onboundschange?: (event: Event) => void;
+}
+
+interface XRPresentationContext {
+  readonly canvas: HTMLCanvasElement;
+}
+
+interface XRSessionCreationOptions {
+  immersive?: boolean;
+  outputContext: XRPresentationContext;
+}
+
+interface XRHitResult {
+  readonly hitMatrix: Float32Array;
+}
+
+interface XR extends EventTarget {
+  requestDevice(): Promise<XRDevice>;
+}
+
+interface XRSession {
+  requestHitTest(
+      origin: Float32Array, direction: Float32Array,
+      frameOfReference: XRFrameOfReference): Promise<XRHitResult[]>
+}
+
+interface XRDevice {
+  supportsSession(sessionOptions: XRSessionCreationOptions): Promise<boolean>;
+}
+
+interface Window {
+  XRSession?: Constructor<XRSession>;
+  XRDevice?: Constructor<XRDevice>;
+  XR?: Constructor<XR>;
+  XRHitResult?: Constructor<XRHitResult>;
+}
+
+interface Navigator {
+  xr?: XR;
+}


### PR DESCRIPTION
This change dips our toes in the TypeScript waters by introducing Web XR API types to the code base and converting our `constants` module over to TypeScript. As you can see from the diff, the changes required for conversion are minimal. Some notes:

 - Some globals, like `opera` and `MSStream` were not given types due to their limited relevance to what we are building
 - Web XR types are currently _not comprehensive_, and only include what is necessary for the `constants` module to compile
 - The Web XR API is rapidly changing, and as of right now the API in Canary does not track with the spec (which has already removed `requestDevice` from `XR` as of this change)