### PR TITLE
Introduce environment-image and environment-intensity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -819,14 +819,6 @@
         "@polymer/polymer": "^3.0.0"
       }
     },
-    "@polymer/lit-element": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/@polymer/lit-element/-/lit-element-0.6.5.tgz",
-      "integrity": "sha512-KVjuU/5Ugp6PFob6YEe1/B4GCKjqhEy9Tj954shL6d3DohT2sNAmbX9QfbXvcZ8RhbVELK6dzbN3i2BRA3mOKg==",
-      "requires": {
-        "lit-html": "^1.0.0-rc.1"
-      }
-    },
     "@polymer/marked-element": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@polymer/marked-element/-/marked-element-3.0.1.tgz",
@@ -6555,10 +6547,20 @@
         "invert-kv": "^1.0.0"
       }
     },
-    "lit-html": {
-      "version": "1.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.0.0-rc.2.tgz",
-      "integrity": "sha512-4bq34lhVmwWly1zBXicOBJLOwaWfjOVbchEEmFnZLuztxjh5wRd2WqV0URX8Q47MQ7PaIjn/eXyTRKsYhSAeRw=="
+    "lit-element": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-2.0.1.tgz",
+      "integrity": "sha512-2bu3B2ZYUZgntvOgu3i5mRK8geo45CLUwxwJEYK54hyednoJasjiTZPB13NBg1D+hNM2JfmWTWJnh1QEUQv7zw==",
+      "requires": {
+        "lit-html": "^1.0.0"
+      },
+      "dependencies": {
+        "lit-html": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.0.0.tgz",
+          "integrity": "sha512-oeWlpLmBW3gFl7979Wol2LKITpmKTUFNn7PnFbh6YNynF61W74l6x5WhwItAwPRSATpexaX1egNnRzlN4GOtfQ=="
+        }
+      }
     },
     "load-json-file": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "web-component-tester": "^6.9.2"
   },
   "dependencies": {
-    "@polymer/lit-element": "^0.6.2",
+    "lit-element": "^2.0.0",
     "three": "^0.101.0"
   },
   "publishConfig": {

--- a/src/documentation/components/example-snippet.ts
+++ b/src/documentation/components/example-snippet.ts
@@ -1,7 +1,7 @@
 import 'prismjs';
 
-import {property} from '@polymer/lit-element';
-import {UpdatingElement} from '@polymer/lit-element/lib/updating-element.js';
+import {property} from 'lit-element';
+import {UpdatingElement} from 'lit-element/lib/updating-element.js';
 
 // Silence tsc since prismjs isn't a proper module
 declare var Prism: any;

--- a/src/test/features/environment-spec.js
+++ b/src/test/features/environment-spec.js
@@ -129,7 +129,12 @@ suite('ModelViewerElementBase with EnvironmentMixin', () => {
         let onLoad = waitForLoadAndEnvMap(scene, element, {url: BG_IMAGE_URL});
         element.src = MODEL_URL;
         element.backgroundImage = BG_IMAGE_URL;
+        document.body.appendChild(element);
         await onLoad;
+      });
+
+      teardown(() => {
+        document.body.removeChild(element);
       });
 
       test('displays background with the correct map', async function() {
@@ -165,7 +170,12 @@ suite('ModelViewerElementBase with EnvironmentMixin', () => {
         });
         element.src = MODEL_URL;
         element.backgroundColor = '#ff0077';
+        document.body.appendChild(element);
         await onLoad;
+      });
+
+      teardown(() => {
+        document.body.removeChild(element);
       });
 
       test('displays background with the correct color', async function() {
@@ -195,7 +205,12 @@ suite('ModelViewerElementBase with EnvironmentMixin', () => {
   suite('exposure', () => {
     setup(async () => {
       element.src = MODEL_URL;
+      document.body.appendChild(element);
       await waitForEvent(element, 'load');
+    });
+
+    teardown(() => {
+      document.body.removeChild(element);
     });
 
     test('changes the tone mapping exposure of the renderer', async () => {
@@ -213,7 +228,12 @@ suite('ModelViewerElementBase with EnvironmentMixin', () => {
   suite('stage-light-intensity', () => {
     setup(async () => {
       element.src = MODEL_URL;
+      document.body.appendChild(element);
       await waitForEvent(element, 'load');
+    });
+
+    teardown(() => {
+      document.body.removeChild(element);
     });
 
     test('changes model scene light intensity', async () => {
@@ -240,7 +260,12 @@ suite('ModelViewerElementBase with EnvironmentMixin', () => {
   suite('shadow-intensity', () => {
     setup(async () => {
       element.src = MODEL_URL;
+      document.body.appendChild(element);
       await waitForEvent(element, 'load');
+    });
+
+    teardown(() => {
+      document.body.removeChild(element);
     });
 
     test('changes the opacity of the static shadow', async () => {
@@ -258,7 +283,12 @@ suite('ModelViewerElementBase with EnvironmentMixin', () => {
       element.setAttribute('src', MODEL_URL);
       element.setAttribute('background-color', '#ff0077');
       element.setAttribute('background-image', BG_IMAGE_URL);
+      document.body.appendChild(element);
       await onLoad;
+    });
+
+    teardown(() => {
+      document.body.removeChild(element);
     });
 
     test('displays background with background-image', async function() {

--- a/src/test/fidelity/components/analysis-view.ts
+++ b/src/test/fidelity/components/analysis-view.ts
@@ -16,7 +16,7 @@
 import './images-4-up.js';
 
 import '@polymer/paper-slider';
-import {html, LitElement, property} from '@polymer/lit-element';
+import {html, LitElement, property} from 'lit-element';
 
 import {AnalysisCompletedMessage, Dimensions, ImageComparisonMessage, ImageComparisonResults} from '../common.js';
 import {ImageAccessor} from '../image-accessor.js';

--- a/src/test/fidelity/components/image-comparison-app.ts
+++ b/src/test/fidelity/components/image-comparison-app.ts
@@ -16,7 +16,7 @@
 import './analysis-view.js';
 import './rendering-scenario.js';
 
-import {html, LitElement, property} from '@polymer/lit-element';
+import {html, LitElement, property} from 'lit-element';
 
 import {ImageComparisonConfig} from '../common.js';
 

--- a/src/test/fidelity/components/images-4-up.ts
+++ b/src/test/fidelity/components/images-4-up.ts
@@ -16,7 +16,7 @@
 import '../image-accessor.js';
 import './magnifying-glass.js';
 
-import {html, LitElement, property} from '@polymer/lit-element';
+import {html, LitElement, property} from 'lit-element';
 
 import {Dimensions, Pixel, Rect} from '../common.js';
 

--- a/src/test/fidelity/components/magnifying-glass.ts
+++ b/src/test/fidelity/components/magnifying-glass.ts
@@ -14,7 +14,7 @@
  */
 
 
-import {html, LitElement, property} from '@polymer/lit-element';
+import {html, LitElement, property} from 'lit-element';
 
 import {Pixel} from '../common.js';
 import {ImageAccessor} from '../image-accessor.js';

--- a/src/test/fidelity/components/rendering-scenario.ts
+++ b/src/test/fidelity/components/rendering-scenario.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import {html, LitElement, property} from '@polymer/lit-element';
+import {html, LitElement, property} from 'lit-element';
 import {Dimensions, GoldenConfig} from '../common.js';
 
 

--- a/src/test/three-components/TextureUtils-spec.js
+++ b/src/test/three-components/TextureUtils-spec.js
@@ -92,7 +92,7 @@ suite('TextureUtils', () => {
     });
   });
 
-  suite('generateEnvironmentTextures', () => {
+  suite('generating an environment map and skybox', () => {
     let textures;
     teardown(() => {
       if (textures) {
@@ -103,7 +103,7 @@ suite('TextureUtils', () => {
     });
 
     test('returns an environmentMap and skybox texture from url', async () => {
-      textures = await textureUtils.generateEnvironmentTextures(EQUI_URL);
+      textures = await textureUtils.generateEnvironmentMapAndSkybox(EQUI_URL);
       expect(textures.skybox.texture.isTexture).to.be.ok;
       expect(textures.environmentMap.isTexture).to.be.ok;
 
@@ -120,7 +120,7 @@ suite('TextureUtils', () => {
         'returns an environmentMap and skybox texture from an HDR url',
         async () => {
           textures =
-              await textureUtils.generateEnvironmentTextures(HDR_EQUI_URL);
+              await textureUtils.generateEnvironmentMapAndSkybox(HDR_EQUI_URL);
           expect(textures.skybox.texture.isTexture).to.be.ok;
           expect(textures.environmentMap.isTexture).to.be.ok;
 
@@ -138,9 +138,11 @@ suite('TextureUtils', () => {
     test(
         'returns an environmentMap and skybox texture from url with PMREM',
         async () => {
-          textures = await textureUtils.generateEnvironmentTextures(EQUI_URL, {
-            pmrem: true,
-          });
+          textures = await textureUtils.generateEnvironmentMapAndSkybox(
+              EQUI_URL, null, {
+                pmrem: true,
+              });
+
           expect(textures.skybox.texture.isTexture).to.be.ok;
           expect(textures.environmentMap.isTexture).to.be.ok;
 
@@ -157,8 +159,8 @@ suite('TextureUtils', () => {
     test(
         'returns an environmentMap and skybox texture from an HDR url',
         async () => {
-          textures =
-              await textureUtils.generateEnvironmentTextures(HDR_EQUI_URL, {
+          textures = await textureUtils.generateEnvironmentMapAndSkybox(
+              HDR_EQUI_URL, null, {
                 pmrem: true,
               });
           expect(textures.skybox.texture.isTexture).to.be.ok;
@@ -177,7 +179,7 @@ suite('TextureUtils', () => {
 
     test('throws if given an invalid url', async () => {
       try {
-        await textureUtils.generateEnvironmentTextures({});
+        await textureUtils.generateEnvironmentMapAndSkybox({});
         expect(false).to.be.ok;
       } catch (e) {
         expect(true).to.be.ok;
@@ -185,17 +187,21 @@ suite('TextureUtils', () => {
     });
   });
 
-  suite('generateDefaultEnvironmentMap', () => {
+  suite('dynamically generating environment maps', () => {
     test('creates a cubemap render target', async () => {
-      const texture = await textureUtils.generateDefaultEnvironmentMap();
+      const {environmentMap: texture} =
+          await textureUtils.generateEnvironmentMapAndSkybox();
+
       expect(textureMatchesMeta(texture, {mapping: 'Cube', url: null}))
           .to.be.ok;
     });
 
     test('creates a cubemap render target with PMREM', async () => {
-      const texture = await textureUtils.generateDefaultEnvironmentMap({
-        pmrem: true,
-      });
+      const {environmentMap: texture} =
+          await textureUtils.generateEnvironmentMapAndSkybox(null, null, {
+            pmrem: true,
+          });
+
       expect(textureMatchesMeta(texture, {mapping: 'PMREM', url: null}))
           .to.be.ok;
     });

--- a/src/three-components/Model.js
+++ b/src/three-components/Model.js
@@ -52,11 +52,31 @@ export default class Model extends Object3D {
     this.modelContainer.traverse(obj => {
       if (obj && obj.isMesh && obj.material) {
         obj.material.envMap = map;
-        obj.material.envMapIntensity = 0.85;
         obj.material.needsUpdate = true;
       }
     });
     this.dispatchEvent({type: 'envmap-change', value: map});
+  }
+
+  setEnvironmentMapIntensity(intensity) {
+    const intensityIsNumber =
+        typeof intensity === 'number' && !self.isNaN(intensity);
+
+    if (!intensityIsNumber) {
+      intensity = 1.0;
+    }
+
+    this.modelContainer.traverse(object => {
+      if (object && object.isMesh && object.material) {
+        const {material} = object;
+        if (Array.isArray(object.material)) {
+          object.material.forEach(
+              material => material.envMapIntensity = intensity);
+        } else {
+          object.material.envMapIntensity = intensity;
+        }
+      }
+    });
   }
 
   /**


### PR DESCRIPTION
This change proposes the introduction of two new user-configurable attribute/properties: `environment-image` and `environment-intensity`. Highlights of the change include:

 - Upgrades `@polymer/lit-element@0.6.x` to `lit-element@2.0.x`
    - Various fixes were necessary to make tests pass after breaking changes from upgrade
 - Adds `environment-image` attribute to control the environment map without affecting the background image or color
 - Adds `environment-intensity` attribute to control the intensity of whatever environment map happens to be used

### Examples

`environment-intensity` oscillating `0.0` - `6.0` | Cycle `environment-image` only | Cycle `background-image` only |
| -------------------------------------------- | ------------------------------- | ----------------------------------- |
![reflectionintensityosc](https://user-images.githubusercontent.com/240083/53581732-fcf79b80-3b32-11e9-9de5-959d2242247f.gif)|![reflectionimageosc](https://user-images.githubusercontent.com/240083/53581738-0254e600-3b33-11e9-9cdb-c055aa67460c.gif)|![reflectionimagebgosc](https://user-images.githubusercontent.com/240083/53581750-05e86d00-3b33-11e9-841c-0f5224fac7df.gif)

### Name rationale

~Terms like environment map and IBL are commonly used to refer to the color information used to approximate the light emitted from physical surfaces in 3D scenes. However, these terms are not as meaningful to folks who do not have a graphics background. In the case of a mirror, puddle or other highly reflective surface, a word that very quickly comes to mind to describe the color information is "reflection." As skybox is the "background", so IBL is the "reflection."~

After a lot of good internal team discussion and [some questionable science](https://twitter.com/0xcda7a/status/1101193335190970369), the attribute names have been changed to `environment-image` and `environment-intensity` respectively. One colleague, when faced with the choice between "reflection" and "environment," responded:

> ok so this is what happened
> i said "obviously reflection"
> and then "oh but if the reflection is changing that means the environment around it is changing!"
> 🤯

Fundamentally speaking, reflectivity is a property of individual materials, and environment is a more technically accurate term.

### Additional comments

This change is larger than I initially anticipated. I began to refactor environment map generation, and then quickly ran up against failing tests because I was not accommodating for #76 properly in some cases. So, rather than further spread the #76 disease, I decided to upgrade us to the latest `lit-element` so that we could benefit from the fix introduced a while back. This prompted additional changes that were difficult to tweeze apart from the original proposal due to the need to make tests pass.

Fixes #122 
Fixes #76 