### PR TITLE
Fix incorrect scale when zooming

### DIFF
--- a/src/model-viewer-base.js
+++ b/src/model-viewer-base.js
@@ -125,6 +125,7 @@ export default class ModelViewerElementBase extends UpdatingElement {
           if (renderer.isPresenting) {
             return;
           }
+
           for (let entry of entries) {
             if (entry.target === this) {
               this[$updateSize](entry.contentRect);

--- a/src/test/three-components/Renderer-spec.js
+++ b/src/test/three-components/Renderer-spec.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import ModelViewerElementBase, {$canvas} from '../../model-viewer-base.js';
+import ModelViewerElementBase, {$canvas, $onResize} from '../../model-viewer-base.js';
 import ModelScene from '../../three-components/ModelScene.js';
 import Renderer from '../../three-components/Renderer.js';
 
@@ -108,6 +108,36 @@ suite('Renderer', () => {
       expect(scene.renderCount).to.be.equal(1);
       expect(!scene.isDirty).to.be.ok;
       expect(renderer.scenesRendered).to.be.equal(1);
+    });
+
+    suite('when resizing', () => {
+      let originalDpr;
+
+      setup(() => {
+        originalDpr = self.devicePixelRatio;
+      });
+
+      teardown(() => {
+        Object.defineProperty(self, 'devicePixelRatio', {value: originalDpr});
+      });
+
+      test('updates effective DPR', async () => {
+        const scene = createScene();
+        const {element} = scene;
+        const initialDpr = renderer.renderer.getPixelRatio();
+        const {width, height} = scene.getSize();
+
+        element[$onResize]({width, height});
+
+        Object.defineProperty(
+            self, 'devicePixelRatio', {value: initialDpr + 1});
+
+        await new Promise(resolve => requestAnimationFrame(resolve));
+
+        const newDpr = renderer.renderer.getPixelRatio();
+
+        expect(newDpr).to.be.equal(initialDpr + 1);
+      });
     });
   });
 });

--- a/src/three-components/Renderer.js
+++ b/src/three-components/Renderer.js
@@ -131,6 +131,11 @@ export default class Renderer extends EventDispatcher {
     this.scenesRendered = 0;
 
     const delta = t - this.lastTick;
+    const dpr = resolveDpr();
+
+    if (dpr !== this.renderer.getPixelRatio()) {
+      this.renderer.setPixelRatio(dpr);
+    }
 
     for (let scene of this.scenes) {
       const {element, width, height, context} = scene;
@@ -152,7 +157,6 @@ export default class Renderer extends EventDispatcher {
       this.renderer.setViewport(0, 0, width, height);
       this.renderer.render(scene, camera);
 
-      const dpr = resolveDpr();
       const widthDPR = width * dpr;
       const heightDPR = height * dpr;
       context.drawImage(


### PR DESCRIPTION
Zooming (e.g., with `⌘ +`/`⌘ -`) changes the effective `devicePixelRatio` and lays everything out accordingly. Previously, WebGLRenderer's DPR was not being updated under these circumstances, causing the model to be incorrectly staged under zoom events (and, incidentally, when turning on device emulation in dev tools).

Current behavior | New behavior
-----------------|---------------
![resizedprbad](https://user-images.githubusercontent.com/240083/51881132-d9bcaf00-232e-11e9-9b73-98e1d9c0aaae.gif)|![resizedprgood](https://user-images.githubusercontent.com/240083/51881141-dde8cc80-232e-11e9-9f0c-4abf4fb8b081.gif)
![resizedprmobilebad](https://user-images.githubusercontent.com/240083/51881152-eccf7f00-232e-11e9-89ef-6bcb259be074.gif)|![resizedprmobilegood](https://user-images.githubusercontent.com/240083/51881155-efca6f80-232e-11e9-8068-5acea9eec220.gif)




Fixes #298 