### PR TITLE
Patch gl.getExtension() EXT_shader_texture_lod for WebGL browser compatibility

### DIFF
--- a/src/three-components/Renderer.js
+++ b/src/three-components/Renderer.js
@@ -20,6 +20,7 @@ import {$tick} from '../model-viewer-base.js';
 
 import TextureUtils from './TextureUtils.js';
 import {ARRenderer} from './ARRenderer.js';
+import * as WebGLExtensionUtils from './WebGLExtensionUtils.js';
 
 const GAMMA_FACTOR = 2.2;
 const DPR = window.devicePixelRatio;
@@ -50,6 +51,8 @@ export default class Renderer extends EventDispatcher {
 
     this.canvas = document.createElement('canvas');
     this.context = this.canvas.getContext('webgl', webGlOptions);
+    WebGLExtensionUtils.applyExtensionCompatibility(this.context);
+
     this.renderer =
         new WebGLRenderer({canvas: this.canvas, context: this.context});
     this.renderer.autoClear = false;

--- a/src/three-components/WebGLExtensionUtils.js
+++ b/src/three-components/WebGLExtensionUtils.js
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const testShaders = {
+  // In some Firefox builds (mobile Android on Pixel at least),
+  // EXT_shader_texture_lod is reported as being supported, but
+  // fails in practice.
+  // @see https://bugzilla.mozilla.org/show_bug.cgi?id=1451287
+  'EXT_shader_texture_lod': `
+#extension GL_EXT_shader_texture_lod : enable
+precision mediump float;
+uniform sampler2D tex;
+void main() {
+    gl_FragColor = texture2DLodEXT(tex, vec2(0.0, 0.0), 0.0);
+}
+`,
+};
+
+const confirmExtension = (gl, name) => {
+  const shader = gl.createShader(gl.FRAGMENT_SHADER);
+  gl.shaderSource(shader, testShaders[name]);
+  gl.compileShader(shader);
+
+  const status = gl.getShaderParameter(shader, gl.COMPILE_STATUS);
+
+  gl.deleteShader(shader);
+  return status;
+};
+
+/**
+ * Patch the values reported by WebGLRenderingContext's
+ * extension store to fix compatibility issues.
+ */
+export const applyExtensionCompatibility = gl => {
+  const getExtension = gl.getExtension;
+  gl.getExtension = name => {
+    let extension;
+
+    if (testShaders[name]) {
+      extension = getExtension.call(gl, name);
+      if (extension && !confirmExtension(gl, name)) {
+        extension = null;
+      }
+    } else {
+      extension = getExtension.call(gl, name);
+    }
+
+    return extension;
+  };
+};


### PR DESCRIPTION
Currently, Firefox can incorrectly appear to support [EXT_shader_texture_lod](https://developer.mozilla.org/en-US/docs/Web/API/EXT_shader_texture_lod) (https://bugzil.la/1451287). Three thinks the extension is supported, so when the shader compiles, an error is thrown. This is reproducible on Firefox Android on Pixel 1 and 2 at least, with these [Khronos conformance tests](https://github.com/KhronosGroup/WebGL/blob/master/sdk/tests/conformance/extensions/ext-shader-texture-lod.html) also failing. It appears [some Samsung devices also have this issue in all browsers](https://github.com/mrdoob/three.js/issues/15343). It appears only textures generated by EquirectangularToCubeGenerator cause this.

Three [provides fallbacks if this extension isn't available](https://github.com/mrdoob/three.js/blob/0c51e577afd011aea8d635db2eeb9185b3999889/src/renderers/shaders/ShaderChunk/envmap_physical_pars_fragment.glsl.js#L77-L85), so we can provide an additional manual check if an extension is supported by compiling a test shader. Fixes #183


@cdata where should this live?
@mrdoob Is this something to upstream?

Now working in Firefox on Android:

![screenshot_20181130-114934](https://user-images.githubusercontent.com/641267/49311964-6ebe3b80-f497-11e8-95a2-10e8cc4886f2.png)
