### PR TITLE
Cap DPR when <meta name="viewport"> is missing

### DIFF
--- a/src/test/utils-spec.js
+++ b/src/test/utils-spec.js
@@ -13,9 +13,9 @@
  * limitations under the License.
  */
 
-import {BoxBufferGeometry, Mesh, Box3, Vector3} from 'three';
+import {Box3, BoxBufferGeometry, Mesh, Vector3} from 'three';
 
-import {deserializeUrl} from '../utils.js';
+import {CAPPED_DEVICE_PIXEL_RATIO, deserializeUrl, resolveDpr} from '../utils.js';
 
 const expect = chai.expect;
 
@@ -35,6 +35,31 @@ suite('utils', () => {
       const {origin} = window.location;
 
       expect(deserializeUrl('foo').indexOf(origin)).to.be.equal(0);
+    });
+  });
+
+  suite('resolveDpr', () => {
+    suite('when <meta name="viewport"> is present', () => {
+      test('resolves the device pixel ratio', () => {
+        const resolvedDpr = resolveDpr();
+        // NOTE(cdata): The main test frame is assumed to have a
+        // <meta name="viewport">. If this changes, it is probably by
+        // accident.
+        const actualDpr = self.devicePixelRatio;
+
+        expect(resolvedDpr).to.be.equal(actualDpr);
+      });
+    });
+
+    suite('when <meta name="viewport"> is not present', () => {
+      test.skip(
+          'caps the device pixel ratio to 1',
+          () => {
+              // There is not a good way to test this given the current
+              // factoring and bundling constraints
+              // TODO:
+              // https://github.com/GoogleWebComponents/model-viewer/issues/262
+          });
     });
   });
 });

--- a/src/three-components/ModelScene.js
+++ b/src/three-components/ModelScene.js
@@ -15,6 +15,8 @@
 
 import {AmbientLight, BackSide, Box3, Color, DirectionalLight, Mesh, MeshBasicMaterial, Object3D, PerspectiveCamera, Scene, SphereBufferGeometry, Vector3} from 'three';
 
+import {resolveDpr} from '../utils.js';
+
 import Model from './Model.js';
 import StaticShadow from './StaticShadow.js';
 
@@ -44,7 +46,6 @@ export const ROOM_PADDING_SCALE = 1.01;
 
 // Vertical field of view of camera, in degrees.
 const FOV = 45;
-const DPR = window.devicePixelRatio;
 
 const $paused = Symbol('paused');
 
@@ -114,6 +115,7 @@ export default class ModelScene extends Scene {
 
     this.roomBox = new Box3();
     this.roomSize = new Vector3();
+    this.dpr = 1;
     this.setSize(width, height);
 
     this.model.addEventListener('model-load', this.onModelLoad);
@@ -157,6 +159,9 @@ export default class ModelScene extends Scene {
       this.width = Math.max(width, 1);
       this.height = Math.max(height, 1);
       this.aspect = this.width / this.height;
+      // In practice, invocations of setSize are throttled at the element level,
+      // so no need to throttle here:
+      this.dpr = resolveDpr();
       this.applyRoomSize();
     }
   }
@@ -166,8 +171,8 @@ export default class ModelScene extends Scene {
    * dimensions for the encapsulating element.
    */
   applyRoomSize() {
-    this.canvas.width = this.width * DPR;
-    this.canvas.height = this.height * DPR;
+    this.canvas.width = this.width * this.dpr;
+    this.canvas.height = this.height * this.dpr;
     this.canvas.style.width = `${this.width}px`;
     this.canvas.style.height = `${this.height}px`;
 

--- a/src/three-components/ModelScene.js
+++ b/src/three-components/ModelScene.js
@@ -115,7 +115,6 @@ export default class ModelScene extends Scene {
 
     this.roomBox = new Box3();
     this.roomSize = new Vector3();
-    this.dpr = 1;
     this.setSize(width, height);
 
     this.model.addEventListener('model-load', this.onModelLoad);
@@ -161,7 +160,6 @@ export default class ModelScene extends Scene {
       this.aspect = this.width / this.height;
       // In practice, invocations of setSize are throttled at the element level,
       // so no need to throttle here:
-      this.dpr = resolveDpr();
       this.applyRoomSize();
     }
   }
@@ -171,8 +169,9 @@ export default class ModelScene extends Scene {
    * dimensions for the encapsulating element.
    */
   applyRoomSize() {
-    this.canvas.width = this.width * this.dpr;
-    this.canvas.height = this.height * this.dpr;
+    const dpr = resolveDpr();
+    this.canvas.width = this.width * dpr;
+    this.canvas.height = this.height * dpr;
     this.canvas.style.width = `${this.width}px`;
     this.canvas.style.height = `${this.height}px`;
 

--- a/src/three-components/Renderer.js
+++ b/src/three-components/Renderer.js
@@ -17,17 +17,15 @@ import {EventDispatcher, WebGLRenderer} from 'three';
 
 import {IS_AR_CANDIDATE} from '../constants.js';
 import {$tick} from '../model-viewer-base.js';
-import {debounce, resolveDpr} from '../utils.js';
+import {resolveDpr} from '../utils.js';
 
 import {ARRenderer} from './ARRenderer.js';
 import TextureUtils from './TextureUtils.js';
 import * as WebGLUtils from './WebGLUtils.js';
 
 const GAMMA_FACTOR = 2.2;
-const UPDATE_DPR_DEBOUNCE_MS = 50;
 
 export const $arRenderer = Symbol('arRenderer');
-const $updateDpr = Symbol('updateDpr');
 
 /**
  * Registers canvases with Canvas2DRenderingContexts and renders them
@@ -65,15 +63,7 @@ export default class Renderer extends EventDispatcher {
     this.renderer.autoClear = false;
     this.renderer.gammaOutput = true;
     this.renderer.gammaFactor = GAMMA_FACTOR;
-
-    this[$updateDpr] = debounce(() => {
-      this.dpr = resolveDpr();
-      this.renderer.setPixelRatio(this.dpr);
-    }, UPDATE_DPR_DEBOUNCE_MS);
-
-    this.dpr = resolveDpr();
-    this.renderer.setPixelRatio(this.dpr);
-    window.addEventListener('resize', this[$updateDpr]);
+    this.renderer.setPixelRatio(resolveDpr());
 
     this[$arRenderer] = ARRenderer.fromInlineRenderer(this);
     this.textureUtils = new TextureUtils(this.renderer);
@@ -162,8 +152,9 @@ export default class Renderer extends EventDispatcher {
       this.renderer.setViewport(0, 0, width, height);
       this.renderer.render(scene, camera);
 
-      const widthDPR = width * this.dpr;
-      const heightDPR = height * this.dpr;
+      const dpr = resolveDpr();
+      const widthDPR = width * dpr;
+      const heightDPR = height * dpr;
       context.drawImage(
           this.renderer.domElement,
           0,
@@ -185,6 +176,5 @@ export default class Renderer extends EventDispatcher {
     super.dispose();
     this.textureUtils.dispose();
     this.textureUtils = null;
-    window.removeEventListener('resize', this[$updateDpr]);
   }
 }

--- a/src/three-components/WebGLUtils.js
+++ b/src/three-components/WebGLUtils.js
@@ -14,8 +14,8 @@
  */
 
 export const getContext = (canvas, options) =>
-  canvas.getContext('webgl', options) ||
-  canvas.getContext('experimental-webgl', options);
+    canvas.getContext('webgl', options) ||
+    canvas.getContext('experimental-webgl', options);
 
 /**
  * Patch the values reported by WebGLRenderingContext's
@@ -36,7 +36,7 @@ export const applyExtensionCompatibility = gl => {
       }`,
   };
 
-  function confirmExtension (gl, name) {
+  function confirmExtension(gl, name) {
     const shader = gl.createShader(gl.FRAGMENT_SHADER);
     gl.shaderSource(shader, testShaders[name]);
     gl.compileShader(shader);

--- a/src/utils.js
+++ b/src/utils.js
@@ -86,3 +86,79 @@ export const openIOSARQuickLook = url => {
   anchor.appendChild(document.createElement('img'));
   anchor.click();
 };
+
+
+/**
+ * This helper analyzes the layout of the current page to decide if we should
+ * use the natural device pixel ratio, or a capped value.
+ *
+ * We cap DPR if there is no meta viewport (suggesting that user is not
+ * consciously specifying how to scale the viewport relative to the device
+ * screen size) and also the window dimensions are a multiple of the effective
+ * screen dimensions (in CSS pixels).
+ *
+ * The rationale for this is that these conditions typically lead to a
+ * pathological outcome on mobile devices. When the window dimensions are
+ * scaled up on a device with a high DPR, we create a canvas that is much
+ * larger than appropriate to accomodate for the pixel density.
+ *
+ * This value needs to be measured in real time, as device pixel ratio can
+ * change over time (e.g., when a user zooms the page). Also, in some cases
+ * (such as Firefox on Android), the window's innerWidth is initially reported
+ * as the same as the screen's availWidth but changes later.
+ *
+ * A user who specifies a meta viewport, thereby consciously creating scaling
+ * conditions where <model-viewer> is slow, will be encouraged to live their
+ * best life.
+ */
+export const resolveDpr = (() => {
+  // The ratio we use for a "capped" scenario:
+  const CAPPED_DEVICE_PIXEL_RATIO = 1;
+
+  // If true, implies that the user is conscious of the viewport scaling
+  // relative to the device screen size.
+  const HAS_META_VIEWPORT_TAG = (() => {
+    const metas = document.head != null ?
+        Array.from(document.head.querySelectorAll('meta')) :
+        [];
+
+    for (const meta of metas) {
+      if (meta.name === 'viewport') {
+        return true;
+      }
+    }
+
+    return false;
+  })();
+
+  // NOTE(cdata): f true, this suggests that the window contents have been
+  // scaled such that the inner width is a multiple of the effective CSS pixel
+  // dimensions of the actual screen. This is assumed to imply one of the
+  // following conditions:
+  //
+  //  1. The window has been manually sized to extent beyond the bounds of
+  // the user's display (probably only possible in desktop scenarios).
+  //  2. There is no meta viewport on a high-DPR device, or else the meta
+  // viewport has scaled the defuault width higher than the screen width of
+  // the device.
+  //
+  // Condition #1 is not very common, but certainly possible. As long as there
+  // is a meta viewport, we won't cap the DPR.
+  // Condition #2 is usually not intentional but very easy to arrive at (a
+  // user need only omit the meta viewport tag and view their site on a
+  // contemporary mobile device).
+  //
+  // @see https://www.quirksmode.org/dom/w3c_cssom.html#screenview
+  const hasRiskyWindowToScreenRatio = () =>
+      Math.max(
+          window.innerWidth / window.screen.availWidth,
+          window.innerHeight / window.screen.availHeight) > 1;
+
+  return () => {
+    const shouldCapDevicePixelRatio =
+        !HAS_META_VIEWPORT_TAG && hasRiskyWindowToScreenRatio();
+
+    return shouldCapDevicePixelRatio ? CAPPED_DEVICE_PIXEL_RATIO :
+                                       window.devicePixelRatio;
+  };
+})();

--- a/src/utils.js
+++ b/src/utils.js
@@ -88,6 +88,10 @@ export const openIOSARQuickLook = url => {
 };
 
 
+// The DPR we use for a "capped" scenario (see resolveDpr below):
+export const CAPPED_DEVICE_PIXEL_RATIO = 1;
+
+
 /**
  * This helper analyzes the layout of the current page to decide if we should
  * use the natural device pixel ratio, or a capped value.
@@ -112,9 +116,6 @@ export const openIOSARQuickLook = url => {
  * best life.
  */
 export const resolveDpr = (() => {
-  // The ratio we use for a "capped" scenario:
-  const CAPPED_DEVICE_PIXEL_RATIO = 1;
-
   // If true, implies that the user is conscious of the viewport scaling
   // relative to the device screen size.
   const HAS_META_VIEWPORT_TAG = (() => {


### PR DESCRIPTION


This change is a candidate to fix #185 . ~**I think this proposal deserves some discussion / debate** as it is an imperfect approach that works in a lot of common cases, but has some known (and probably unknown) failure modes.~ Concisely, this is the strategy being proposed:

 > If the document _does not_ have a meta viewport tag, ~_and_ the ratio of the window dimensions to the screen dimensions (in CSS pixels) is greater than one,~ _then_ cap the effective device pixel ratio to 1.

~Known failure modes include:~

 i. ~**Page without meta viewport viewed on desktop** window-to-screen ratio exceeds 1 due to user manually scaling the window to be wider than their desktop screen.~
 ii.  ~**Page without meta viewport viewed on mobile** is loaded in an iframe, and the iframe-to-screen ratio is <= 1 (see [here](https://lopsided-motion.glitch.me/index-nmv2.html)).~
 iii. ~Any others...?~

EDIT: The demo links are somewhat frozen in time, and use a build that applies a more complex heuristic than will be shipped in this PR.

A slightly patched version of this change can be viewed in the live demo: [https://lopsided-motion.glitch.me/](https://lopsided-motion.glitch.me/).

A version of the same demo where `<meta name="viewport">` is omitted can be found here: [https://lopsided-motion.glitch.me/index-nmv.html](https://lopsided-motion.glitch.me/index-nmv.html).

In both demos, the device pixel ratio being used is printed to the console for your reference.

I tested both pages in the following browsers:

 - iPhone XR Simulator / iOS 12 Safari
 - Pixel 1 / Google Chrome 70
 - Pixel 1 / Firefox 63

For the basic no-`<meta name="viewport">` case, performance is significantly improved without any subjective loss in quality.

Still TODO:
 - [x] Test `resolveDpr` implementation

Fixes #185 