### PR TITLE
Re-introduce the directional light to the scene

### DIFF
--- a/src/features/environment.js
+++ b/src/features/environment.js
@@ -19,6 +19,8 @@ import {$needsRender, $onModelLoad, $renderer, $scene, $tick} from '../model-vie
 const DEFAULT_BACKGROUND_COLOR = '#ffffff';
 const GAMMA_TO_LINEAR = 2.2;
 
+const WHITE = new Color('#ffffff');
+
 const $currentCubemap = Symbol('currentCubemap');
 const $setEnvironmentImage = Symbol('setEnvironmentImage');
 const $setEnvironmentColor = Symbol('setEnvironmentColor');
@@ -36,12 +38,12 @@ export const EnvironmentMixin = (ModelViewerElement) => {
       };
     }
 
-    get [$hasBackgroundImage]() {
+    get[$hasBackgroundImage]() {
       // @TODO #76
       return this.backgroundImage && this.backgroundImage !== 'null';
     }
 
-    get [$hasBackgroundColor]() {
+    get[$hasBackgroundColor]() {
       // @TODO #76
       return this.backgroundColor && this.backgroundColor !== 'null';
     }
@@ -90,7 +92,7 @@ export const EnvironmentMixin = (ModelViewerElement) => {
     /**
      * @param {string} url
      */
-    async [$setEnvironmentImage](url) {
+    async[$setEnvironmentImage](url) {
       const textureUtils = this[$renderer].textureUtils;
       const textures = await textureUtils.toCubemapAndEquirect(url);
 
@@ -110,7 +112,7 @@ export const EnvironmentMixin = (ModelViewerElement) => {
         return;
       }
 
-      const { cubemap, equirect } = textures;
+      const {cubemap, equirect} = textures;
 
       this[$scene].skysphere.material.color = new Color(0xffffff);
       this[$scene].skysphere.material.map = equirect;
@@ -132,6 +134,11 @@ export const EnvironmentMixin = (ModelViewerElement) => {
       this[$scene].skysphere.material.color = new Color(color);
       this[$scene].skysphere.material.color.convertGammaToLinear(
           GAMMA_TO_LINEAR);
+
+      this[$scene].shadowLight.color.copy(
+          this[$scene].skysphere.material.color);
+      this[$scene].shadowLight.color.lerpHSL(WHITE, 0.5);
+
       this[$scene].skysphere.material.map = null;
       this[$scene].skysphere.material.needsUpdate = true;
 

--- a/src/features/environment.js
+++ b/src/features/environment.js
@@ -24,6 +24,7 @@ const WHITE = new Color('#ffffff');
 const $currentCubemap = Symbol('currentCubemap');
 const $setEnvironmentImage = Symbol('setEnvironmentImage');
 const $setEnvironmentColor = Symbol('setEnvironmentColor');
+const $setShadowLightColor = Symbol('setShadowLightColor');
 const $hasBackgroundImage = Symbol('hasBackgroundImage');
 const $hasBackgroundColor = Symbol('hasBackgroundColor');
 const $deallocateTextures = Symbol('deallocateTextures');
@@ -120,6 +121,8 @@ export const EnvironmentMixin = (ModelViewerElement) => {
       this[$currentCubemap] = cubemap;
       this[$scene].model.applyEnvironmentMap(cubemap);
 
+      this[$setShadowLightColor](WHITE);
+
       this[$needsRender]();
     }
 
@@ -131,13 +134,10 @@ export const EnvironmentMixin = (ModelViewerElement) => {
 
       this[$deallocateTextures]();
 
-      this[$scene].skysphere.material.color = new Color(color);
-      this[$scene].skysphere.material.color.convertGammaToLinear(
-          GAMMA_TO_LINEAR);
-
-      this[$scene].shadowLight.color.copy(
-          this[$scene].skysphere.material.color);
-      this[$scene].shadowLight.color.lerpHSL(WHITE, 0.5);
+      const skysphereColor = this[$scene].skysphere.material.color =
+          new Color(color);
+      skysphereColor.convertGammaToLinear(GAMMA_TO_LINEAR);
+      this[$setShadowLightColor](skysphereColor);
 
       this[$scene].skysphere.material.map = null;
       this[$scene].skysphere.material.needsUpdate = true;
@@ -148,6 +148,11 @@ export const EnvironmentMixin = (ModelViewerElement) => {
       this[$scene].model.applyEnvironmentMap(this[$currentCubemap]);
 
       this[$needsRender]();
+    }
+
+    [$setShadowLightColor](color) {
+      this[$scene].shadowLight.color.copy(color);
+      this[$scene].shadowLight.color.lerpHSL(WHITE, 0.5);
     }
 
     [$deallocateTextures]() {

--- a/src/test/features/environment-spec.js
+++ b/src/test/features/environment-spec.js
@@ -137,6 +137,19 @@ suite('ModelViewerElementBase with EnvironmentMixin', () => {
           url: element.backgroundImage
         })).to.be.ok;
       });
+
+      suite('and a background-color property', () => {
+        setup(async () => {
+          element.backgroundColor = '#ff0077';
+          await timePasses();
+        });
+
+        test('the directional light is white', () => {
+          const lightColor =
+              scene.shadowLight.color.getHexString().toLowerCase();
+          expect(lightColor).to.be.equal('ffffff');
+        });
+      });
     });
   });
 
@@ -164,6 +177,10 @@ suite('ModelViewerElementBase with EnvironmentMixin', () => {
             await timePasses();
             expect(skysphereUsingColor(scene, 'ff0077')).to.be.ok;
           });
+      test('the directional light is tinted', () => {
+        const lightColor = scene.shadowLight.color.getHexString().toLowerCase();
+        expect(lightColor).to.not.be.equal('ffffff');
+      });
     });
   });
 

--- a/src/three-components/ModelScene.js
+++ b/src/three-components/ModelScene.js
@@ -84,7 +84,7 @@ export default class ModelScene extends Scene {
     // This light is only for generating (fake) shadows
     // and does not needed to be added to the scene.
     // @see StaticShadow.js
-    this.shadowLight = new DirectionalLight(0xffffff, 0);
+    this.shadowLight = new DirectionalLight(0xffffff, 1);
     this.shadowLight.position.set(0, 10, 0);
     this.shadowLight.name = 'ShadowLight';
 
@@ -107,6 +107,7 @@ export default class ModelScene extends Scene {
 
     this.add(this.pivot);
     this.add(this.light);
+    this.add(this.shadowLight);
     this.add(this.skysphere);
     this.pivot.add(this.model);
 


### PR DESCRIPTION
This change is a candidate to address #179

 - Re-introduces a directional light by adding the "shadow" light to the scene
 - Shadow light hue is tinted to match background color if configured

### Before / after samples

![astrocolordl](https://user-images.githubusercontent.com/240083/49619309-e6490a80-f970-11e8-927a-5a9d44abe636.gif)

![dhpbrdl 2018-12-06 15_54_17](https://user-images.githubusercontent.com/240083/49619318-eea14580-f970-11e8-947a-a95a160cab61.gif)

![shiskbgdl 2018-12-06 16_01_45](https://user-images.githubusercontent.com/240083/49619321-f2cd6300-f970-11e8-91e1-6eb760444c73.gif)

![vf1adl 2018-12-06 15_34_12](https://user-images.githubusercontent.com/240083/49619326-f8c34400-f970-11e8-826f-8082dcd2dee4.gif)


Fixes #179
