### PR TITLE
Configure exposure, maps to tone mapping exposure

### DIFF
--- a/src/features/environment.js
+++ b/src/features/environment.js
@@ -19,7 +19,7 @@ import {$needsRender, $onModelLoad, $renderer, $scene, $tick} from '../model-vie
 
 const DEFAULT_BACKGROUND_COLOR = '#ffffff';
 const DEFAULT_SHADOW_STRENGTH = 0.0;
-const DEFAULT_EXPOSURE = 0.9;
+const DEFAULT_EXPOSURE = 1.0;
 
 const WHITE = new Color('#ffffff');
 

--- a/src/features/environment.js
+++ b/src/features/environment.js
@@ -19,6 +19,7 @@ import {$needsRender, $onModelLoad, $renderer, $scene, $tick} from '../model-vie
 
 const DEFAULT_BACKGROUND_COLOR = '#ffffff';
 const DEFAULT_SHADOW_STRENGTH = 0.0;
+const DEFAULT_EXPOSURE = 0.9;
 
 const WHITE = new Color('#ffffff');
 
@@ -31,6 +32,7 @@ const $hasBackgroundImage = Symbol('hasBackgroundImage');
 const $hasBackgroundColor = Symbol('hasBackgroundColor');
 const $deallocateTextures = Symbol('deallocateTextures');
 const $updateSceneLighting = Symbol('updateSceneLighting');
+const $updateToneMapping = Symbol('updateToneMapping');
 const $updateShadow = Symbol('updateShadow');
 
 export const EnvironmentMixin = (ModelViewerElement) => {
@@ -41,13 +43,15 @@ export const EnvironmentMixin = (ModelViewerElement) => {
         backgroundImage: {type: String, attribute: 'background-image'},
         backgroundColor: {type: String, attribute: 'background-color'},
         experimentalPmrem: {type: Boolean, attribute: 'experimental-pmrem'},
-        shadowIntensity: {type: Number, attribute: 'shadow-intensity'}
+        shadowIntensity: {type: Number, attribute: 'shadow-intensity'},
+        exposure: {type: Number, attribute: 'exposure'}
       };
     }
 
     constructor(...args) {
       super(...args);
       this.shadowIntensity = DEFAULT_SHADOW_STRENGTH;
+      this.exposure = DEFAULT_EXPOSURE;
     }
 
     get[$hasBackgroundImage]() {
@@ -65,6 +69,10 @@ export const EnvironmentMixin = (ModelViewerElement) => {
 
       if (changedProperties.has('shadowIntensity')) {
         this[$updateShadow]();
+      }
+
+      if (changedProperties.has('exposure')) {
+        this[$updateToneMapping]();
       }
 
       if (!changedProperties.has('backgroundImage') &&
@@ -177,6 +185,11 @@ export const EnvironmentMixin = (ModelViewerElement) => {
 
     [$updateShadow]() {
       this[$scene].shadow.intensity = this.shadowIntensity;
+      this[$needsRender]();
+    }
+
+    [$updateToneMapping]() {
+      this[$renderer].exposure = this.exposure;
       this[$needsRender]();
     }
 

--- a/src/test/features/environment-spec.js
+++ b/src/test/features/environment-spec.js
@@ -192,6 +192,24 @@ suite('ModelViewerElementBase with EnvironmentMixin', () => {
     });
   });
 
+  suite('exposure', () => {
+    setup(async () => {
+      element.src = MODEL_URL;
+      await waitForEvent(element, 'load');
+    });
+
+    test('changes the tone mapping exposure of the renderer', async () => {
+      const originalToneMappingExposure =
+          scene.renderer.renderer.toneMappingExposure;
+      element.exposure = 2.0;
+      await timePasses();
+      const newToneMappingExposure =
+          scene.renderer.renderer.toneMappingExposure;
+      expect(newToneMappingExposure)
+          .to.be.greaterThan(originalToneMappingExposure);
+    });
+  });
+
   suite('shadow-intensity', () => {
     setup(async () => {
       element.src = MODEL_URL;

--- a/src/three-components/Renderer.js
+++ b/src/three-components/Renderer.js
@@ -93,6 +93,16 @@ export default class Renderer extends EventDispatcher {
     this.lastTick = performance.now();
   }
 
+  set exposure(exposure) {
+    const exposureIsNumber =
+        typeof exposure === 'number' && !self.isNaN(exposure);
+    this.renderer.toneMappingExposure = exposureIsNumber ? exposure : 0.9;
+  }
+
+  get exposure() {
+    return this.renderer.toneMappingExposure;
+  }
+
   setRendererSize(width, height) {
     if (this.canRender) {
       this.renderer.setSize(width, height, false);

--- a/src/three-components/Renderer.js
+++ b/src/three-components/Renderer.js
@@ -75,8 +75,6 @@ export default class Renderer extends EventDispatcher {
       // ACESFilmicToneMapping appears to be the most "saturated",
       // and similar to Filament's gltf-viewer.
       this.renderer.toneMapping = ACESFilmicToneMapping;
-      this.renderer.toneMappingExposure = 0.9;
-
     } catch (error) {
       this.context = null;
       console.warn(error);
@@ -96,7 +94,7 @@ export default class Renderer extends EventDispatcher {
   set exposure(exposure) {
     const exposureIsNumber =
         typeof exposure === 'number' && !self.isNaN(exposure);
-    this.renderer.toneMappingExposure = exposureIsNumber ? exposure : 0.9;
+    this.renderer.toneMappingExposure = exposureIsNumber ? exposure : 1.0;
   }
 
   get exposure() {

--- a/test/fidelity/alpha-blend-litmus/index.html
+++ b/test/fidelity/alpha-blend-litmus/index.html
@@ -28,6 +28,7 @@
 <body>
   <model-viewer src="../../../examples/assets/alpha-blend-litmus.glb"
       experimental-pmrem
+      exposure="0.9"
       background-image="../../../examples/assets/quick_4k.png"
       style="width: 768px; height: 768px;">
   </model-viewer>

--- a/test/fidelity/damaged-helmet-hdr-pmrem/index.html
+++ b/test/fidelity/damaged-helmet-hdr-pmrem/index.html
@@ -28,6 +28,7 @@
 <body>
   <model-viewer src="../../../examples/assets/DamagedHelmet/DamagedHelmet.gltf"
       background-image="../../../examples/assets/aircraft_workshop_01_4k.hdr"
+      exposure="0.9"
       experimental-pmrem
       style="width: 768px; height: 768px;">
   </model-viewer>

--- a/test/fidelity/damaged-helmet-solid-color-pmrem/index.html
+++ b/test/fidelity/damaged-helmet-solid-color-pmrem/index.html
@@ -28,6 +28,7 @@
 <body>
   <model-viewer src="../../../examples/assets/glTF-Sample-Models/2.0/DamagedHelmet/glTF/DamagedHelmet.gltf"
       background-color="#BEA6CC"
+      exposure="0.9"
       experimental-pmrem
       style="width: 768px; height: 768px;">
   </model-viewer>

--- a/test/fidelity/khronos-2CylinderEngine/index.html
+++ b/test/fidelity/khronos-2CylinderEngine/index.html
@@ -28,6 +28,7 @@
 <body>
   <model-viewer src="../../../examples/assets/glTF-Sample-Models/2.0/2CylinderEngine/glTF/2CylinderEngine.gltf"
       background-image="../../../examples/assets/pillars_4k.hdr"
+      exposure="0.9"
       experimental-pmrem
       style="width: 1024px; height: 768px;">
   </model-viewer>

--- a/test/fidelity/khronos-AlphaBlendModeTest/index.html
+++ b/test/fidelity/khronos-AlphaBlendModeTest/index.html
@@ -28,6 +28,7 @@
 <body>
   <model-viewer src="../../../examples/assets/glTF-Sample-Models/2.0/AlphaBlendModeTest/glTF/AlphaBlendModeTest.gltf"
       background-image="../../../examples/assets/pillars_4k.hdr"
+      exposure="0.9"
       experimental-pmrem
       style="width: 1024px; height: 768px;">
   </model-viewer>

--- a/test/fidelity/khronos-AntiqueCamera/index.html
+++ b/test/fidelity/khronos-AntiqueCamera/index.html
@@ -28,6 +28,7 @@
 <body>
   <model-viewer src="../../../examples/assets/glTF-Sample-Models/2.0/AntiqueCamera/glTF/AntiqueCamera.gltf"
       background-image="../../../examples/assets/pillars_4k.hdr"
+      exposure="0.9"
       experimental-pmrem
       style="width: 512px; height: 1024px;">
   </model-viewer>

--- a/test/fidelity/khronos-Avocado/index.html
+++ b/test/fidelity/khronos-Avocado/index.html
@@ -28,6 +28,7 @@
 <body>
   <model-viewer src="../../../examples/assets/glTF-Sample-Models/2.0/Avocado/glTF/Avocado.gltf"
       background-image="../../../examples/assets/pillars_4k.hdr"
+      exposure="0.9"
       experimental-pmrem
       style="width: 768px; height: 768px;">
   </model-viewer>

--- a/test/fidelity/khronos-BoomBox/index.html
+++ b/test/fidelity/khronos-BoomBox/index.html
@@ -28,6 +28,7 @@
 <body>
   <model-viewer src="../../../examples/assets/glTF-Sample-Models/2.0/BoomBox/glTF/BoomBox.gltf"
       background-image="../../../examples/assets/pillars_4k.hdr"
+      exposure="0.9"
       experimental-pmrem
       style="width: 768px; height: 768px;">
   </model-viewer>

--- a/test/fidelity/khronos-BoxVertexColors/index.html
+++ b/test/fidelity/khronos-BoxVertexColors/index.html
@@ -28,6 +28,7 @@
 <body>
   <model-viewer src="../../../examples/assets/glTF-Sample-Models/2.0/BoxVertexColors/glTF/BoxVertexColors.gltf"
       background-image="../../../examples/assets/pillars_4k.hdr"
+      exposure="0.9"
       experimental-pmrem
       style="width: 768px; height: 768px;">
   </model-viewer>

--- a/test/fidelity/khronos-Buggy/index.html
+++ b/test/fidelity/khronos-Buggy/index.html
@@ -28,6 +28,7 @@
 <body>
   <model-viewer src="../../../examples/assets/glTF-Sample-Models/2.0/Buggy/glTF/Buggy.gltf"
       background-image="../../../examples/assets/pillars_4k.hdr"
+      exposure="0.9"
       experimental-pmrem
       style="width: 768px; height: 768px;">
   </model-viewer>

--- a/test/fidelity/khronos-CesiumMilkTruck/index.html
+++ b/test/fidelity/khronos-CesiumMilkTruck/index.html
@@ -28,6 +28,7 @@
 <body>
   <model-viewer src="../../../examples/assets/glTF-Sample-Models/2.0/CesiumMilkTruck/glTF/CesiumMilkTruck.gltf"
       background-image="../../../examples/assets/pillars_4k.hdr"
+      exposure="0.9"
       experimental-pmrem
       style="width: 768px; height: 768px;">
   </model-viewer>

--- a/test/fidelity/khronos-Corset/index.html
+++ b/test/fidelity/khronos-Corset/index.html
@@ -28,6 +28,7 @@
 <body>
   <model-viewer src="../../../examples/assets/glTF-Sample-Models/2.0/Corset/glTF/Corset.gltf"
       background-image="../../../examples/assets/pillars_4k.hdr"
+      exposure="0.9"
       experimental-pmrem
       style="width: 768px; height: 768px;">
   </model-viewer>

--- a/test/fidelity/khronos-Cube/index.html
+++ b/test/fidelity/khronos-Cube/index.html
@@ -28,6 +28,7 @@
 <body>
   <model-viewer src="../../../examples/assets/glTF-Sample-Models/2.0/Cube/glTF/Cube.gltf"
       background-image="../../../examples/assets/pillars_4k.hdr"
+      exposure="0.9"
       experimental-pmrem
       style="width: 768px; height: 768px;">
   </model-viewer>

--- a/test/fidelity/khronos-Duck/index.html
+++ b/test/fidelity/khronos-Duck/index.html
@@ -28,6 +28,7 @@
 <body>
   <model-viewer src="../../../examples/assets/glTF-Sample-Models/2.0/Duck/glTF/Duck.gltf"
       background-image="../../../examples/assets/pillars_4k.hdr"
+      exposure="0.9"
       experimental-pmrem
       style="width: 768px; height: 768px;">
   </model-viewer>

--- a/test/fidelity/khronos-EnvironmentTest/index.html
+++ b/test/fidelity/khronos-EnvironmentTest/index.html
@@ -28,6 +28,7 @@
 <body>
   <model-viewer src="../../../examples/assets/glTF-Sample-Models/2.0/EnvironmentTest/glTF/EnvironmentTest.gltf"
       background-image="../../../examples/assets/pillars_4k.hdr"
+      exposure="0.9"
       experimental-pmrem
       style="width: 1024px; height: 768px;">
   </model-viewer>

--- a/test/fidelity/khronos-GearboxAssy/index.html
+++ b/test/fidelity/khronos-GearboxAssy/index.html
@@ -28,6 +28,7 @@
 <body>
   <model-viewer src="../../../examples/assets/glTF-Sample-Models/2.0/GearboxAssy/glTF/GearboxAssy.gltf"
       background-image="../../../examples/assets/pillars_4k.hdr"
+      exposure="0.9"
       experimental-pmrem
       style="width: 768px; height: 768px;">
   </model-viewer>

--- a/test/fidelity/khronos-Lantern/index.html
+++ b/test/fidelity/khronos-Lantern/index.html
@@ -28,6 +28,7 @@
 <body>
   <model-viewer src="../../../examples/assets/glTF-Sample-Models/2.0/Lantern/glTF/Lantern.gltf"
       background-image="../../../examples/assets/pillars_4k.hdr"
+      exposure="0.9"
       experimental-pmrem
       style="width: 768px; height: 768px;">
   </model-viewer>

--- a/test/fidelity/khronos-MetalRoughSpheres/index.html
+++ b/test/fidelity/khronos-MetalRoughSpheres/index.html
@@ -28,6 +28,7 @@
 <body>
   <model-viewer src="../../../examples/assets/glTF-Sample-Models/2.0/MetalRoughSpheres/glTF/MetalRoughSpheres.gltf"
       background-image="../../../examples/assets/pillars_4k.hdr"
+      exposure="0.9"
       experimental-pmrem
       style="width: 768px; height: 768px;">
   </model-viewer>

--- a/test/fidelity/khronos-MultiUVTest/index.html
+++ b/test/fidelity/khronos-MultiUVTest/index.html
@@ -28,6 +28,7 @@
 <body>
   <model-viewer src="../../../examples/assets/glTF-Sample-Models/2.0/MultiUVTest/glTF/MultiUVTest.gltf"
       background-image="../../../examples/assets/pillars_4k.hdr"
+      exposure="0.9"
       experimental-pmrem
       style="width: 768px; height: 768px;">
   </model-viewer>

--- a/test/fidelity/khronos-NormalTangentMirrorTest/index.html
+++ b/test/fidelity/khronos-NormalTangentMirrorTest/index.html
@@ -28,6 +28,7 @@
 <body>
   <model-viewer src="../../../examples/assets/glTF-Sample-Models/2.0/NormalTangentMirrorTest/glTF/NormalTangentMirrorTest.gltf"
       background-image="../../../examples/assets/pillars_4k.hdr"
+      exposure="0.9"
       experimental-pmrem
       style="width: 768px; height: 768px;">
   </model-viewer>

--- a/test/fidelity/khronos-NormalTangentTest/index.html
+++ b/test/fidelity/khronos-NormalTangentTest/index.html
@@ -28,6 +28,7 @@
 <body>
   <model-viewer src="../../../examples/assets/glTF-Sample-Models/2.0/NormalTangentTest/glTF/NormalTangentTest.gltf"
       background-image="../../../examples/assets/pillars_4k.hdr"
+      exposure="0.9"
       experimental-pmrem
       style="width: 768px; height: 768px;">
   </model-viewer>

--- a/test/fidelity/khronos-OrientationTest/index.html
+++ b/test/fidelity/khronos-OrientationTest/index.html
@@ -28,6 +28,7 @@
 <body>
   <model-viewer src="../../../examples/assets/glTF-Sample-Models/2.0/OrientationTest/glTF/OrientationTest.gltf"
       background-image="../../../examples/assets/pillars_4k.hdr"
+      exposure="0.9"
       experimental-pmrem
       style="width: 768px; height: 768px;">
   </model-viewer>

--- a/test/fidelity/khronos-SciFiHelmet/index.html
+++ b/test/fidelity/khronos-SciFiHelmet/index.html
@@ -28,6 +28,7 @@
 <body>
   <model-viewer src="../../../examples/assets/glTF-Sample-Models/2.0/SciFiHelmet/glTF/SciFiHelmet.gltf"
       background-image="../../../examples/assets/pillars_4k.hdr"
+      exposure="0.9"
       experimental-pmrem
       style="width: 768px; height: 768px;">
   </model-viewer>

--- a/test/fidelity/khronos-SpecGlossVsMetalRough/index.html
+++ b/test/fidelity/khronos-SpecGlossVsMetalRough/index.html
@@ -28,6 +28,7 @@
 <body>
   <model-viewer src="../../../examples/assets/glTF-Sample-Models/2.0/SpecGlossVsMetalRough/glTF/SpecGlossVsMetalRough.gltf"
       background-image="../../../examples/assets/pillars_4k.hdr"
+      exposure="0.9"
       experimental-pmrem
       style="width: 768px; height: 768px;">
   </model-viewer>

--- a/test/fidelity/khronos-Suzanne/index.html
+++ b/test/fidelity/khronos-Suzanne/index.html
@@ -28,6 +28,7 @@
 <body>
   <model-viewer src="../../../examples/assets/glTF-Sample-Models/2.0/Suzanne/glTF/Suzanne.gltf"
       background-image="../../../examples/assets/pillars_4k.hdr"
+      exposure="0.9"
       experimental-pmrem
       style="width: 768px; height: 768px;">
   </model-viewer>

--- a/test/fidelity/khronos-TextureCoordinateTest/index.html
+++ b/test/fidelity/khronos-TextureCoordinateTest/index.html
@@ -28,6 +28,7 @@
 <body>
   <model-viewer src="../../../examples/assets/glTF-Sample-Models/2.0/TextureCoordinateTest/glTF/TextureCoordinateTest.gltf"
       background-image="../../../examples/assets/pillars_4k.hdr"
+      exposure="0.9"
       experimental-pmrem
       style="width: 768px; height: 768px;">
   </model-viewer>

--- a/test/fidelity/khronos-TextureSettingsTest/index.html
+++ b/test/fidelity/khronos-TextureSettingsTest/index.html
@@ -28,6 +28,7 @@
 <body>
   <model-viewer src="../../../examples/assets/glTF-Sample-Models/2.0/TextureSettingsTest/glTF/TextureSettingsTest.gltf"
       background-image="../../../examples/assets/pillars_4k.hdr"
+      exposure="0.9"
       experimental-pmrem
       style="width: 768px; height: 768px;">
   </model-viewer>

--- a/test/fidelity/khronos-TextureTransformTest/index.html
+++ b/test/fidelity/khronos-TextureTransformTest/index.html
@@ -28,6 +28,7 @@
 <body>
   <model-viewer src="../../../examples/assets/glTF-Sample-Models/2.0/TextureTransformTest/glTF/TextureTransformTest.gltf"
       background-image="../../../examples/assets/pillars_4k.hdr"
+      exposure="0.9"
       experimental-pmrem
       style="width: 768px; height: 768px;">
   </model-viewer>

--- a/test/fidelity/khronos-UnlitTest/index.html
+++ b/test/fidelity/khronos-UnlitTest/index.html
@@ -28,6 +28,7 @@
 <body>
   <model-viewer src="../../../examples/assets/glTF-Sample-Models/2.0/UnlitTest/glTF/UnlitTest.gltf"
       background-image="../../../examples/assets/pillars_4k.hdr"
+      exposure="0.9"
       experimental-pmrem
       style="width: 768px; height: 768px;">
   </model-viewer>

--- a/test/fidelity/khronos-VertexColorTest/index.html
+++ b/test/fidelity/khronos-VertexColorTest/index.html
@@ -28,6 +28,7 @@
 <body>
   <model-viewer src="../../../examples/assets/glTF-Sample-Models/2.0/VertexColorTest/glTF/VertexColorTest.gltf"
       background-image="../../../examples/assets/pillars_4k.hdr"
+      exposure="0.9"
       experimental-pmrem
       style="width: 768px; height: 768px;">
   </model-viewer>

--- a/test/fidelity/pbr-spheres/index.html
+++ b/test/fidelity/pbr-spheres/index.html
@@ -28,6 +28,7 @@
 <body>
   <model-viewer src="../../../examples/assets/pbr-spheres.glb"
       background-image="../../../examples/assets/quick_4k.png"
+      exposure="0.9"
       experimental-pmrem
       style="width: 768px; height: 768px;">
   </model-viewer>


### PR DESCRIPTION
![exposure](https://user-images.githubusercontent.com/240083/53524780-35489c80-3a95-11e9-9864-7372aed16ebc.gif)

This change proposes the addition of a property `exposure` for controlling `toneMappingExposure` on the renderer.

 - This default `toneMappingExposure` has been changed to `1.0`
 - Fidelity tests that check against Filament have had their exposures manually configured down to `0.9` to match the old default
 - In the image above, `exposure` is oscillating between `0.0` and `4.0`.

Fixes #209 