### PR TITLE
Add configurable shadow intensity, change default

### DIFF
--- a/src/features/environment.js
+++ b/src/features/environment.js
@@ -16,7 +16,6 @@
 import {BackSide, BoxBufferGeometry, Color, Mesh, ShaderLib, ShaderMaterial, UniformsUtils} from 'three';
 
 import {$needsRender, $onModelLoad, $renderer, $scene, $tick} from '../model-viewer-base.js';
-import {BASE_SHADOW_OPACITY} from '../three-components/StaticShadow.js'
 
 const DEFAULT_BACKGROUND_COLOR = '#ffffff';
 const DEFAULT_SHADOW_STRENGTH = 0.0;
@@ -42,13 +41,13 @@ export const EnvironmentMixin = (ModelViewerElement) => {
         backgroundImage: {type: String, attribute: 'background-image'},
         backgroundColor: {type: String, attribute: 'background-color'},
         experimentalPmrem: {type: Boolean, attribute: 'experimental-pmrem'},
-        shadowStrength: {type: Number, attribute: 'shadow-strength'}
+        shadowIntensity: {type: Number, attribute: 'shadow-intensity'}
       };
     }
 
     constructor(...args) {
       super(...args);
-      this.shadowStrength = DEFAULT_SHADOW_STRENGTH;
+      this.shadowIntensity = DEFAULT_SHADOW_STRENGTH;
     }
 
     get[$hasBackgroundImage]() {
@@ -64,7 +63,7 @@ export const EnvironmentMixin = (ModelViewerElement) => {
     update(changedProperties) {
       super.update(changedProperties);
 
-      if (changedProperties.has('shadowStrength')) {
+      if (changedProperties.has('shadowIntensity')) {
         this[$updateShadow]();
       }
 
@@ -177,12 +176,7 @@ export const EnvironmentMixin = (ModelViewerElement) => {
     }
 
     [$updateShadow]() {
-      const {shadowStrength} = this;
-      const shadowStrengthIsNumber =
-          typeof shadowStrength === 'number' && !Number.isNaN(shadowStrength);
-
-      this[$scene].shadow.material.opacity = BASE_SHADOW_OPACITY *
-          (shadowStrengthIsNumber ? shadowStrength : DEFAULT_SHADOW_STRENGTH);
+      this[$scene].shadow.intensity = this.shadowIntensity;
       this[$needsRender]();
     }
 

--- a/src/test/features/environment-spec.js
+++ b/src/test/features/environment-spec.js
@@ -192,6 +192,21 @@ suite('ModelViewerElementBase with EnvironmentMixin', () => {
     });
   });
 
+  suite('shadow-strength', () => {
+    setup(async () => {
+      element.src = MODEL_URL;
+      await waitForEvent(element, 'load');
+    });
+
+    test('changes the opacity of the static shadow', async () => {
+      const originalOpacity = scene.shadow.material.opacity;
+      element.shadowStrength = 1.0;
+      await timePasses();
+      const newOpacity = scene.shadow.material.opacity;
+      expect(newOpacity).to.be.greaterThan(originalOpacity);
+    });
+  });
+
   suite('with background-color and background-image properties', () => {
     setup(async () => {
       let onLoad = waitForLoadAndEnvMap(scene, element, {url: BG_IMAGE_URL});

--- a/src/test/features/environment-spec.js
+++ b/src/test/features/environment-spec.js
@@ -192,7 +192,7 @@ suite('ModelViewerElementBase with EnvironmentMixin', () => {
     });
   });
 
-  suite('shadow-strength', () => {
+  suite('shadow-intensity', () => {
     setup(async () => {
       element.src = MODEL_URL;
       await waitForEvent(element, 'load');
@@ -200,7 +200,7 @@ suite('ModelViewerElementBase with EnvironmentMixin', () => {
 
     test('changes the opacity of the static shadow', async () => {
       const originalOpacity = scene.shadow.material.opacity;
-      element.shadowStrength = 1.0;
+      element.shadowIntensity = 1.0;
       await timePasses();
       const newOpacity = scene.shadow.material.opacity;
       expect(newOpacity).to.be.greaterThan(originalOpacity);

--- a/src/three-components/StaticShadow.js
+++ b/src/three-components/StaticShadow.js
@@ -72,7 +72,7 @@ export default class StaticShadow extends Mesh {
 
   set intensity(intensity) {
     const intensityIsNumber =
-        typeof intensity === 'number' && !Number.isNaN(intensity);
+        typeof intensity === 'number' && !self.isNaN(intensity);
 
     this.material.opacity =
         BASE_SHADOW_OPACITY * (intensityIsNumber ? intensity : 0.0);

--- a/src/three-components/StaticShadow.js
+++ b/src/three-components/StaticShadow.js
@@ -20,7 +20,7 @@ const $renderTarget = Symbol('renderTarget');
 
 const scale = new Vector3();
 
-export const BASE_SHADOW_OPACITY = 0.1;
+const BASE_SHADOW_OPACITY = 0.1;
 
 const DEFAULT_CONFIG = {
   near: 0.01,
@@ -64,6 +64,18 @@ export default class StaticShadow extends Mesh {
     this.material.needsUpdate = true;
 
     this[$camera] = new OrthographicCamera();
+  }
+
+  get intensity() {
+    return this.material.opacity / BASE_SHADOW_OPACITY;
+  }
+
+  set intensity(intensity) {
+    const intensityIsNumber =
+        typeof intensity === 'number' && !Number.isNaN(intensity);
+
+    this.material.opacity =
+        BASE_SHADOW_OPACITY * (intensityIsNumber ? intensity : 0.0);
   }
 
   /**

--- a/src/three-components/StaticShadow.js
+++ b/src/three-components/StaticShadow.js
@@ -20,6 +20,8 @@ const $renderTarget = Symbol('renderTarget');
 
 const scale = new Vector3();
 
+export const BASE_SHADOW_OPACITY = 0.1;
+
 const DEFAULT_CONFIG = {
   near: 0.01,
   far: 100,
@@ -33,7 +35,7 @@ const shadowGeneratorMaterial = new MeshBasicMaterial({
 
 const shadowTextureMaterial = new MeshBasicMaterial({
   transparent: true,
-  opacity: 0.1,
+  opacity: BASE_SHADOW_OPACITY,
 });
 
 /**


### PR DESCRIPTION
![shadow-strength](https://user-images.githubusercontent.com/240083/53512683-3d461380-3a78-11e9-9717-e1547c065942.gif)

This change proposes the addition of configurable shadow intensity, with a new default of `0.0`, effectively causing shadows to be hidden by default.

The image above demonstrates the shadow being changed on a timer between values `0.0` and `2.0`. The previous default intensity can be achieved by setting the value to `1.0`.

Fixes #206 