### PR TITLE
ARRenderer uses EventDispatcher; EventTarget only in tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -622,6 +622,12 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@jsantell/event-target": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@jsantell/event-target/-/event-target-1.0.0.tgz",
+      "integrity": "sha512-qagtanba96aH/4DZvDpYZDiZ71RrCdejLO1AHSMN9ZqIIJbs1wDdn33lQa+g/vrdIzP+gF7p+tsZEazOXaJXng==",
+      "dev": true
+    },
     "@koa/cors": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/@koa/cors/-/cors-2.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "3d"
   ],
   "devDependencies": {
+    "@jsantell/event-target": "^1.0.0",
     "@magicleap/prismatic": "^0.17.5",
     "@polymer/iron-demo-helpers": "^3.0.2",
     "@polymer/paper-button": "^3.0.1",

--- a/src/test/three-components/ARRenderer-spec.js
+++ b/src/test/three-components/ARRenderer-spec.js
@@ -24,13 +24,15 @@ import {assetPath, timePasses, waitForEvent} from '../helpers.js';
 
 const expect = chai.expect;
 
-const applyPhoneRotation = camera => {
-  // Rotate 180 degrees on Y (so it's not the default)
-  // and angle 45 degrees towards the ground, like a phone.
-  camera.matrix.identity()
-    .makeRotationAxis(new Vector3(0, 1, 0), Math.PI)
-    .multiply(new Matrix4().makeRotationAxis(new Vector3(1, 0, 0), -Math.PI / 4));
-}
+const applyPhoneRotation =
+    camera => {
+      // Rotate 180 degrees on Y (so it's not the default)
+      // and angle 45 degrees towards the ground, like a phone.
+      camera.matrix.identity()
+          .makeRotationAxis(new Vector3(0, 1, 0), Math.PI)
+          .multiply(new Matrix4().makeRotationAxis(
+              new Vector3(1, 0, 0), -Math.PI / 4));
+    }
 
 class MockXRFrame {
   constructor(session) {
@@ -254,8 +256,8 @@ suite('ARRenderer', () => {
         expect(arRenderer.dolly.position.z).to.be.equal(2);
 
         // Now point phone upwards
-        arRenderer.camera.matrix.identity()
-          .makeRotationAxis(new Vector3(1, 0, 0), Math.PI / 2);
+        arRenderer.camera.matrix.identity().makeRotationAxis(
+            new Vector3(1, 0, 0), Math.PI / 2);
         arRenderer.camera.matrix.setPosition(new Vector3(0, 2, 0));
         arRenderer.camera.updateMatrixWorld(true);
         await arRenderer.placeModel();

--- a/src/three-components/ARRenderer.js
+++ b/src/three-components/ARRenderer.js
@@ -1,4 +1,4 @@
-import {Matrix4, Object3D, PerspectiveCamera, Raycaster, Scene, Vector3, WebGLRenderer} from 'three';
+import {EventDispatcher, Matrix4, Object3D, PerspectiveCamera, Raycaster, Scene, Vector3, WebGLRenderer} from 'three';
 
 import {assertIsArCandidate} from '../utils.js';
 
@@ -27,7 +27,7 @@ const vector3 = new Vector3();
 const originArray = new Float32Array(3);
 const directionArray = new Float32Array(3);
 
-export class ARRenderer extends EventTarget {
+export class ARRenderer extends EventDispatcher {
   /**
    * Given an inline Renderer, construct an ARRenderer and return it
    */
@@ -282,7 +282,7 @@ height: 100%;`);
       presentedScene.skysphere.visible = false;
       this.dolly.add(presentedScene);
 
-      this.dispatchEvent(new CustomEvent('modelmove'));
+      this.dispatchEvent({type: 'modelmove'});
     }
   }
 

--- a/test/index.html
+++ b/test/index.html
@@ -46,8 +46,10 @@
   <script src="../node_modules/resize-observer-polyfill/dist/ResizeObserver.js"></script>
 
   <!-- Fullscreen polyfill is required to support WebXR-based AR in stable browsers that support it: -->
-  <script src="../node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>
+  <!--<script src="../node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>-->
 
+  <!-- EventTarget polyfill is *only* needed for running the tests -->
+  <script src="../node_modules/@jsantell/event-target/dist/event-target.js"></script>
 
   <script src="../node_modules/web-component-tester/browser.js"></script>
 </head>

--- a/test/legacy.html
+++ b/test/legacy.html
@@ -49,6 +49,9 @@
   <!-- Fullscreen polyfill is required to support Web XR-based AR in stable browsers that support it: -->
   <!--<script src="../node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>-->
 
+  <!-- EventTarget polyfill is *only* needed for running the tests -->
+  <script src="../node_modules/@jsantell/event-target/dist/event-target.js"></script>
+
 
   <script src="../node_modules/web-component-tester/browser.js"></script>
 </head>


### PR DESCRIPTION
 - Changes `ARRenderer` to use `EventDispatcher`
 - Adds the `EventTarget` polyfill for use in test suites.

Fixes #283 