### PR TITLE
Fixing shadows in WebXR

### DIFF
--- a/src/three-components/ARRenderer.js
+++ b/src/three-components/ARRenderer.js
@@ -198,6 +198,7 @@ export class ARRenderer {
 
     this[$frameOfReference] = null;
     this[$presentedScene] = null;
+    this.renderer.setFramebuffer(null);
 
     if (this.outputCanvas.parentNode != null) {
       this.outputCanvas.parentNode.removeChild(this.outputCanvas);

--- a/src/three-components/StaticShadow.js
+++ b/src/three-components/StaticShadow.js
@@ -17,6 +17,7 @@ import {Color, Mesh, MeshBasicMaterial, MultiplyBlending, OrthographicCamera, Pl
 
 const $camera = Symbol('camera');
 const $renderTarget = Symbol('renderTarget');
+const $preservedRenderTarget = Symbol('preservedRenderTarget');
 
 const scale = new Vector3();
 
@@ -62,6 +63,23 @@ export default class StaticShadow extends Mesh {
     this.material.needsUpdate = true;
 
     this[$camera] = new OrthographicCamera();
+  }
+
+  /**
+   * In WebXR AR, the default framebuffer used by three is one provided by
+   * the WebXR Device API -- `renderer.setFramebuffer()` handles that
+   * for three's shadows, but for our own render targets, we have to
+   * manually handle.
+   *
+   * @see https://github.com/mrdoob/three.js/pull/14132
+   */
+  onBeforeRender(renderer) {
+    this[$preservedRenderTarget] = renderer.getRenderTarget();
+    renderer.setRenderTarget(this[$renderTarget]);
+  }
+
+  onAfterRender(renderer) {
+    renderer.setRenderTarget(this[$preservedRenderTarget]);
   }
 
   /**


### PR DESCRIPTION
WebXR requires rendering to a specific framebuffer, and internally in three, it made some assumptions about the default framebuffer (I forget the details) and `setFramebuffer()` (https://github.com/mrdoob/three.js/pull/14132) was added to WebGLRenderer for shadows, which is handled because WebGLShadowMap [sets a render target](https://github.com/mrdoob/three.js/blob/2db634d94955e119d5a519d091cb57ebf52f55e3/src/renderers/webgl/WebGLShadowMap.js#L225). Ultimately needed to add an onBeforeRender for any(?) RenderTarget when rendering to the AR framebuffer, AFAICT.