### PR TITLE
Implement basic keyboard support for camera orbit

### DIFF
--- a/src/features/controls.js
+++ b/src/features/controls.js
@@ -16,8 +16,8 @@
 import {PerspectiveCamera, Vector3} from 'three';
 
 import {$needsRender, $onModelLoad, $onResize, $scene} from '../model-viewer-base.js';
-import OrbitControls from '../third_party/three/OrbitControls.js';
 import {FRAMED_HEIGHT} from '../three-components/ModelScene.js';
+import {PatchedOrbitControls} from '../three-components/PatchedOrbitControls.js';
 
 const ORBIT_NEAR_PLANE = 0.01;
 const ORBIT_FAR_PLANE = 1000;
@@ -58,7 +58,7 @@ export const ControlsMixin = (ModelViewerElement) => {
         this[$scene].setCamera(this[$orbitCamera]);
 
         this[$controls] =
-            new OrbitControls(this[$orbitCamera], this[$scene].canvas);
+            new PatchedOrbitControls(this[$orbitCamera], this[$scene].canvas);
         this[$controls].target.set(0, FRAMED_HEIGHT / 2, 0);
         this[$controls].enabled = true;
         // Panning performed via right click, two finger move

--- a/src/test/index.js
+++ b/src/test/index.js
@@ -20,6 +20,7 @@ import './three-components/Renderer-spec.js';
 import './three-components/ARRenderer-spec.js';
 import './three-components/TextureUtils-spec.js';
 import './three-components/CachingGLTFLoader-spec.js';
+import './three-components/PatchedOrbitControls-spec.js';
 import './features/controls-spec.js';
 import './features/environment-spec.js';
 import './features/loading-spec.js';

--- a/src/test/three-components/PatchedOrbitControls-spec.js
+++ b/src/test/three-components/PatchedOrbitControls-spec.js
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import {PerspectiveCamera, Vector3} from 'three';
+
+import {PatchedOrbitControls} from '../../three-components/PatchedOrbitControls.js';
+
+const expect = chai.expect;
+
+suite('PatchedOrbitControls', () => {
+  const origin = new Vector3(0, 0, 0);
+  const cameraStartingPosition = new Vector3(0, 0, 1);
+  let element;
+  let camera;
+  let controls;
+
+  setup(() => {
+    element = document.createElement('div');
+    camera = new PerspectiveCamera();
+    camera.position.copy(cameraStartingPosition);
+    controls = new PatchedOrbitControls(camera, element);
+    controls.enableKeys = false;
+  });
+
+  teardown(() => {
+    controls.dispose();
+  });
+
+  suite('global keyboard input', () => {
+    test('does not change orbital position of camera', () => {
+      const event = new CustomEvent('keydown');
+      event.keyCode = controls.keys.UP;
+      window.dispatchEvent(event);
+
+      expect(camera.position.z).to.be.equal(cameraStartingPosition.z);
+    });
+  });
+
+  suite('local keyboard input', () => {
+    test('changes orbital position of camera', () => {
+      const event = new CustomEvent('keydown');
+      event.keyCode = controls.keys.UP;
+      element.dispatchEvent(event);
+
+      expect(camera.position.z).to.not.be.equal(cameraStartingPosition.z);
+    });
+  });
+});
+
+window.V = Vector3;

--- a/src/third_party/three/OrbitControls.js
+++ b/src/third_party/three/OrbitControls.js
@@ -123,6 +123,15 @@ const OrbitControls = function ( object, domElement ) {
 
 	};
 
+  /**
+   * NOTE(cdata): This method is added to enable further patching in a
+   * subclass.
+   * @see src/three-components/PatchedOrbitControls.js
+   */
+  this.getSphericalDelta = function () {
+    return sphericalDelta;
+  };
+
 	// this method is exposed, but perhaps it would be better if we can make it private...
 	this.update = function () {
 

--- a/src/three-components/PatchedOrbitControls.js
+++ b/src/three-components/PatchedOrbitControls.js
@@ -30,6 +30,8 @@ export class PatchedOrbitControls extends OrbitControls {
 
     this[$onKeyDown] = (event) => this.onKeyDown(event);
     this.domElement.addEventListener('keydown', this[$onKeyDown]);
+
+    Object.assign(this.keys, {PAGE_UP: 33, PAGE_DOWN: 34});
   }
 
   dispose() {
@@ -41,6 +43,14 @@ export class PatchedOrbitControls extends OrbitControls {
     let handled = false;
 
     switch (event.keyCode) {
+      case this.keys.PAGE_UP:
+        this.zoomIn();
+        handled = true;
+        break;
+      case this.keys.PAGE_DOWN:
+        this.zoomOut();
+        handled = true;
+        break;
       case this.keys.UP:
         this.orbitUp(KEYBOARD_ORBIT_INCREMENT);
         handled = true;
@@ -63,6 +73,18 @@ export class PatchedOrbitControls extends OrbitControls {
       event.preventDefault();
       this.update();
     }
+  }
+
+  zoomIn() {
+    const event = new CustomEvent('wheel');
+    event.deltaY = -1;
+    this.domElement.dispatchEvent(event);
+  }
+
+  zoomOut() {
+    const event = new CustomEvent('wheel');
+    event.deltaY = 1;
+    this.domElement.dispatchEvent(event);
   }
 
   orbitUp(increment) {

--- a/src/three-components/PatchedOrbitControls.js
+++ b/src/three-components/PatchedOrbitControls.js
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import OrbitControls from '../third_party/three/OrbitControls.js';
+
+const $onKeyDown = Symbol('onKeyDown');
+
+const KEYBOARD_ORBIT_INCREMENT = Math.PI / 10;
+
+/**
+ * This patched extension of OrbitControls adds automatic support for
+ * controlling the orbit of the camera with the keyboard arrows when the
+ * element is focused.
+ */
+export class PatchedOrbitControls extends OrbitControls {
+  constructor(...args) {
+    super(...args);
+
+    this[$onKeyDown] = (event) => this.onKeyDown(event);
+    this.domElement.addEventListener('keydown', this[$onKeyDown]);
+  }
+
+  dispose() {
+    super.dispose();
+    this.domElement.removeEventListener('keydown', this[$onKeyDown]);
+  }
+
+  onKeyDown(event) {
+    let handled = false;
+
+    switch (event.keyCode) {
+      case this.keys.UP:
+        this.orbitUp(KEYBOARD_ORBIT_INCREMENT);
+        handled = true;
+        break;
+      case this.keys.BOTTOM:
+        this.orbitDown(KEYBOARD_ORBIT_INCREMENT);
+        handled = true;
+        break;
+      case this.keys.LEFT:
+        this.orbitLeft(KEYBOARD_ORBIT_INCREMENT);
+        handled = true;
+        break;
+      case this.keys.RIGHT:
+        this.orbitRight(KEYBOARD_ORBIT_INCREMENT);
+        handled = true;
+        break;
+    }
+
+    if (handled) {
+      event.preventDefault();
+      this.update();
+    }
+  }
+
+  orbitUp(increment) {
+    this.getSphericalDelta().phi += increment;
+  }
+
+  orbitDown(increment) {
+    this.getSphericalDelta().phi -= increment;
+  }
+
+  orbitLeft(increment) {
+    this.getSphericalDelta().theta += increment;
+  }
+
+  orbitRight(increment) {
+    this.getSphericalDelta().theta -= increment;
+  }
+}


### PR DESCRIPTION
This change patches `OrbitControls` to support basic keyboard input for controlling the camera orbit. ~Currently only orbit is supported (notably not zoom).~

Update: zoom support has also been added via page-up and page-down.

I tried out the built-in keyboard input, but it is designed to control panning (not orbit), which we currently don't enable for `<model-viewer>`.

Also, the built-in keyboard input responds to global keyboard events, so it would likely be unsuitable anyway (every key input would control all `<model-viewer>`s at once).

This implementation only listens for events on the `<canvas>`, so the `<model-viewer>` must be focused before it will respond to keyboard input.

Keyboard orbiting is jumpy right now, but as we rewrite controls later this sprint we can look into smoothing this out substantially.

### Orbit

![keyboardinput](https://user-images.githubusercontent.com/240083/49261925-fbfe8300-f3f8-11e8-86f1-ff51a583fd57.gif)

### Zoom

![kbdzoom](https://user-images.githubusercontent.com/240083/49274258-a04ded00-f42c-11e8-93bb-c3e4a5490dfb.gif)

Fixes #222 