### PR TITLE
Improved a11y for <model-viewer> controls

### DIFF
--- a/examples/background-image.html
+++ b/examples/background-image.html
@@ -69,7 +69,6 @@
                     background-image="assets/whipple_creek_regional_park_04_1k.jpg"
                     alt="A 3D model of a damaged helmet with a forest in the background"
                     src="assets/DamagedHelmet/DamagedHelmet.gltf">
-                  <img src="https://upload.wikimedia.org/wikipedia/commons/c/c4/24-cell-orig.gif" slot="controls-prompt" width="200">
                 </model-viewer>
             </template>
         </example-snippet>

--- a/examples/background-image.html
+++ b/examples/background-image.html
@@ -68,7 +68,9 @@
                     controls
                     background-image="assets/whipple_creek_regional_park_04_1k.jpg"
                     alt="A 3D model of a damaged helmet with a forest in the background"
-                    src="assets/DamagedHelmet/DamagedHelmet.gltf"></model-viewer>
+                    src="assets/DamagedHelmet/DamagedHelmet.gltf">
+                  <img src="https://upload.wikimedia.org/wikipedia/commons/c/c4/24-cell-orig.gif" slot="controls-prompt" width="200">
+                </model-viewer>
             </template>
         </example-snippet>
       </div>

--- a/src/assets/controls-svg.js
+++ b/src/assets/controls-svg.js
@@ -1,0 +1,71 @@
+export default `
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="250px" height="200px" viewBox="0 0 250 200" fill="transparent">
+  <!-- Rotation arc -->
+  <path id="orbit"
+        d="M50,75 C55,50 195,50 200,75 C195,100 55,100 50,75"
+        stroke-linecap="round"
+        stroke-dasharray="180 180"
+        stroke-dashoffset="-60"
+        stroke="#a1a1a1"
+        stroke-width="7"
+        fill="transparent">
+    <animate attributeName="stroke-dashoffset"
+           dur="1.75s"
+           calcMode="linear"
+           values="-40;-40.56;-42.08;-44.32;-47.04;-50;-52.96;-55.68;-57.92;-59.44;-60;-59.44;-57.92;-55.68;-52.96;-50;-47.04;-44.32;-42.08;-40.56;-40"
+           keyTimes="0;0.05;0.1;0.15;0.2;0.25;0.3;0.35;0.4;0.45;0.5;0.55;0.6;0.65;0.7;0.75;0.8;0.85;0.9;0.95;1"
+           repeatCount="indefinite" />
+  </path>
+
+  <path d="M50,75 C55,50 195,50 200,75 C195,100 55,100 50,75"
+        opacity="1"
+        stroke-linecap="round"
+        stroke-dasharray="140 220"
+        stroke="white"
+        stroke-width="7"
+
+        fill="transparent">
+    <animate attributeName="stroke-dashoffset"
+           dur="1.75s"
+           calcMode="linear"
+           values="-225;-225.56;-227.07999999999998;-229.32;-232.04;-235;-237.96;-240.68;-242.92;-244.44;-245;-244.44;-242.92;-240.68;-237.96;-235;-232.04;-229.32;-227.07999999999998;-225.56;-225"
+           keyTimes="0;0.05;0.1;0.15;0.2;0.25;0.3;0.35;0.4;0.45;0.5;0.55;0.6;0.65;0.7;0.75;0.8;0.85;0.9;0.95;1"
+           repeatCount="indefinite" />
+  </path>
+
+  <!-- Hand Icon -->
+  <defs>
+    <path id="a" d="M0 0h24v24H0V0z"/>
+  </defs>
+  <clipPath id="b">
+    <use xlink:href="#a" overflow="visible"/>
+  </clipPath>
+
+  <g transform="translate(100, 70) scale(3.5)">
+    <g transform="translate(0, 0)">
+      <animateTransform
+         attributeName="transform"
+         type="translate"
+         repeatCount="indefinite"
+         keyTimes="0;0.05;0.1;0.15;0.2;0.25;0.3;0.35;0.4;0.45;0.5;0.55;0.6;0.65;0.7;0.75;0.8;0.85;0.9;0.95;1"
+         values="0,0;-0.16800000000000015,0;-0.6239999999999988,0;-1.2960000000000003,0;-2.111999999999999,0;-3,0;-3.8879999999999995,0;-4.704,0;-5.3759999999999994,0;-5.832,0;-6,0;-5.832,0;-5.3759999999999994,0;-4.704,0;-3.8879999999999995,0;-3,0;-2.111999999999999,0;-1.2960000000000003,0;-0.6239999999999988,0;-0.16800000000000015,0;0,0"
+         dur="1.75s" />
+      <path clip-path="url(#b)"
+            fill="white"
+            d="M9 11.24V7.5C9 6.12 10.12 5 11.5 5S14 6.12 14 7.5v3.74c1.21-.81 2-2.18 2-3.74C16 5.01 13.99 3 11.5 3S7 5.01 7 7.5c0 1.56.79 2.93 2 3.74zm9.84 4.63l-4.54-2.26c-.17-.07-.35-.11-.54-.11H13v-6c0-.83-.67-1.5-1.5-1.5S10 6.67 10 7.5v10.74l-3.43-.72c-.08-.01-.15-.03-.24-.03-.31 0-.59.13-.79.33l-.79.8 4.94 4.94c.27.27.65.44 1.06.44h6.79c.75 0 1.33-.55 1.44-1.28l.75-5.27c.01-.07.02-.14.02-.2 0-.62-.38-1.16-.91-1.38z"/>
+    </g>
+  </g>
+
+  <!-- Arrow -->
+  <polyline id="Path-3" stroke="#a1a1a1" stroke-width="7" stroke-linecap="round" stroke-linejoin="round" transform="translate(-33.952293, -4) rotate(-39.000000) " points="35.5366949 39.6822958 26.6550872 26.0761929 41.2494988 29.5432078">
+    <animateMotion
+        calcMode="linear"
+        keyPoints="0.095;0.09668;0.10124;0.10796;0.11612;0.125;0.13388;0.14204;0.14876;0.15332;0.155;0.15332;0.14876;0.14204;0.13388;0.125;0.11612;0.10796;0.10124;0.09668;0.095"
+        keyTimes="0;0.05;0.1;0.15;0.2;0.25;0.3;0.35;0.4;0.45;0.5;0.55;0.6;0.65;0.7;0.75;0.8;0.85;0.9;0.95;1"
+        dur="1.75s"
+        repeatCount="indefinite">
+      <mpath xlink:href="#orbit"/>
+    </animateMotion>
+  </polyline>
+</svg>
+`;

--- a/src/features/controls.js
+++ b/src/features/controls.js
@@ -22,7 +22,7 @@ import {SmoothControls} from '../three-components/SmoothControls.js';
 const ORBIT_NEAR_PLANE = 0.01;
 const ORBIT_FAR_PLANE = 1000;
 
-const IDLE_PROMPT_THRESHOLD_MS = 3000;
+export const IDLE_PROMPT_THRESHOLD_MS = 3000;
 export const IDLE_PROMPT =
     'Use mouse, touch or arrow keys to control the camera!';
 
@@ -176,11 +176,14 @@ export const ControlsMixin = (ModelViewerElement) => {
     [$onChange](e) {
       this[$needsRender]();
 
+      // Effectively cancel the timer waiting for user interaction:
+      this[$waitingToPromptUser] = false;
+
       // NOTE(cdata): On change (in other words, the camera has adjusted its
       // orbit), if the user has been prompted at least once already, we no
       // longer need to prompt the user in the future.
-      if (this[$shouldPromptUserToInteract] && this[$userPromptedOnce]) {
-        this[$waitingToPromptUser] = this[$shouldPromptUserToInteract] = false;
+      if (this[$userPromptedOnce]) {
+        this[$shouldPromptUserToInteract] = false;
       }
     }
   };

--- a/src/template.js
+++ b/src/template.js
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+import ControlsPrompt from './assets/controls-svg.js';
 import ARGlyph from './assets/view-in-ar-material-svg.js';
 
 const template = document.createElement('template');
@@ -89,6 +90,31 @@ template.innerHTML = `
     canvas.show {
       display: block;
     }
+
+    .slot.controls-prompt {
+      display: flex;
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      pointer-events: none;
+      align-items: center;
+      justify-content: center;
+      opacity: 0;
+      transform-origin: center center;
+      transform: scale(0.9);
+      transition: transform 0.3s, opacity 0.3s;
+    }
+
+    .slot.controls-prompt svg {
+      transform: scale(0.5);
+    }
+
+    .slot.controls-prompt.visible {
+      opacity: 1;
+      transform: scale(1);
+    }
   </style>
   <div class="container">
     <a tabindex="2"
@@ -103,6 +129,13 @@ template.innerHTML = `
         aria-label="A depiction of a 3D model"
         aria-live="polite">
     </canvas>
+    <!-- NOTE(cdata): We need to wrap slots because browsers without ShadowDOM
+         will have their <slot> elements removed by ShadyCSS -->
+    <div class="slot controls-prompt">
+      <slot name="controls-prompt" aria-hidden="true">
+        ${ControlsPrompt}
+      </slot>
+    </div>
   </div>
   <slot></slot>
 `;

--- a/src/template.js
+++ b/src/template.js
@@ -91,12 +91,18 @@ template.innerHTML = `
     }
   </style>
   <div class="container">
-    <a tabindex="2" class="enter-ar" href="#" aria-label="View this 3D model in augmented reality">
+    <a tabindex="2"
+        class="enter-ar"
+        href="#"
+        aria-label="View this 3D model in augmented reality">
       <div class="disc"></div>
       ${ARGlyph}
     </a>
     <div class="poster" aria-hidden="true" aria-label="Activate to view in 3D!"></div>
-    <canvas tabindex="1" aria-label="A depiction of a 3D model"></canvas>
+    <canvas tabindex="1"
+        aria-label="A depiction of a 3D model"
+        aria-live="polite">
+    </canvas>
   </div>
   <slot></slot>
 `;

--- a/src/test/features/controls-spec.js
+++ b/src/test/features/controls-spec.js
@@ -13,9 +13,9 @@
  * limitations under the License.
  */
 
-import {$controls, ControlsMixin} from '../../features/controls.js';
+import {$controls, ControlsMixin, IDLE_PROMPT} from '../../features/controls.js';
 import ModelViewerElementBase, {$scene} from '../../model-viewer-base.js';
-import {assetPath, timePasses, waitForEvent} from '../helpers.js';
+import {assetPath, dispatchSyntheticEvent, timePasses, until, waitForEvent} from '../helpers.js';
 
 const expect = chai.expect;
 
@@ -77,6 +77,32 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
         element.controls = false;
         await timePasses();
         expect(element[$controls]).to.be.not.ok;
+      });
+
+      suite('a11y', () => {
+        test('prompts user to interact when focused', async () => {
+          const {canvas} = element[$scene];
+          const originalLabel = canvas.getAttribute('aria-label');
+
+          canvas.focus();
+
+          await until(() => canvas.getAttribute('aria-label') === IDLE_PROMPT);
+
+          dispatchSyntheticEvent(
+              element, 'mousedown', {clientX: 0, clientY: 10});
+          dispatchSyntheticEvent(
+              element, 'mousemove', {clientX: 0, clientY: 0});
+
+          canvas.blur();
+
+          await timePasses();
+
+          canvas.focus();
+
+          await timePasses();
+
+          expect(canvas.getAttribute('aria-label')).to.be.equal(originalLabel);
+        });
       });
     });
   });

--- a/src/test/features/controls-spec.js
+++ b/src/test/features/controls-spec.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import {$controls, ControlsMixin, IDLE_PROMPT, IDLE_PROMPT_THRESHOLD_MS} from '../../features/controls.js';
+import {$controls, $promptElement, ControlsMixin, IDLE_PROMPT, IDLE_PROMPT_THRESHOLD_MS} from '../../features/controls.js';
 import ModelViewerElementBase, {$scene} from '../../model-viewer-base.js';
 import {assetPath, dispatchSyntheticEvent, rafPasses, timePasses, until, waitForEvent} from '../helpers.js';
 
@@ -87,6 +87,7 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
       suite('a11y', () => {
         test('prompts user to interact when focused', async () => {
           const {canvas} = element[$scene];
+          const promptElement = element[$promptElement];
           const originalLabel = canvas.getAttribute('aria-label');
 
           // NOTE(cdata): This wait time was added in order to deflake tests on
@@ -99,10 +100,13 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
           canvas.focus();
 
           await until(() => canvas.getAttribute('aria-label') === IDLE_PROMPT);
+
+          expect(promptElement.classList.contains('visible')).to.be.equal(true);
         });
 
         test('does not prompt if user already interacted', async () => {
           const {canvas} = element[$scene];
+          const promptElement = element[$promptElement];
           const originalLabel = canvas.getAttribute('aria-label');
 
           canvas.focus();
@@ -114,6 +118,9 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
           await timePasses(IDLE_PROMPT_THRESHOLD_MS + 100);
 
           expect(canvas.getAttribute('aria-label')).to.be.equal(originalLabel);
+
+          expect(promptElement.classList.contains('visible'))
+              .to.be.equal(false);
         });
       });
     });

--- a/src/test/three-components/SmoothControls-spec.js
+++ b/src/test/three-components/SmoothControls-spec.js
@@ -53,7 +53,7 @@ const cameraIsLookingAt = (camera, position) => {
 /**
  * Settle controls by performing 50 frames worth of updates
  */
-const settleControls = controls =>
+export const settleControls = controls =>
     controls.update(performance.now, FIFTY_FRAME_DELTA);
 
 suite('SmoothControls', () => {


### PR DESCRIPTION
# Improved a11y for `<model-viewer>` controls

This change is the rolled up PR including work from #322 and #325. Since this work all ties in to #299, I have copied over relevant graphics and descriptions so that everything can be tested / signed-off-on in its integrated form before it lands in master. Detailed info related to the change follows:

## Prompt screen reader users to interact w/ camera

This change proposes an ARIA-based interaction prompt for users who are focused on an activated `<model-viewer>` element with `controls` configured. The logic for this prompt is roughly:

 1. A user focuses the `<model-viewer>` (after any `poster` or equivalent is dismissed)
 2. After a period of time (currently ~3s), if the user has not interacted w/ the controls, they are prompted to interact ("Use mouse, touch or arrow keys to control the camera!")
 3. If the user blurs and then re-focuses the `<model-viewer>` without having interacted, repeat step 2
 4. If the user interacts with the `<model-viewer>` controls, we no longer prompt them to interact

![interactionprompt](https://user-images.githubusercontent.com/240083/51934383-4c25a180-23b8-11e9-9eba-01fe23397a73.gif)

**Note:** the interaction prompt copy has been updated since the GIF was recorded, but the flow is the same.

## Visually prompt viewer to try controls

This change proposes a visual counterpart to the controls prompt suggested in #319 .

 - The timing and dismissal logic is the same as the ARIA prompt
 - An animated SVG is bundled to offer a reasonable default experience
 - Default prompt can be overridden by distributing "light tree" content to the `controls-prompt` slot

### Default visual prompt

![controlsprompt](https://user-images.githubusercontent.com/240083/51965692-36979280-241f-11e9-88f3-2e7401244230.gif)

### Customized visual prompt

```html
<model-viewer src="something.gltf" controls>
  <!-- NOTE: Any custom content (not just images) can be used in place
       of the default prompt: -->
  <img src="something.gif" slot="controls-prompt">
</model-viewer>
```

![controlspromptcustom](https://user-images.githubusercontent.com/240083/51965700-3ac3b000-241f-11e9-9dfe-6a2ee46548a3.gif)

## Announce camera orientation to screen readers

This change is meant to complement a11y / interaction improvements brought by #319 and #322 .

 - When the orientation of the camera changes significantly, the new orientation is announced to screen readers
 - When the model loses focus and then regains focus, the original ARIA label is announced
 - Azimuth is separated into quadrants: front, left, back and right
 - The top third of the sphere is the "upper" pole, the bottom third is the "lower" pole

---
![announceviewdirection](https://user-images.githubusercontent.com/240083/52077104-ffbb9c80-2544-11e9-82fe-4c3104f0bacd.gif)

Fixes #316 
Fixes #317 via #322 
Fixes #315 via #325 
Fixes #299 