### PR TITLE
Add CXXFLAGS for Filament on Debian

### DIFF
--- a/scripts/install-third-party-renderers.sh
+++ b/scripts/install-third-party-renderers.sh
@@ -96,6 +96,7 @@ cp $GLTF_RENDERER_CPP_PATH $FILAMENT_DIR/samples
 # Export critical environment variables for bulding Filament
 export CC=clang-7
 export CXX=clang++-7
+export CXXFLAGS="-stdlib=libc++"
 export FILAMENT_REQUIRES_CXXABI=true
 
 ./build.sh -j release

--- a/scripts/install-third-party-renderers.sh
+++ b/scripts/install-third-party-renderers.sh
@@ -93,7 +93,7 @@ git reset --hard origin/master
 git apply $FILAMENT_PATCH_PATH
 cp $GLTF_RENDERER_CPP_PATH $FILAMENT_DIR/samples
 
-# Export critical environment variables for bulding Filament
+# Export critical environment variables for building Filament
 export CC=clang-7
 export CXX=clang++-7
 export CXXFLAGS=-stdlib=libc++

--- a/scripts/install-third-party-renderers.sh
+++ b/scripts/install-third-party-renderers.sh
@@ -96,7 +96,7 @@ cp $GLTF_RENDERER_CPP_PATH $FILAMENT_DIR/samples
 # Export critical environment variables for bulding Filament
 export CC=clang-7
 export CXX=clang++-7
-export CXXFLAGS="-stdlib=libc++"
+export CXXFLAGS=-stdlib=libc++
 export FILAMENT_REQUIRES_CXXABI=true
 
 ./build.sh -j release

--- a/scripts/install-third-party-renderers.sh
+++ b/scripts/install-third-party-renderers.sh
@@ -94,10 +94,18 @@ git apply $FILAMENT_PATCH_PATH
 cp $GLTF_RENDERER_CPP_PATH $FILAMENT_DIR/samples
 
 # Export critical environment variables for building Filament
-export CC=clang-7
-export CXX=clang++-7
 export CXXFLAGS=-stdlib=libc++
-export FILAMENT_REQUIRES_CXXABI=true
+if [ "Linux" = $(uname -s) ]; then
+  export CC=clang-7
+  export CXX=clang++-7
+  export FILAMENT_REQUIRES_CXXABI=true
+elif [ "Darwin" = $(uname -s) ]; then
+  # no customizations needed
+  :
+else
+  echo "unknown platform: $(uname -s)"
+  exit 1
+fi
 
 ./build.sh -j release
 


### PR DESCRIPTION
Without `CXXFLAGS=-stdlib=libc++`, Filament won't build on my Debian machine.

It doesn't impact compilation on MacOS, but I had to make other changes that I'll ask about below.