### PR TITLE
Fix PBR test models to use full range of metallic/roughness

### DIFF
--- a/examples/assets/reflective-sphere.gltf
+++ b/examples/assets/reflective-sphere.gltf
@@ -116,8 +116,8 @@
   "materials": [
     {
       "pbrMetallicRoughness": {
-        "metallicFactor": 0.76,
-        "roughnessFactor": 0.12
+        "metallicFactor": 1.0,
+        "roughnessFactor": 0.0
       }
     }
   ],


### PR DESCRIPTION
It looks when I made pbr-spheres there was an off by one on the range of material values, and for some reason reflective-sphere wasn't fully metal/zero roughness, leading to a lot of wrong assumptions on my end. The diffuse was wayyy too bright.

Updated PBR spheres to be the same color as MetalRoughnessSpheres (https://github.com/GoogleWebComponents/model-viewer/issues/236), which is testing texture maps more so than IBL, so no need to use the reference material which clocks in at 9MB more than this stripped down version (which is half the size of the current pbr-spheres with shared geometry). I think then we could close https://github.com/GoogleWebComponents/model-viewer/issues/236. Compare below (specifically the lighting of the grey spheres).

![screenshot from 2018-11-30 17-20-04](https://user-images.githubusercontent.com/641267/49322546-3b92a100-f4c5-11e8-8c71-6f187389a707.png)

Original reference rendered view model-viewer:

![screenshot from 2018-11-30 17-32-37](https://user-images.githubusercontent.com/641267/49322640-13577200-f4c6-11e8-8219-bcf27c95501f.png)


Yesssss

![screenshot from 2018-11-30 17-05-08](https://user-images.githubusercontent.com/641267/49322592-9926ed80-f4c5-11e8-99f0-59bface7df13.png)

