### PR TITLE
add a 'view source' button to the examples

### DIFF
--- a/examples/augmented-reality.html
+++ b/examples/augmented-reality.html
@@ -72,6 +72,10 @@
           (<a href="https://poly.google.com/view/dLHpzNdygsg">source</a>)
         </div>
     </div>
+
+    <a href="https://github.com/GoogleWebComponents/model-viewer/blob/master/examples/augmented-reality.html"
+      class="viewSource">View source<a/>
+
     <script src="./built/dependencies.js"></script>
     <script src="../dist/model-viewer.js"></script>
 </body>

--- a/examples/background-color.html
+++ b/examples/background-color.html
@@ -122,6 +122,9 @@
         </div>
     </div>
 
+    <a href="https://github.com/GoogleWebComponents/model-viewer/blob/master/examples/background-color.html"
+      class="viewSource">View source<a/>
+
     <script src="./scripts/helpers.js"></script>
     <script src="./built/dependencies.js"></script>
     <script src="../dist/model-viewer.js"></script>

--- a/examples/background-image.html
+++ b/examples/background-image.html
@@ -142,6 +142,10 @@
           (<a href="https://hdrihaven.com/hdri/?h=whipple_creek_regional_park_04">source</a>)
         </div>
     </div>
+
+    <a href="https://github.com/GoogleWebComponents/model-viewer/blob/master/examples/background-image.html"
+      class="viewSource">View source<a/>
+
     <script src="./scripts/helpers.js"></script>
     <script src="./built/dependencies.js"></script>
     <script src="../dist/model-viewer.js"></script>

--- a/examples/default.html
+++ b/examples/default.html
@@ -61,6 +61,10 @@
       licensed under <a href="https://creativecommons.org/licenses/by/2.0/">CC-BY</a>
       (<a href="https://poly.google.com/view/dLHpzNdygsg">source</a>)
     </div>
+
+    <a href="https://github.com/GoogleWebComponents/model-viewer/blob/master/examples/default.html"
+      class="viewSource">View source<a/>
+
     <script src="./built/dependencies.js"></script>
     <script src="../dist/model-viewer.js"></script>
 </body>

--- a/examples/fuzzer.html
+++ b/examples/fuzzer.html
@@ -64,6 +64,10 @@
             <paper-button raised id="run">Run</paper-button>
         </div>
         <model-viewer id="fuzzee"></model-viewer>
+
+        <a href="https://github.com/GoogleWebComponents/model-viewer/blob/master/examples/fuzzer.html"
+          class="viewSource">View source<a/>
+
         <script src="./scripts/helpers.js"></script>
         <script src="./built/dependencies.js"></script>
         <script src="../dist/model-viewer.js"></script>

--- a/examples/list.html
+++ b/examples/list.html
@@ -70,6 +70,10 @@ model-viewer {
           licensed under <a href="https://creativecommons.org/licenses/by/2.0/">CC-BY</a>
           (<a href="https://poly.google.com/view/dLHpzNdygsg">source</a>)
         </div>
+
+        <a href="https://github.com/GoogleWebComponents/model-viewer/blob/master/examples/list.html"
+          class="viewSource">View source<a/>
+
     <script src="../dist/model-viewer.js"></script>
 </body>
 </html>

--- a/examples/loading.html
+++ b/examples/loading.html
@@ -128,6 +128,10 @@
           (<a href="https://poly.google.com/view/6uTsH2jqgVn">source</a>)
         </div>
     </div>
+
+    <a href="https://github.com/GoogleWebComponents/model-viewer/blob/master/examples/loading.html"
+      class="viewSource">View source<a/>
+
     <script src="scripts/helpers.js"></script>
     <script src="./built/dependencies.js"></script>
     <script src="../dist/model-viewer.js"></script>

--- a/examples/multiple-elements.html
+++ b/examples/multiple-elements.html
@@ -119,6 +119,9 @@
         </div>
     </div>
 
+    <a href="https://github.com/GoogleWebComponents/model-viewer/blob/master/examples/multiple-elements.html"
+      class="viewSource">View source<a/>
+
     <script src="../dist/model-viewer.js"></script>
 </body>
 </html>

--- a/examples/pbr.html
+++ b/examples/pbr.html
@@ -101,6 +101,10 @@
           (<a href="https://hdrihaven.com/hdri/?h=whipple_creek_regional_park_04">source</a>)
         </div>
     </div>
+
+    <a href="https://github.com/GoogleWebComponents/model-viewer/blob/master/examples/pbr.html"
+      class="viewSource">View source<a/>
+
     <script src="./scripts/helpers.js"></script>
     <script src="./scripts/lazy-inject.js"></script>
     <script src="./built/dependencies.js"></script>

--- a/examples/sources.html
+++ b/examples/sources.html
@@ -112,6 +112,10 @@
           (<a href="https://poly.google.com/view/dLHpzNdygsg">source</a>)
         </div>
     </div>
+
+    <a href="https://github.com/GoogleWebComponents/model-viewer/blob/master/examples/sources.html"
+      class="viewSource">View source<a/>
+
     <script src="./scripts/helpers.js"></script>
     <script src="./built/dependencies.js"></script>
     <script src="../dist/model-viewer.js"></script>

--- a/examples/styles/examples.css
+++ b/examples/styles/examples.css
@@ -68,3 +68,18 @@ model-viewer {
 .attribution:last-child {
   padding-bottom: 100px;
 }
+
+.viewSource {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  padding: 8px;
+  color: #fff;
+  background-color: #555;
+  opacity: 0.7;
+}
+
+.viewSource:hover {
+  cursor: pointer;
+  opacity: 1;
+}


### PR DESCRIPTION
Styling from the three.js docs; happy to tweak

![viewsource](https://user-images.githubusercontent.com/562883/49321805-b4422f00-f4be-11e8-97fd-6081e6a86112.png)

Fixes #177 
