### PR TITLE
Patch styles to fix obscured AR button

### DIFF
--- a/examples/augmented-reality.html
+++ b/examples/augmented-reality.html
@@ -23,6 +23,18 @@
   minimum-scale=1.0, maximum-scale=1.0">
   <link type="text/css" href="styles/examples.css" rel="stylesheet" />
   <link rel="shortcut icon" type="image/png" href="assets/favicon.png"/>
+
+  <style>
+    @media only screen and (max-width: 800px) {
+      #demo-container {
+        height: 450px;
+      }
+      model-viewer {
+        padding-top: 60px;
+        background-color: #222;
+      }
+    }
+  </style>
   <!-- The following libraries and polyfills are recommended to maximize browser support -->
   <!-- Include prismatic.js for Magic Leap support: -->
   <script src="../node_modules/@magicleap/prismatic/prismatic.min.js"></script>
@@ -41,6 +53,7 @@
 
   <!-- Fullscreen polyfill is required for using experimental AR features in Canary: -->
   <script src="../node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>
+
 </head>
 <body>
 


### PR DESCRIPTION
This change proposes a page-specific CSS patch to fix the obscured "Enter AR" button called out in #348.

Below are samples of the new layout. Note that these changes only affect the AR examples page:

Mobile layout | Desktop layout
--------------|---------------
![image](https://user-images.githubusercontent.com/240083/52513485-e27b7380-2bbf-11e9-8212-b98af3531382.png)|![image](https://user-images.githubusercontent.com/240083/52513499-0343c900-2bc0-11e9-99b4-dd5eeb2c6764.png)

Fixes #348 