### PR TITLE
Announce camera orientation

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -69,7 +69,6 @@
                   src="assets/Astronaut.glb"
                   alt="A 3D model of an astronaut"
                   controls
-                  auto-rotate
                   background-color="#455A64">
                 </model-viewer>
             </template>

--- a/src/test/three-components/SmoothControls-spec.js
+++ b/src/test/three-components/SmoothControls-spec.js
@@ -53,7 +53,7 @@ const cameraIsLookingAt = (camera, position) => {
 /**
  * Settle controls by performing 50 frames worth of updates
  */
-const settleControls = controls =>
+export const settleControls = controls =>
     controls.update(performance.now, FIFTY_FRAME_DELTA);
 
 suite('SmoothControls', () => {


### PR DESCRIPTION
This change is meant to complement a11y / interaction improvements brought by #319 and #322 .

 - When the orientation of the camera changes significantly, the new orientation is announced to screen readers
 - When the model loses focus and then regains focus, the original ARIA label is announced
 - Azimuth is separated into quadrants: front, left, back and right
 - The top third of the sphere is the "upper" pole, the bottom third is the "lower" pole

---
![announceviewdirection](https://user-images.githubusercontent.com/240083/52077104-ffbb9c80-2544-11e9-82fe-4c3104f0bacd.gif)

Fixes #315 