### PR TITLE
Add configurable stage light intensity

### DIFF
--- a/src/test/features/environment-spec.js
+++ b/src/test/features/environment-spec.js
@@ -210,6 +210,33 @@ suite('ModelViewerElementBase with EnvironmentMixin', () => {
     });
   });
 
+  suite('stage-light-intensity', () => {
+    setup(async () => {
+      element.src = MODEL_URL;
+      await waitForEvent(element, 'load');
+    });
+
+    test('changes model scene light intensity', async () => {
+      const originalLightIntensity = scene.light.intensity;
+      element.stageLightIntensity = 0.5;
+      await timePasses();
+      const newLightIntensity = scene.light.intensity;
+      expect(newLightIntensity).to.be.lessThan(originalLightIntensity);
+    });
+
+    suite('with experimental-pmrem', () => {
+      test('further lowers scene light intensity', async () => {
+        element.stageLightIntensity = 0.5;
+        await timePasses();
+        const lightIntensity = scene.light.intensity;
+        element.experimentalPmrem = true;
+        await waitForEvent(element, 'environment-changed');
+        const newLightIntensity = scene.light.intensity;
+        expect(newLightIntensity).to.be.lessThan(lightIntensity);
+      });
+    });
+  });
+
   suite('shadow-intensity', () => {
     setup(async () => {
       element.src = MODEL_URL;

--- a/src/test/three-components/TextureUtils-spec.js
+++ b/src/test/three-components/TextureUtils-spec.js
@@ -30,7 +30,9 @@ suite('TextureUtils', () => {
   let textureUtils;
   setup(() => {
     const renderer = new WebGLRenderer({canvas});
-    textureUtils = new TextureUtils(renderer);
+    // NOTE(cdata): We need to lower the samples here or else tests that use
+    // PMREM have a tendency to time out on iOS Simulator
+    textureUtils = new TextureUtils(renderer, {pmremSamples: 4});
   });
   teardown(() => textureUtils.dispose());
 
@@ -114,51 +116,64 @@ suite('TextureUtils', () => {
           .to.be.ok;
     });
 
-    test('returns an environmentMap and skybox texture from an HDR url', async () => {
-      textures = await textureUtils.generateEnvironmentTextures(HDR_EQUI_URL);
-      expect(textures.skybox.texture.isTexture).to.be.ok;
-      expect(textures.environmentMap.isTexture).to.be.ok;
+    test(
+        'returns an environmentMap and skybox texture from an HDR url',
+        async () => {
+          textures =
+              await textureUtils.generateEnvironmentTextures(HDR_EQUI_URL);
+          expect(textures.skybox.texture.isTexture).to.be.ok;
+          expect(textures.environmentMap.isTexture).to.be.ok;
 
-      expect(textureMatchesMeta(
-                 textures.skybox.texture, {mapping: 'Cube', url: HDR_EQUI_URL}))
-          .to.be.ok;
+          expect(textureMatchesMeta(textures.skybox.texture, {
+            mapping: 'Cube',
+            url: HDR_EQUI_URL
+          })).to.be.ok;
 
-      expect(textureMatchesMeta(
-                 textures.environmentMap, {mapping: 'Cube', url: HDR_EQUI_URL}))
-          .to.be.ok;
-    });
+          expect(textureMatchesMeta(textures.environmentMap, {
+            mapping: 'Cube',
+            url: HDR_EQUI_URL
+          })).to.be.ok;
+        });
 
-    test('returns an environmentMap and skybox texture from url with PMREM', async () => {
-      textures = await textureUtils.generateEnvironmentTextures(EQUI_URL, {
-        pmrem: true,
-      });
-      expect(textures.skybox.texture.isTexture).to.be.ok;
-      expect(textures.environmentMap.isTexture).to.be.ok;
+    test(
+        'returns an environmentMap and skybox texture from url with PMREM',
+        async () => {
+          textures = await textureUtils.generateEnvironmentTextures(EQUI_URL, {
+            pmrem: true,
+          });
+          expect(textures.skybox.texture.isTexture).to.be.ok;
+          expect(textures.environmentMap.isTexture).to.be.ok;
 
-      expect(textureMatchesMeta(
-                 textures.skybox.texture, {mapping: 'Cube', url: EQUI_URL}))
-          .to.be.ok;
+          expect(textureMatchesMeta(
+                     textures.skybox.texture, {mapping: 'Cube', url: EQUI_URL}))
+              .to.be.ok;
 
-      expect(textureMatchesMeta(
-                 textures.environmentMap, {mapping: 'PMREM', url: EQUI_URL}))
-          .to.be.ok;
-    });
+          expect(textureMatchesMeta(textures.environmentMap, {
+            mapping: 'PMREM',
+            url: EQUI_URL
+          })).to.be.ok;
+        });
 
-    test('returns an environmentMap and skybox texture from an HDR url', async () => {
-      textures = await textureUtils.generateEnvironmentTextures(HDR_EQUI_URL, {
-        pmrem: true,
-      });
-      expect(textures.skybox.texture.isTexture).to.be.ok;
-      expect(textures.environmentMap.isTexture).to.be.ok;
+    test(
+        'returns an environmentMap and skybox texture from an HDR url',
+        async () => {
+          textures =
+              await textureUtils.generateEnvironmentTextures(HDR_EQUI_URL, {
+                pmrem: true,
+              });
+          expect(textures.skybox.texture.isTexture).to.be.ok;
+          expect(textures.environmentMap.isTexture).to.be.ok;
 
-      expect(textureMatchesMeta(
-                 textures.skybox.texture, {mapping: 'Cube', url: HDR_EQUI_URL}))
-          .to.be.ok;
+          expect(textureMatchesMeta(textures.skybox.texture, {
+            mapping: 'Cube',
+            url: HDR_EQUI_URL
+          })).to.be.ok;
 
-      expect(textureMatchesMeta(
-                 textures.environmentMap, {mapping: 'PMREM', url: HDR_EQUI_URL}))
-          .to.be.ok;
-    });
+          expect(textureMatchesMeta(textures.environmentMap, {
+            mapping: 'PMREM',
+            url: HDR_EQUI_URL
+          })).to.be.ok;
+        });
 
     test('throws if given an invalid url', async () => {
       try {
@@ -173,8 +188,7 @@ suite('TextureUtils', () => {
   suite('generateDefaultEnvironmentMap', () => {
     test('creates a cubemap render target', async () => {
       const texture = await textureUtils.generateDefaultEnvironmentMap();
-      expect(
-          textureMatchesMeta(texture, {mapping: 'Cube', url: null }))
+      expect(textureMatchesMeta(texture, {mapping: 'Cube', url: null}))
           .to.be.ok;
     });
 
@@ -182,8 +196,7 @@ suite('TextureUtils', () => {
       const texture = await textureUtils.generateDefaultEnvironmentMap({
         pmrem: true,
       });
-      expect(
-          textureMatchesMeta(texture, {mapping: 'PMREM', url: null }))
+      expect(textureMatchesMeta(texture, {mapping: 'PMREM', url: null}))
           .to.be.ok;
     });
   });

--- a/src/three-components/ModelScene.js
+++ b/src/three-components/ModelScene.js
@@ -28,6 +28,12 @@ export const ScaleTypes = {
   Framed: 'framed',
   Lifesize: 'lifesize',
 };
+
+export const IlluminationRole = {
+  Primary: 'primary',
+  Secondary: 'secondary'
+};
+
 const ScaleTypeNames = Object.keys(ScaleTypes).map(type => ScaleTypes[type]);
 
 // This (arbitrary) value represents the height of the scene in
@@ -43,6 +49,12 @@ export const FRAMED_HEIGHT = 10;
 // visible "room" in the future where framing needs to be precise), we shrink
 // the room by a little bit so it's always slightly bigger than the model.
 export const ROOM_PADDING_SCALE = 1.01;
+
+const AMBIENT_LIGHT_LOW_INTENSITY = 0.05;
+const DIRECTIONAL_LIGHT_LOW_INTENSITY = 0.5;
+
+const AMBIENT_LIGHT_HIGH_INTENSITY = 3.0;
+const DIRECTIONAL_LIGHT_HIGH_INTENSITY = 0.75;
 
 // Vertical field of view of camera, in degrees.
 const FOV = 45;
@@ -78,13 +90,14 @@ export default class ModelScene extends Scene {
 
     this.model = new Model();
     this.shadow = new StaticShadow();
-    this.light = new AmbientLight(0xffffff, 3.0);
+    this.light = new AmbientLight(0xffffff, AMBIENT_LIGHT_HIGH_INTENSITY);
     this.light.name = 'AmbientLight';
 
     // This light is only for generating (fake) shadows
     // and does not needed to be added to the scene.
     // @see StaticShadow.js
-    this.shadowLight = new DirectionalLight(0xffffff, 0.75);
+    this.shadowLight =
+        new DirectionalLight(0xffffff, DIRECTIONAL_LIGHT_HIGH_INTENSITY);
     this.shadowLight.position.set(0, 10, 0);
     this.shadowLight.name = 'ShadowLight';
 
@@ -201,6 +214,18 @@ export default class ModelScene extends Scene {
     this.camera.updateProjectionMatrix();
 
     this.updateStaticShadow();
+  }
+
+  configureStageLighting(intensityScale, illuminationRole) {
+    this.light.intensity = intensityScale *
+        (illuminationRole === IlluminationRole.Primary ?
+             AMBIENT_LIGHT_HIGH_INTENSITY :
+             AMBIENT_LIGHT_LOW_INTENSITY);
+    this.shadowLight.intensity = intensityScale *
+        (illuminationRole === IlluminationRole.Primary ?
+             DIRECTIONAL_LIGHT_HIGH_INTENSITY :
+             DIRECTIONAL_LIGHT_LOW_INTENSITY);
+    this.isDirty = true;
   }
 
   /**


### PR DESCRIPTION
This change proposes adding a `stage-light-intensity` attribute/property for configuring the intensity of Three.js ambient/directional lights in the scene.

 - Intensity in this context is a scalar that is applied to the base intensity of the ambient and directional lights separately
   - Rationale here is that the base intensity for each of these lights is different, and also based on the current role (see below)
 - Stage lights now also have a "primary" and "secondary" role, for non-PMREM and PMREM rendering respectively
   - The rationale here is that when PMREM is activated, the stage lights should be de-emphasized (they become "secondary" lighting)
   - This is an implementation detail, not directly configurable by the `<model-element>` user
 - `0.0` intensity turns off the stage lights; `1.0` is the current defaults as we know them; there is no upper bound

#### <div align="center">`stage-light-intensity` oscillating from 0.0 to 6.0</div>

| PMREM on                     | PMREM off                     |
| ----------------------- | ----------------------- |
![lights-osc-pmrem 2019-02-27 18_26_45](https://user-images.githubusercontent.com/240083/53537219-11e61780-3abe-11e9-9b86-b7d13895558a.gif)|![lights-osc-no-pmrem 2019-02-27 18_31_44](https://user-images.githubusercontent.com/240083/53537221-15799e80-3abe-11e9-9437-57773d1ab6ce.gif)|


`stage-light-intensity="1.0"` Toggling PMREM on and off |
--------------------------------------------------------- |
![lights-pmrem-no-pmrem](https://user-images.githubusercontent.com/240083/53536287-9afb4f80-3aba-11e9-8a22-6e38d34294f5.gif)|


