### PR TITLE
Remove hard dependency on ResizeObserver

### DIFF
--- a/POLYFILLS.md
+++ b/POLYFILLS.md
@@ -39,10 +39,29 @@ fine. The following is a selection of recommended polyfill implementations:
 Please keep in mind that your mileage may vary depending on the browsers you
 need to support and the fidelity of the polyfills used.
 
-**NOTE:** The Fullscreen API is only necessary for the experimental Web XR
+### Regarding Fullscreen API
+
+The Fullscreen API is only necessary for the experimental Web XR
 Device API-based AR mode. Since this is only available behind a flag in Chrome
 Dev today, it is not necessary to load a Fullscreen API polyfill in production
 scenarios.
+
+### Regarding Resize Observer
+
+If Resize Observer is available in the page, the `<model-element>` will be able
+to automatically recompute the scale and framing of its 3D content in many types
+of scenarios where layout is changing (for example, when its parent container
+changes size due to an animation or transition).
+
+However, it is important to note that Resize Observer is optional because the
+polyfill is known to have performance consequences that might be considered
+unacceptable for some use cases (it uses a Mutation Observer that observes the
+whole document tree).
+
+If Resize Observer is _not_ available, the `<model-element>` will fall back to
+observing global `resize` events. In this condition, you can force the element
+to recompute its internal layout by dispatching a synthetic global `resize`
+event.
 
 ## Usage Example
 

--- a/POLYFILLS.md
+++ b/POLYFILLS.md
@@ -59,8 +59,8 @@ unacceptable for some use cases (it uses a Mutation Observer that observes the
 whole document tree).
 
 If Resize Observer is _not_ available, the `<model-element>` will fall back to
-observing global `resize` events. In this condition, you can force the element
-to recompute its internal layout by dispatching a synthetic global `resize`
+observing window `resize` events. In this condition, you can force the element
+to recompute its internal layout by dispatching a synthetic window `resize`
 event.
 
 ## Usage Example

--- a/POLYFILLS.md
+++ b/POLYFILLS.md
@@ -1,20 +1,25 @@
 # Polyfills
 
-`<model-viewer>` relies on standardized features of the Web Platform to do a lot of
-what it does. Some of these features are very new and don't exist in all
+`<model-viewer>` relies on standardized features of the Web Platform to do a lot
+of what it does. Some of these features are very new and don't exist in all
 browsers yet. In order to maximize browser compatibility, you should install
 [polyfills](https://en.wikipedia.org/wiki/Polyfill_(programming)) to fill in the
 gaps for some of the newest features.
 
 ## Browser Support
 
-The following emerging standard web platform APIs are needed by this library:
+The following emerging standard web platform APIs are required by
+`<model-viewer>`:
 
  - [Custom Elements](https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements) ([CanIUse](https://caniuse.com/#feat=custom-elementsv1), [Platform Status](https://www.chromestatus.com/features/4696261944934400))
  - [Shadow DOM](https://dom.spec.whatwg.org/#shadow-trees) ([CanIUse](https://caniuse.com/#feat=shadowdomv1), [Platform Status](https://www.chromestatus.com/features/4667415417847808))
- - [Resize Observer](https://wicg.github.io/ResizeObserver/) ([CanIUse](https://caniuse.com/#feat=resizeobserver), [Platform Status](https://www.chromestatus.com/features/5705346022637568))
  - [Intersection Observer](https://w3c.github.io/IntersectionObserver/) ([CanIUse](https://caniuse.com/#feat=intersectionobserver), [Platform Status](https://www.chromestatus.com/features/5695342691483648))
  - [Fullscreen API](https://fullscreen.spec.whatwg.org/) ([CanIUse](https://caniuse.com/#feat=fullscreen), [Platform Status](https://www.chromestatus.com/features/6596356319739904))
+
+The following emerging web platform API is optional, and will be used by
+`<model-viewer>` if it is detected on the page:
+
+ - [Resize Observer](https://wicg.github.io/ResizeObserver/) ([CanIUse](https://caniuse.com/#feat=resizeobserver), [Platform Status](https://www.chromestatus.com/features/5705346022637568))
 
 Additionally, the following _highly experimental and volatile_ APIs are needed
 to enable in-browser AR (currently available in Chrome Canary only):
@@ -65,8 +70,7 @@ the rest of your application code:
 
     <!-- Web Components polyfill is required to support Edge and Firefox < 63: -->
     <script src="./node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
-
-    <!-- Resize Observer polyfill is required for non-Chrome browsers: -->
+    <!-- Resize Observer polyfill is optional, and improves resize behavior in non-Chrome browsers: -->
     <script src="./node_modules/resize-observer-polyfill/dist/ResizeObserver.js"></script>
 
     <!-- Intersection Observer polyfill is required for Safari and IE11 -->

--- a/README.md
+++ b/README.md
@@ -117,13 +117,17 @@ learn how to polyfill for maximum browser compatibility!**
 
 Feature                   | Chrome | Canary | Safari 12 | Firefox 63 | Firefox 62 | Edge  | IE 11
 --------------------------|--------|--------|-----------|------------|------------|-------|------
-Resize Observer           |     ✅ |     ✅ |        🚧 |         🚧 |         🚧 |    🚧 |   🚧
+Resize Observer¹          |     ✅ |     ✅ |        🚧 |         🚧 |         🚧 |    🚧 |   🚧
 Custom Elements           |     ✅ |     ✅ |        ✅ |         🚧 |         🚧 |    🚧 |   🚧
 Shadow DOM                |     ✅ |     ✅ |        ✅ |         ✅ |         🚧 |    🚧 |   🚧
 Intersection Observer     |     ✅ |     ✅ |        🚧 |         ✅ |         ✅ |    ✅ |   🚧
 Fullscreen API            |     🚧 |     ✅ |        🚧 |         🚧 |         🚧 |    🚧 |   🚧
 WebXR Device API          |     🚫 |     🎌 |        🚫 |         🚫 |         🚫 |    🚫 |   🚫
 WebXR HitTest API         |     🚫 |     🎌 |        🚫 |         🚫 |         🚫 |    🚫 |   🚫
+
+_1: Resize Observer is optional, and will be used if available. For more details
+please refer to
+[POLYFILLS.md](https://github.com/PolymerLabs/model-viewer/blob/master/POLYFILLS.md#regarding-resize-observer)_
 
 ### IE 11 Support
 

--- a/examples/augmented-reality.html
+++ b/examples/augmented-reality.html
@@ -36,7 +36,7 @@
   <!-- Intersection Observer polyfill is required for Safari and IE11 -->
   <script src="../node_modules/intersection-observer/intersection-observer.js"></script>
 
-  <!-- Resize Observer polyfill is required for non-Chrome browsers: -->
+  <!-- Resize Observer polyfill is optional, and improves resize behavior in non-Chrome browsers: -->
   <script src="../node_modules/resize-observer-polyfill/dist/ResizeObserver.js"></script>
 
   <!-- Fullscreen polyfill is required for using experimental AR features in Canary: -->

--- a/examples/background-color.html
+++ b/examples/background-color.html
@@ -37,7 +37,7 @@
   <!-- Intersection Observer polyfill is required for Safari and IE11 -->
   <script src="../node_modules/intersection-observer/intersection-observer.js"></script>
 
-  <!-- Resize Observer polyfill is required for non-Chrome browsers: -->
+  <!-- Resize Observer polyfill is optional, and improves resize behavior in non-Chrome browsers: -->
   <script src="../node_modules/resize-observer-polyfill/dist/ResizeObserver.js"></script>
 
   <!-- Fullscreen polyfill is required for using experimental AR features in Canary: -->

--- a/examples/background-image.html
+++ b/examples/background-image.html
@@ -37,7 +37,7 @@
   <!-- Intersection Observer polyfill is required for Safari and IE11 -->
   <script src="../node_modules/intersection-observer/intersection-observer.js"></script>
 
-  <!-- Resize Observer polyfill is required for non-Chrome browsers: -->
+  <!-- Resize Observer polyfill is optional, and improves resize behavior in non-Chrome browsers: -->
   <script src="../node_modules/resize-observer-polyfill/dist/ResizeObserver.js"></script>
 
   <!-- Fullscreen polyfill is required for using experimental AR features in Canary: -->

--- a/examples/default.html
+++ b/examples/default.html
@@ -36,7 +36,7 @@
   <!-- Intersection Observer polyfill is required for Safari and IE11 -->
   <script src="../node_modules/intersection-observer/intersection-observer.js"></script>
 
-  <!-- Resize Observer polyfill is required for non-Chrome browsers: -->
+  <!-- Resize Observer polyfill is optional, and improves resize behavior in non-Chrome browsers: -->
   <script src="../node_modules/resize-observer-polyfill/dist/ResizeObserver.js"></script>
 
   <!-- Fullscreen polyfill is required for using experimental AR features in Canary: -->

--- a/examples/fuzzer.html
+++ b/examples/fuzzer.html
@@ -34,7 +34,7 @@
   <!-- Intersection Observer polyfill is required for Safari and IE11 -->
   <script src="../node_modules/intersection-observer/intersection-observer.js"></script>
 
-  <!-- Resize Observer polyfill is required for non-Chrome browsers: -->
+  <!-- Resize Observer polyfill is optional, and improves resize behavior in non-Chrome browsers: -->
   <script src="../node_modules/resize-observer-polyfill/dist/ResizeObserver.js"></script>
 
   <!-- Fullscreen polyfill is required for using experimental AR features in Canary: -->

--- a/examples/index.html
+++ b/examples/index.html
@@ -36,7 +36,7 @@
   <!-- Intersection Observer polyfill is required for Safari and IE11 -->
   <script src="../node_modules/intersection-observer/intersection-observer.js"></script>
 
-  <!-- Resize Observer polyfill is required for non-Chrome browsers: -->
+  <!-- Resize Observer polyfill is optional, and improves resize behavior in non-Chrome browsers: -->
   <script src="../node_modules/resize-observer-polyfill/dist/ResizeObserver.js"></script>
 
   <!-- Fullscreen polyfill is required for using experimental AR features in Canary: -->

--- a/examples/list.html
+++ b/examples/list.html
@@ -33,7 +33,7 @@
   <!-- Intersection Observer polyfill is required for Safari and IE11 -->
   <script src="../node_modules/intersection-observer/intersection-observer.js"></script>
 
-  <!-- Resize Observer polyfill is required for non-Chrome browsers: -->
+  <!-- Resize Observer polyfill is optional, and improves resize behavior in non-Chrome browsers: -->
   <script src="../node_modules/resize-observer-polyfill/dist/ResizeObserver.js"></script>
 
   <!-- Fullscreen polyfill is required for using experimental AR features in Canary: -->

--- a/examples/loading.html
+++ b/examples/loading.html
@@ -37,7 +37,7 @@
   <!-- Intersection Observer polyfill is required for Safari and IE11 -->
   <script src="../node_modules/intersection-observer/intersection-observer.js"></script>
 
-  <!-- Resize Observer polyfill is required for non-Chrome browsers: -->
+  <!-- Resize Observer polyfill is optional, and improves resize behavior in non-Chrome browsers: -->
   <script src="../node_modules/resize-observer-polyfill/dist/ResizeObserver.js"></script>
 
   <!-- Fullscreen polyfill is required for using experimental AR features in Canary: -->

--- a/examples/multiple-elements.html
+++ b/examples/multiple-elements.html
@@ -36,7 +36,7 @@
   <!-- Intersection Observer polyfill is required for Safari and IE11 -->
   <script src="../node_modules/intersection-observer/intersection-observer.js"></script>
 
-  <!-- Resize Observer polyfill is required for non-Chrome browsers: -->
+  <!-- Resize Observer polyfill is optional, and improves resize behavior in non-Chrome browsers: -->
   <script src="../node_modules/resize-observer-polyfill/dist/ResizeObserver.js"></script>
 
   <!-- Fullscreen polyfill is required for using experimental AR features in Canary: -->

--- a/examples/pbr.html
+++ b/examples/pbr.html
@@ -36,7 +36,7 @@
   <!-- Intersection Observer polyfill is required for Safari and IE11 -->
   <script src="../node_modules/intersection-observer/intersection-observer.js"></script>
 
-  <!-- Resize Observer polyfill is required for non-Chrome browsers: -->
+  <!-- Resize Observer polyfill is optional, and improves resize behavior in non-Chrome browsers: -->
   <script src="../node_modules/resize-observer-polyfill/dist/ResizeObserver.js"></script>
 
   <!-- Fullscreen polyfill is required to support all stable browsers: -->

--- a/examples/sources.html
+++ b/examples/sources.html
@@ -37,7 +37,7 @@
   <!-- Intersection Observer polyfill is required for Safari and IE11 -->
   <script src="../node_modules/intersection-observer/intersection-observer.js"></script>
 
-  <!-- Resize Observer polyfill is required for non-Chrome browsers: -->
+  <!-- Resize Observer polyfill is optional, and improves resize behavior in non-Chrome browsers: -->
   <script src="../node_modules/resize-observer-polyfill/dist/ResizeObserver.js"></script>
 
   <!-- Fullscreen polyfill is required for using experimental AR features in Canary: -->

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,20 +2,22 @@
 // the appropriate flags. However, just because we have the API does not
 // guarantee that AR will work.
 export const HAS_WEBXR_DEVICE_API = navigator.xr != null &&
-    window.XRSession != null && window.XRDevice != null &&
-    window.XRDevice.prototype.supportsSession != null;
+    self.XRSession != null && self.XRDevice != null &&
+    self.XRDevice.prototype.supportsSession != null;
 
 export const HAS_WEBXR_HIT_TEST_API =
-    HAS_WEBXR_DEVICE_API && window.XRSession!.prototype.requestHitTest;
+    HAS_WEBXR_DEVICE_API && self.XRSession!.prototype.requestHitTest;
 
 export const HAS_FULLSCREEN_API = document.documentElement != null &&
     document.documentElement.requestFullscreen != null;
+
+export const HAS_RESIZE_OBSERVER = self.ResizeObserver != null;
 
 export const IS_AR_CANDIDATE = HAS_WEBXR_HIT_TEST_API && HAS_FULLSCREEN_API;
 
 export const IS_MOBILE = (() => {
   const userAgent =
-      navigator.userAgent || navigator.vendor || (window as any).opera;
+      navigator.userAgent || navigator.vendor || (self as any).opera;
   let check = false;
   // eslint-disable-next-line
   if (/(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino/i
@@ -28,7 +30,7 @@ export const IS_MOBILE = (() => {
 })();
 
 export const IS_IOS =
-    /iPad|iPhone|iPod/.test(navigator.userAgent) && !(window as any).MSStream;
+    /iPad|iPhone|iPod/.test(navigator.userAgent) && !(self as any).MSStream;
 
 export const IS_AR_QUICKLOOK_CANDIDATE = (() => {
   const tempAnchor = document.createElement('a');

--- a/src/model-viewer-base.js
+++ b/src/model-viewer-base.js
@@ -115,20 +115,21 @@ export default class ModelViewerElementBase extends UpdatingElement {
 
     // Set a resize observer so we can scale our canvas
     // if our <model-viewer> changes
-    this.resizeObserver = HAS_RESIZE_OBSERVER ? new ResizeObserver(entries => {
-      // Don't resize anything if in AR mode; otherwise the canvas
-      // scaling to fullscreen on entering AR will clobber the flat/2d
-      // dimensions of the element.
-      if (renderer.isPresenting) {
-        return;
-      }
-      for (let entry of entries) {
-        if (entry.target === this) {
-          this[$updateSize](entry.contentRect);
-        }
-      }
-    }) :
-                                                null;
+    this.resizeObserver = HAS_RESIZE_OBSERVER ?
+        new ResizeObserver((entries) => {
+          // Don't resize anything if in AR mode; otherwise the canvas
+          // scaling to fullscreen on entering AR will clobber the flat/2d
+          // dimensions of the element.
+          if (renderer.isPresenting) {
+            return;
+          }
+          for (let entry of entries) {
+            if (entry.target === this) {
+              this[$updateSize](entry.contentRect);
+            }
+          }
+        }) :
+        null;
 
     this.intersectionObserver = new IntersectionObserver(entries => {
       for (let entry of entries) {

--- a/src/template.js
+++ b/src/template.js
@@ -20,6 +20,7 @@ template.innerHTML = `
   <style>
     :host {
       display: block;
+      contain: strict;
       width: 300px;
       height: 150px;
     }

--- a/src/types/resizeobserver.d.ts
+++ b/src/types/resizeobserver.d.ts
@@ -1,0 +1,9 @@
+interface ResizeObserver {
+  observe(element: Element): void;
+  unobserve(element: Element): void;
+  disconnect(): void;
+}
+
+interface Window {
+  ResizeObserver?: Constructor<ResizeObserver>
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -55,6 +55,23 @@ export const toFullUrl = (partialUrl) => {
   return url.toString();
 };
 
+
+export const debounce = (fn, ms) => {
+  let timer = null;
+
+  return (...args) => {
+    if (timer != null) {
+      self.clearTimeout(timer);
+    }
+
+    timer = self.setTimeout(() => {
+      timer = null;
+      fn(...args);
+    }, ms);
+  };
+};
+
+
 /**
  * Takes a URL to a USDZ file and sets the appropriate
  * fields so that Safari iOS can intent to their

--- a/test/index.html
+++ b/test/index.html
@@ -42,7 +42,7 @@
     }
   </script>
 
-  <!-- Resize Observer polyfill is required for non-Chrome browsers: -->
+  <!-- Resize Observer polyfill is optional, and improves resize behavior in non-Chrome browsers: -->
   <script src="../node_modules/resize-observer-polyfill/dist/ResizeObserver.js"></script>
 
   <!-- Fullscreen polyfill is required to support WebXR-based AR in stable browsers that support it: -->

--- a/test/legacy.html
+++ b/test/legacy.html
@@ -43,8 +43,8 @@
     }
   </script>
 
-  <!-- Resize Observer polyfill is required for non-Chrome browsers: -->
-  <script src="../node_modules/resize-observer-polyfill/dist/ResizeObserver.js"></script>
+  <!-- Resize Observer polyfill is optional, and improves resize behavior in non-Chrome browsers: -->
+  <!--<script src="../node_modules/resize-observer-polyfill/dist/ResizeObserver.js"></script>-->
 
   <!-- Fullscreen polyfill is required to support Web XR-based AR in stable browsers that support it: -->
   <!--<script src="../node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>-->


### PR DESCRIPTION
Some details about this change:

 - `ResizeObserver` is used if (and only if) the API is detected on the page
 - If `ResizeObserver` is not available, the element falls back to updating on global `resize` events
 - If global `resize` events are used, layout measurement is debounced with a 50ms threshold
 - Resize observation for all conditions is now enabled in `connectedCallback` and disabled in `disconnectedCallback`
 - `ResizeObserver` polyfill is no longer loaded in the "legacy" test suite in order to get coverage for the fallback condition
 - Docs have been updated to emphasize that `ResizeObserver` is optional and will be used only if available

Fixes #155 