### PR TITLE
Sparsely announce loading status to screen readers

### DIFF
--- a/examples/styles/examples.css
+++ b/examples/styles/examples.css
@@ -14,8 +14,8 @@
  */
 
 /* @import url('https://fonts.googleapis.com/css?family=Rubik'); */
-@import url('https://fonts.googleapis.com/css?family=Rubik:400,500,700');
-@import url('https://fonts.googleapis.com/css?family=Roboto+Mono:400,500');
+/*@import url('https://fonts.googleapis.com/css?family=Rubik:400,500,700');*/
+/*@import url('https://fonts.googleapis.com/css?family=Roboto+Mono:400,500');*/
 
 body {
   font-family: 'Rubik', sans-serif;

--- a/examples/styles/examples.css
+++ b/examples/styles/examples.css
@@ -14,8 +14,8 @@
  */
 
 /* @import url('https://fonts.googleapis.com/css?family=Rubik'); */
-/*@import url('https://fonts.googleapis.com/css?family=Rubik:400,500,700');*/
-/*@import url('https://fonts.googleapis.com/css?family=Roboto+Mono:400,500');*/
+@import url('https://fonts.googleapis.com/css?family=Rubik:400,500,700');
+@import url('https://fonts.googleapis.com/css?family=Roboto+Mono:400,500');
 
 body {
   font-family: 'Rubik', sans-serif;

--- a/src/features/loading.js
+++ b/src/features/loading.js
@@ -194,7 +194,6 @@ export const LoadingMixin = (ModelViewerElement) => {
       }
 
       if (!this.src) {
-        console.warn('No src to preload!');
         return;
       }
 

--- a/src/features/loading/status-announcer.ts
+++ b/src/features/loading/status-announcer.ts
@@ -14,13 +14,14 @@
  */
 
 import ModelViewerElementBase from '../../model-viewer-base.js';
-import {debounce} from '../../utils.js';
+import {debounce, getFirstMapKey} from '../../utils.js';
 
 export const INITIAL_STATUS_ANNOUNCEMENT =
     'This page includes one or more 3D models that are loading';
 export const FINISHED_LOADING_ANNOUNCEMENT =
     'All 3D models in the page have loaded';
 export const UPDATE_STATUS_DEBOUNCE_MS = 100;
+
 
 const $modelViewerStatusInstance = Symbol('modelViewerStatusInstance');
 const $updateStatus = Symbol('updateStatus');
@@ -131,8 +132,10 @@ export class LoadingStatusAnnouncer {
     instanceStatus.instanceWasUnregistered();
 
     if (this.modelViewerStatusInstance === modelViewer) {
-      this.modelViewerStatusInstance =
-          statuses.size > 0 ? statuses.keys().next().value : null;
+      this.modelViewerStatusInstance = statuses.size > 0 ?
+          getFirstMapKey<ModelViewerElementBase, InstanceLoadingStatus>(
+              statuses) :
+          null;
     }
   }
 
@@ -163,7 +166,6 @@ export class LoadingStatusAnnouncer {
       return;
     }
 
-    console.log('Initial status');
     this.statusElement.textContent = INITIAL_STATUS_ANNOUNCEMENT;
     this.statusUpdateInProgress = true;
 
@@ -173,7 +175,6 @@ export class LoadingStatusAnnouncer {
       await Promise.all(loadingPromises);
     }
 
-    console.log('Finished status');
     this.statusElement.textContent = FINISHED_LOADING_ANNOUNCEMENT;
     this.statusUpdateInProgress = false;
   }

--- a/src/features/loading/status-announcer.ts
+++ b/src/features/loading/status-announcer.ts
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import ModelViewerElementBase from '../../model-viewer-base.js';
+import {debounce} from '../../utils.js';
+
+export const INITIAL_STATUS_ANNOUNCEMENT =
+    'This page includes one or more 3D models that are loading';
+export const FINISHED_LOADING_ANNOUNCEMENT =
+    'All 3D models in the page have loaded';
+export const UPDATE_STATUS_DEBOUNCE_MS = 100;
+
+const $modelViewerStatusInstance = Symbol('modelViewerStatusInstance');
+const $updateStatus = Symbol('updateStatus');
+
+interface InstanceLoadingStatus {
+  instanceWasUnregistered: () => void;
+  loadAttemptCompletes: Promise<any>;
+}
+
+/**
+ * The LoadingStatusAnnouncer manages announcements of loading status across
+ * all <model-viewer> elements in the document at any given time. As new
+ * <model-viewer> elements are connected to the document, they are registered
+ * with a LoadingStatusAnnouncer singleton. As they are disconnected, the are
+ * also unregistered. Announcements are made to indicate the following
+ * conditions:
+ *
+ *  1. There are <model-viewer> elements that have yet to finish loading
+ *  2. All <model-viewer> elements in the page have finished attempting to load
+ */
+export class LoadingStatusAnnouncer {
+  /**
+   * The "status" instance is the <model-viewer> instance currently designated
+   * to announce the loading status of all <model-viewer> elements in the
+   * document at any given time. It might change as <model-viewer> elements are
+   * attached or detached over time.
+   */
+  protected[$modelViewerStatusInstance]: ModelViewerElementBase|null = null;
+
+  protected registeredInstanceStatuses:
+      Map<ModelViewerElementBase, InstanceLoadingStatus> =
+          new Map<ModelViewerElementBase, InstanceLoadingStatus>();
+
+  protected loadingPromises: Array<Promise<any>> = [];
+
+  /**
+   * This element is a node that floats around the document as the status
+   * instance changes (see above). It is a singleton that represents the loading
+   * status for all <model-viewer> elements currently in the page. It has its
+   * role attribute set to "status", which causes screen readers to announce
+   * any changes to its text content.
+   *
+   * @see https://www.w3.org/TR/wai-aria-1.1/#status
+   */
+  readonly statusElement: HTMLParagraphElement = document.createElement('p');
+  protected statusUpdateInProgress: boolean = false;
+
+  protected[$updateStatus]: () => void =
+      debounce(() => this.updateStatus(), UPDATE_STATUS_DEBOUNCE_MS);
+
+  constructor() {
+    this.statusElement.setAttribute('role', 'status');
+    this.statusElement.style.position = 'absolute';
+    this.statusElement.style.color = 'transparent';
+    this.statusElement.style.pointerEvents = 'none';
+  }
+
+  /**
+   * Register a <model-viewer> element with the announcer. If it is not yet
+   * loaded, its loading status will be tracked by the announcer.
+   */
+  registerInstance(modelViewer: ModelViewerElementBase) {
+    if (this.registeredInstanceStatuses.has(modelViewer)) {
+      return;
+    }
+
+    let instanceWasUnregistered = () => {};
+    const loadShouldBeMeasured =
+        modelViewer.loaded === false && !!(modelViewer as any).src;
+    const loadAttemptCompletes = loadShouldBeMeasured ?
+        new Promise((resolve) => {
+          const resolveHandler = () => {
+            resolve();
+
+            modelViewer.removeEventListener('load', resolveHandler);
+            modelViewer.removeEventListener('error', resolveHandler);
+          };
+
+          modelViewer.addEventListener('load', resolveHandler);
+          modelViewer.addEventListener('error', resolveHandler);
+
+          instanceWasUnregistered = resolveHandler;
+        }) :
+        Promise.resolve();
+
+    this.registeredInstanceStatuses.set(
+        modelViewer, {instanceWasUnregistered, loadAttemptCompletes});
+
+    this.loadingPromises.push(loadAttemptCompletes);
+
+    if (this.modelViewerStatusInstance == null) {
+      this.modelViewerStatusInstance = modelViewer;
+    }
+  }
+
+  /**
+   * Unregister a <model-viewer> element with the announcer. Its loading status
+   * will no longer be tracked by the announcer.
+   */
+  unregisterInstance(modelViewer: ModelViewerElementBase) {
+    if (!this.registeredInstanceStatuses.has(modelViewer)) {
+      return;
+    }
+
+    const statuses = this.registeredInstanceStatuses;
+    const instanceStatus = statuses.get(modelViewer)!;
+    statuses.delete(modelViewer);
+    instanceStatus.instanceWasUnregistered();
+
+    if (this.modelViewerStatusInstance === modelViewer) {
+      this.modelViewerStatusInstance =
+          statuses.size > 0 ? statuses.keys().next().value : null;
+    }
+  }
+
+  protected get modelViewerStatusInstance(): ModelViewerElementBase|null {
+    return this[$modelViewerStatusInstance];
+  }
+
+  protected set modelViewerStatusInstance(value: ModelViewerElementBase|null) {
+    const currentInstance = this[$modelViewerStatusInstance];
+    if (currentInstance === value) {
+      return;
+    }
+
+    const {statusElement} = this;
+
+    if (value != null && value.shadowRoot != null) {
+      value.shadowRoot.appendChild(statusElement);
+    } else if (statusElement.parentNode != null) {
+      statusElement.parentNode.removeChild(statusElement);
+    }
+
+    this[$modelViewerStatusInstance] = value;
+    this[$updateStatus]();
+  }
+
+  protected async updateStatus() {
+    if (this.statusUpdateInProgress || this.loadingPromises.length === 0) {
+      return;
+    }
+
+    console.log('Initial status');
+    this.statusElement.textContent = INITIAL_STATUS_ANNOUNCEMENT;
+    this.statusUpdateInProgress = true;
+
+    while (this.loadingPromises.length) {
+      const {loadingPromises} = this;
+      this.loadingPromises = [];
+      await Promise.all(loadingPromises);
+    }
+
+    console.log('Finished status');
+    this.statusElement.textContent = FINISHED_LOADING_ANNOUNCEMENT;
+    this.statusUpdateInProgress = false;
+  }
+}

--- a/src/test/features/loading/status-announcer-spec.ts
+++ b/src/test/features/loading/status-announcer-spec.ts
@@ -13,12 +13,11 @@
  * limitations under the License.
  */
 import {LoadingMixin} from '../../../features/loading.js';
-import {FINISHED_LOADING_ANNOUNCEMENT, INITIAL_STATUS_ANNOUNCEMENT, LoadingStatusAnnouncer, UPDATE_STATUS_DEBOUNCE_MS} from '../../../features/loading/status-announcer.js';
+import {FINISHED_LOADING_ANNOUNCEMENT, INITIAL_STATUS_ANNOUNCEMENT, LoadingStatusAnnouncer} from '../../../features/loading/status-announcer.js';
 import ModelViewerElementBase from '../../../model-viewer-base.js';
-import {assetPath, isInDocumentTree, timePasses, until, waitForEvent} from '../../helpers.js';
+import {assetPath, isInDocumentTree, until, waitForEvent} from '../../helpers.js';
 
 const expect = chai.expect;
-const TIME_TO_UPDATE_MS = UPDATE_STATUS_DEBOUNCE_MS + 50;
 
 suite('LoadingStatusAnnouncer', () => {
   let nextId = 0;
@@ -47,7 +46,7 @@ suite('LoadingStatusAnnouncer', () => {
 
         loadingStatusAnnouncer.registerInstance(element);
 
-        await timePasses(TIME_TO_UPDATE_MS);
+        await waitForEvent(loadingStatusAnnouncer, 'initial-status-announced');
 
         const {statusElement} = loadingStatusAnnouncer;
 
@@ -62,8 +61,10 @@ suite('LoadingStatusAnnouncer', () => {
 
           loadingStatusAnnouncer.registerInstance(element);
 
-          await until(() => element.loaded);
-          await timePasses(TIME_TO_UPDATE_MS);
+          await Promise.all([
+            until(() => element.loaded),
+            waitForEvent(loadingStatusAnnouncer, 'finished-loading-announced')
+          ]);
 
           const {statusElement} = loadingStatusAnnouncer;
 
@@ -82,9 +83,10 @@ suite('LoadingStatusAnnouncer', () => {
           loadingStatusAnnouncer.registerInstance(elementOne);
           loadingStatusAnnouncer.registerInstance(elementTwo);
 
-          await Promise.all(
-              [until(() => elementOne.loaded), until(() => elementTwo.loaded)]);
-          await timePasses(TIME_TO_UPDATE_MS);
+          await Promise.all([
+            until(() => elementOne.loaded && elementTwo.loaded),
+            waitForEvent(loadingStatusAnnouncer, 'finished-loading-announced')
+          ]);
 
           const {statusElement} = loadingStatusAnnouncer;
 
@@ -106,8 +108,10 @@ suite('LoadingStatusAnnouncer', () => {
             loadingStatusAnnouncer.registerInstance(elementOne);
             loadingStatusAnnouncer.registerInstance(elementTwo);
 
-            await until(() => elementTwo.loaded);
-            await timePasses(TIME_TO_UPDATE_MS);
+            await Promise.all([
+              until(() => elementTwo.loaded),
+              waitForEvent(loadingStatusAnnouncer, 'finished-loading-announced')
+            ]);
 
             const {statusElement} = loadingStatusAnnouncer;
 
@@ -129,8 +133,11 @@ suite('LoadingStatusAnnouncer', () => {
             loadingStatusAnnouncer.registerInstance(elementOne);
             loadingStatusAnnouncer.registerInstance(elementTwo);
 
-            await Promise.all([errorOccurs, until(() => elementTwo.loaded)]);
-            await timePasses(TIME_TO_UPDATE_MS);
+            await Promise.all([
+              errorOccurs,
+              until(() => elementTwo.loaded),
+              waitForEvent(loadingStatusAnnouncer, 'finished-loading-announced')
+            ]);
 
             const {statusElement} = loadingStatusAnnouncer;
 

--- a/src/test/features/loading/status-announcer-spec.ts
+++ b/src/test/features/loading/status-announcer-spec.ts
@@ -18,6 +18,7 @@ import ModelViewerElementBase from '../../../model-viewer-base.js';
 import {assetPath, isInDocumentTree, timePasses, until, waitForEvent} from '../../helpers.js';
 
 const expect = chai.expect;
+const TIME_TO_UPDATE_MS = UPDATE_STATUS_DEBOUNCE_MS + 50;
 
 suite('LoadingStatusAnnouncer', () => {
   let nextId = 0;
@@ -46,7 +47,7 @@ suite('LoadingStatusAnnouncer', () => {
 
         loadingStatusAnnouncer.registerInstance(element);
 
-        await timePasses(UPDATE_STATUS_DEBOUNCE_MS);
+        await timePasses(TIME_TO_UPDATE_MS);
 
         const {statusElement} = loadingStatusAnnouncer;
 
@@ -62,7 +63,7 @@ suite('LoadingStatusAnnouncer', () => {
           loadingStatusAnnouncer.registerInstance(element);
 
           await until(() => element.loaded);
-          await timePasses(UPDATE_STATUS_DEBOUNCE_MS);
+          await timePasses(TIME_TO_UPDATE_MS);
 
           const {statusElement} = loadingStatusAnnouncer;
 
@@ -83,7 +84,7 @@ suite('LoadingStatusAnnouncer', () => {
 
           await Promise.all(
               [until(() => elementOne.loaded), until(() => elementTwo.loaded)]);
-          await timePasses(UPDATE_STATUS_DEBOUNCE_MS);
+          await timePasses(TIME_TO_UPDATE_MS);
 
           const {statusElement} = loadingStatusAnnouncer;
 
@@ -106,7 +107,7 @@ suite('LoadingStatusAnnouncer', () => {
             loadingStatusAnnouncer.registerInstance(elementTwo);
 
             await until(() => elementTwo.loaded);
-            await timePasses(UPDATE_STATUS_DEBOUNCE_MS);
+            await timePasses(TIME_TO_UPDATE_MS);
 
             const {statusElement} = loadingStatusAnnouncer;
 
@@ -129,7 +130,7 @@ suite('LoadingStatusAnnouncer', () => {
             loadingStatusAnnouncer.registerInstance(elementTwo);
 
             await Promise.all([errorOccurs, until(() => elementTwo.loaded)]);
-            await timePasses(UPDATE_STATUS_DEBOUNCE_MS);
+            await timePasses(TIME_TO_UPDATE_MS);
 
             const {statusElement} = loadingStatusAnnouncer;
 

--- a/src/test/features/loading/status-announcer-spec.ts
+++ b/src/test/features/loading/status-announcer-spec.ts
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {LoadingMixin} from '../../../features/loading.js';
+import {FINISHED_LOADING_ANNOUNCEMENT, INITIAL_STATUS_ANNOUNCEMENT, LoadingStatusAnnouncer, UPDATE_STATUS_DEBOUNCE_MS} from '../../../features/loading/status-announcer.js';
+import ModelViewerElementBase from '../../../model-viewer-base.js';
+import {assetPath, isInDocumentTree, timePasses, until, waitForEvent} from '../../helpers.js';
+
+const expect = chai.expect;
+
+suite('LoadingStatusAnnouncer', () => {
+  let nextId = 0;
+  let tagName: string;
+  let ModelViewerElement: any;
+  let loadingStatusAnnouncer: LoadingStatusAnnouncer;
+
+  setup(() => {
+    tagName = `model-viewer-loading-announcer-${nextId++}`;
+    ModelViewerElement = class extends LoadingMixin
+    (ModelViewerElementBase) {
+      static get is() {
+        return tagName;
+      }
+    };
+    customElements.define(tagName, ModelViewerElement);
+    loadingStatusAnnouncer = new LoadingStatusAnnouncer();
+  });
+
+  suite('when a model is registered', () => {
+    suite('that has a src', () => {
+      test('sets initial status', async () => {
+        const element = new ModelViewerElement();
+        element.poster = assetPath('Astronaut.png');
+        element.src = assetPath('Astronaut.glb');
+
+        loadingStatusAnnouncer.registerInstance(element);
+
+        await timePasses(UPDATE_STATUS_DEBOUNCE_MS);
+
+        const {statusElement} = loadingStatusAnnouncer;
+
+        expect(statusElement.textContent)
+            .to.be.equal(INITIAL_STATUS_ANNOUNCEMENT);
+      });
+
+      suite('after the model loads', () => {
+        test('sets the finished status', async () => {
+          const element = new ModelViewerElement();
+          element.src = assetPath('Astronaut.glb');
+
+          loadingStatusAnnouncer.registerInstance(element);
+
+          await until(() => element.loaded);
+          await timePasses(UPDATE_STATUS_DEBOUNCE_MS);
+
+          const {statusElement} = loadingStatusAnnouncer;
+
+          expect(statusElement.textContent)
+              .to.be.equal(FINISHED_LOADING_ANNOUNCEMENT);
+        });
+      });
+
+      suite('there are other registered models', () => {
+        test('sets finished status when all models are loaded', async () => {
+          const elementOne = new ModelViewerElement();
+          const elementTwo = new ModelViewerElement();
+
+          elementOne.src = elementTwo.src = assetPath('Astronaut.glb');
+
+          loadingStatusAnnouncer.registerInstance(elementOne);
+          loadingStatusAnnouncer.registerInstance(elementTwo);
+
+          await Promise.all(
+              [until(() => elementOne.loaded), until(() => elementTwo.loaded)]);
+          await timePasses(UPDATE_STATUS_DEBOUNCE_MS);
+
+          const {statusElement} = loadingStatusAnnouncer;
+
+          expect(statusElement.textContent)
+              .to.be.equal(FINISHED_LOADING_ANNOUNCEMENT);
+        });
+
+        suite('one model is already loaded', () => {
+          test('eventually sets finished status', async () => {
+            const elementOne = new ModelViewerElement();
+            const elementTwo = new ModelViewerElement();
+
+            elementOne.src = assetPath('Astronaut.glb');
+
+            await until(() => elementOne.loaded);
+
+            elementTwo.src = assetPath('Astronaut.glb');
+
+            loadingStatusAnnouncer.registerInstance(elementOne);
+            loadingStatusAnnouncer.registerInstance(elementTwo);
+
+            await until(() => elementTwo.loaded);
+            await timePasses(UPDATE_STATUS_DEBOUNCE_MS);
+
+            const {statusElement} = loadingStatusAnnouncer;
+
+            expect(statusElement.textContent)
+                .to.be.equal(FINISHED_LOADING_ANNOUNCEMENT);
+          });
+        });
+
+        suite('one model fails', () => {
+          test('eventually sets finished status', async () => {
+            const elementOne = new ModelViewerElement();
+            const elementTwo = new ModelViewerElement();
+
+            const errorOccurs = waitForEvent(elementOne, 'error');
+
+            elementOne.src = assetPath('DOES_NOT_EXIST.glb');
+            elementTwo.src = assetPath('Astronaut.glb');
+
+            loadingStatusAnnouncer.registerInstance(elementOne);
+            loadingStatusAnnouncer.registerInstance(elementTwo);
+
+            await Promise.all([errorOccurs, until(() => elementTwo.loaded)]);
+            await timePasses(UPDATE_STATUS_DEBOUNCE_MS);
+
+            const {statusElement} = loadingStatusAnnouncer;
+
+            expect(statusElement.textContent)
+                .to.be.equal(FINISHED_LOADING_ANNOUNCEMENT);
+          });
+        });
+
+        suite('first element is removed', () => {
+          test('status element remains in the document tree', async () => {
+            // NOTE(cdata): We use ModelViewerElementBase here because we are
+            // testing behavior that is affected by connected/disconnected
+            // side-effects in LoadingMixin.
+            const elementOne = new ModelViewerElementBase();
+            const elementTwo = new ModelViewerElementBase();
+
+            document.body.appendChild(elementOne);
+            document.body.appendChild(elementTwo);
+
+            const {statusElement} = loadingStatusAnnouncer;
+
+            loadingStatusAnnouncer.registerInstance(elementOne);
+
+            expect(isInDocumentTree(statusElement)).to.be.equal(true);
+
+            loadingStatusAnnouncer.registerInstance(elementTwo);
+
+            loadingStatusAnnouncer.unregisterInstance(elementOne);
+            document.body.removeChild(elementOne);
+
+            expect(isInDocumentTree(statusElement)).to.be.equal(true);
+            document.body.removeChild(elementTwo);
+          });
+        });
+      });
+    });
+  });
+});

--- a/src/test/helpers.js
+++ b/src/test/helpers.js
@@ -105,7 +105,7 @@ export const assetPath = (name) => `${ASSETS_DIRECTORY}${name}`;
 
 
 /**
- * Returns truu if the given element is in the tree of the document of the
+ * Returns true if the given element is in the tree of the document of the
  * current frame.
  *
  * @param {HTMLElement} element

--- a/src/test/helpers.js
+++ b/src/test/helpers.js
@@ -59,7 +59,7 @@ export const textureMatchesMeta = (texture, meta) => !!(
  * @param {string} eventName
  * @param {?Function} predicate
  */
-export const waitForEvent = (target, eventName, predicate) =>
+export const waitForEvent = (target, eventName, predicate = null) =>
     new Promise(resolve => {
       function handler(e) {
         if (!predicate || predicate(e)) {
@@ -93,4 +93,34 @@ export const dispatchSyntheticEvent = (element, type, properties = {
 
 export const ASSETS_DIRECTORY = '../examples/assets/';
 
+/**
+ * Returns the full path for an asset by name. This is a convenience helper so
+ * that we don't need to change paths throughout all test suites if we ever
+ * decide to move files around.
+ *
+ * @param {string} name
+ * @return {string}
+ */
 export const assetPath = (name) => `${ASSETS_DIRECTORY}${name}`;
+
+
+/**
+ * Returns truu if the given element is in the tree of the document of the
+ * current frame.
+ *
+ * @param {HTMLElement} element
+ * @return {boolean}
+ */
+export const isInDocumentTree = (element) => {
+  let root = element.getRootNode();
+
+  while (root !== element && root != null) {
+    if (root.nodeType === Node.DOCUMENT_NODE) {
+      return root === document;
+    }
+
+    root = root.host && root.host.getRootNode();
+  }
+
+  return false;
+};

--- a/src/test/helpers.js
+++ b/src/test/helpers.js
@@ -55,7 +55,7 @@ export const textureMatchesMeta = (texture, meta) => !!(
     }, true));
 
 /**
- * @param {EventTarget} target
+ * @param {EventTarget|EventDispatcher} target
  * @param {string} eventName
  * @param {?Function} predicate
  */

--- a/src/test/index.js
+++ b/src/test/index.js
@@ -24,5 +24,6 @@ import './three-components/CachingGLTFLoader-spec.js';
 import './features/controls-spec.js';
 import './features/environment-spec.js';
 import './features/loading-spec.js';
+import './features/loading/status-announcer-spec.js';
 import './features/magic-leap-spec.js';
 import './features/ar-spec.js';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,12 +13,12 @@
  * limitations under the License.
  */
 
-import {Vector3} from 'three';
-
 import {HAS_FULLSCREEN_API, HAS_WEBXR_DEVICE_API, HAS_WEBXR_HIT_TEST_API, IS_AR_CANDIDATE} from './constants.js';
 
-export const deserializeUrl = (url) =>
+
+export const deserializeUrl = (url: string): string|null =>
     (url != null && url !== 'null') ? toFullUrl(url) : null;
+
 
 export const assertIsArCandidate = () => {
   if (IS_AR_CANDIDATE) {
@@ -44,22 +44,23 @@ export const assertIsArCandidate = () => {
           missingApis.join(', ')}`);
 };
 
+
 /**
  * Converts a partial URL string to a fully qualified URL string.
  *
  * @param {String} url
  * @return {String}
  */
-export const toFullUrl = (partialUrl) => {
+export const toFullUrl = (partialUrl: string): string => {
   const url = new URL(partialUrl, window.location.toString());
   return url.toString();
 };
 
 
-export const debounce = (fn, ms) => {
-  let timer = null;
+export const debounce = (fn: (...args: Array<any>) => any, ms: number) => {
+  let timer: number|null = null;
 
-  return (...args) => {
+  return (...args: Array<any>) => {
     if (timer != null) {
       self.clearTimeout(timer);
     }
@@ -71,14 +72,16 @@ export const debounce = (fn, ms) => {
   };
 };
 
+
 /**
  * @param {Number} edge
  * @param {Number} value
  * @return {Number} 0 if value is less than edge, otherwise 1
  */
-export const step = (edge, value) => {
+export const step = (edge: number, value: number): number => {
   return value < edge ? 0 : 1;
 };
+
 
 /**
  * @param {Number} value
@@ -86,9 +89,11 @@ export const step = (edge, value) => {
  * @param {Number} upperLimit
  * @return {Number} value clamped within lowerLimit..upperLimit
  */
-export const clamp = (value, lowerLimit, upperLimit) => Math.max(
-    lowerLimit === -Infinity ? value : lowerLimit,
-    Math.min(upperLimit === Infinity ? value : upperLimit, value));
+export const clamp =
+    (value: number, lowerLimit: number, upperLimit: number): number => Math.max(
+        lowerLimit === -Infinity ? value : lowerLimit,
+        Math.min(upperLimit === Infinity ? value : upperLimit, value));
+
 
 /**
  * Takes a URL to a USDZ file and sets the appropriate
@@ -97,7 +102,7 @@ export const clamp = (value, lowerLimit, upperLimit) => Math.max(
  *
  * @param {String} url
  */
-export const openIOSARQuickLook = url => {
+export const openIOSARQuickLook = (url: string) => {
   const anchor = document.createElement('a');
   anchor.setAttribute('rel', 'ar');
   anchor.setAttribute('href', url);
@@ -133,7 +138,7 @@ export const CAPPED_DEVICE_PIXEL_RATIO = 1;
  * conditions where <model-viewer> is slow, will be encouraged to live their
  * best life.
  */
-export const resolveDpr = (() => {
+export const resolveDpr: () => number = (() => {
   // If true, implies that the user is conscious of the viewport scaling
   // relative to the device screen size.
   const HAS_META_VIEWPORT_TAG = (() => {
@@ -158,3 +163,32 @@ export const resolveDpr = (() => {
   return () => HAS_META_VIEWPORT_TAG ? window.devicePixelRatio :
                                        CAPPED_DEVICE_PIXEL_RATIO;
 })();
+
+
+/**
+ * Returns the first key in a Map in iteration order.
+ *
+ * NOTE(cdata): This is necessary because IE11 does not implement iterator
+ * methods of Map, and polymer-build does not polyfill these methods for
+ * compatibility and performance reasons. This helper proposes that it is
+ * a reasonable compromise to sacrifice a very small amount of runtime
+ * performance in IE11 for the sake of code clarity.
+ */
+export const getFirstMapKey = <T = any, U = any>(map: Map<T, U>): T|null => {
+  if (map.keys != null) {
+    return map.keys().next().value || null;
+  }
+
+  let firstKey: T|null = null;
+
+  try {
+    map.forEach((_value: U, key: T, _map: Map<T, U>) => {
+      firstKey = key;
+      // Stop iterating the Map with forEach:
+      throw new Error();
+    });
+  } catch (_error) {
+  }
+
+  return firstKey;
+};


### PR DESCRIPTION
This change proposes providing screenreader users with sparse updates on the current loading status of all `<model-viewer>` elements on the page. Some details of the change:

 - A singleton manages aggregation and observation of the loading state of all `<model-viewer>` instances that apply the `LoadingMixin`
 - `<model-viewer>` instances are observed when they connect to the document, and ignored after they disconnect
 - Two announcements are made: an initial one ("There are 3D models that are loading") and a final one ("All 3D models have loaded")
 - An initial announcement is made if (and only if) there is at least one `<model-viewer>` in the document
 - When all currently observed instances have either loaded or errored, the final announcement is made
 - Note: since the status announcer is bundled with the `<model-viewer>` implementation, at least one `<model-viewer>` must be upgraded and in the document for the initial to be made

Here is a demo of the behavior, using emulated network conditions ("Fast 3G" in DevTools):

![announceloading](https://user-images.githubusercontent.com/240083/52509964-07b3b600-2baf-11e9-9b78-8e378b08d690.gif)

Fixes #301 