### PR TITLE
Upgrade Three.js to r101

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10353,9 +10353,9 @@
       }
     },
     "three": {
-      "version": "0.100.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.100.0.tgz",
-      "integrity": "sha512-/lN2rdE1OqIwJr4/HcSaOisiCY0uVA0sqPpbCG5nil2uICEdS0LfGwSVYTtZDsIpR76r3++h5H3Hzg5D+SJBRQ=="
+      "version": "0.101.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.101.1.tgz",
+      "integrity": "sha512-8ufimUVmRLtH+BTpEIbDjdGEKQOVWLMLgGynaKin1KbYTE136ZNOepJ8EgByi0tN43dQ7B1YrKLCJgXGy4bLmw=="
     },
     "through": {
       "version": "2.3.8",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
   },
   "dependencies": {
     "@polymer/lit-element": "^0.6.2",
-    "three": "^0.100.0"
+    "three": "^0.101.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
This paves the way for:

 - Usage of scene.background in HDR changes #196 
 - Importing discrete modules, even from TypeScript, to reduce bundle size

Fixes #330 
