### PR TITLE
Do not apply environment maps to unlit models. Fixes #374

### DIFF
--- a/examples/assets/Triangle.gltf
+++ b/examples/assets/Triangle.gltf
@@ -1,0 +1,87 @@
+{
+  "scenes" : [
+    {
+      "nodes" : [ 0 ]
+    }
+  ],
+
+  "nodes" : [
+    {
+      "mesh" : 0
+    }
+  ],
+
+  "meshes" : [
+    {
+      "primitives" : [ {
+        "attributes" : {
+          "POSITION" : 1
+        },
+        "indices" : 0,
+        "material": 0
+      }, {
+        "attributes" : {
+          "POSITION" : 1
+        },
+        "indices" : 0,
+        "material": 1
+      } ]
+    }
+  ],
+  "materials": [
+    {"name": "MaterialA", "pbrMetallicRoughness": {
+      "baseColorFactor": [1, 0.766, 0.336, 1.0],
+      "metallicFactor": 0.0,
+      "roughnessFactor": 1.0
+    }},
+    {"name": "MaterialB", "pbrMetallicRoughness": {
+      "baseColorFactor": [0.766, 1, 0.336, 1.0],
+      "metallicFactor": 1.0,
+      "roughnessFactor": 0.0
+    }}
+  ],
+  "buffers" : [
+    {
+      "uri" : "data:application/octet-stream;base64,AAABAAIAAAAAAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAACAPwAAAAA=",
+      "byteLength" : 44
+    }
+  ],
+  "bufferViews" : [
+    {
+      "buffer" : 0,
+      "byteOffset" : 0,
+      "byteLength" : 6,
+      "target" : 34963
+    },
+    {
+      "buffer" : 0,
+      "byteOffset" : 8,
+      "byteLength" : 36,
+      "target" : 34962
+    }
+  ],
+  "accessors" : [
+    {
+      "bufferView" : 0,
+      "byteOffset" : 0,
+      "componentType" : 5123,
+      "count" : 3,
+      "type" : "SCALAR",
+      "max" : [ 2 ],
+      "min" : [ 0 ]
+    },
+    {
+      "bufferView" : 1,
+      "byteOffset" : 0,
+      "componentType" : 5126,
+      "count" : 3,
+      "type" : "VEC3",
+      "max" : [ 1.0, 1.0, 0.0 ],
+      "min" : [ 0.0, 0.0, 0.0 ]
+    }
+  ],
+
+  "asset" : {
+    "version" : "2.0"
+  }
+}

--- a/examples/assets/attributions.md
+++ b/examples/assets/attributions.md
@@ -53,3 +53,7 @@ licensed under <a href="https://hdrihaven.com/p/license.php">CC0</a>
 ## cube.gltf, offcenter-cube.gltf, pbr-spheres.glb, radiance.glb, reflective-sphere.gltf
 
 Contributed by <a href="https://github.com/jsantell">jsantell</a>
+
+## Triangle.gltf
+
+Contributed by <a href="https://github.com/donmccurdy">donmccurdy</a>

--- a/src/three-components/CachingGLTFLoader.js
+++ b/src/three-components/CachingGLTFLoader.js
@@ -48,7 +48,9 @@ export class CachingGLTFLoader {
         // Set a high renderOrder while we're here to ensure the model
         // always renders on top of the skysphere
         object.renderOrder = 1000;
-        if (object.material) {
+        if (Array.isArray(object.material)) {
+          object.material = object.material.map(m => m.clone());
+        } else if (object.material) {
           object.material = object.material.clone();
         }
       });

--- a/src/three-components/Model.js
+++ b/src/three-components/Model.js
@@ -49,8 +49,22 @@ export default class Model extends Object3D {
   }
 
   applyEnvironmentMap(map) {
+    // Note that unlit models (using MeshBasicMaterial) should not apply
+    // an environment map, even though `map` is the currently configured
+    // environment map.
     this.modelContainer.traverse(obj => {
-      if (obj && obj.isMesh && obj.material) {
+      // There are some cases where `obj.material` is
+      // an array of materials.
+      if (Array.isArray(obj.material)) {
+        for (let material of obj.material) {
+          if (material.isMeshBasicMaterial) {
+            continue;
+          }
+          material.envMap = map;
+          material.needsUpdate = true;
+        }
+      }
+      else if (obj.material && !obj.material.isMeshBasicMaterial) {
         obj.material.envMap = map;
         obj.material.needsUpdate = true;
       }


### PR DESCRIPTION
Currently with a default env map, image env map, and PMREM'd env map currently:

![localhost_5000_examples_fullscreen2 html 11](https://user-images.githubusercontent.com/641267/53048345-60a20a80-3449-11e9-9a91-837f523ec2b5.png)

With this patch:

![localhost_5000_examples_fullscreen2 html 10](https://user-images.githubusercontent.com/641267/53048371-6e579000-3449-11e9-979e-f7aebcb34719.png)

Note that `UnlitTest.glb` is included (4kb) -- can reference the Khronos models if/when they land. The Astronaut is *not* unlit AFAICT (or, does not use the unlit extension), maybe should change the background-image demo describing it as such.