### PR TITLE
Make IntersectionObserver optional

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,6 +13,8 @@ export const HAS_FULLSCREEN_API = document.documentElement != null &&
 
 export const HAS_RESIZE_OBSERVER = self.ResizeObserver != null;
 
+export const HAS_INTERSECTION_OBSERVER = self.IntersectionObserver != null;
+
 export const IS_AR_CANDIDATE = HAS_WEBXR_HIT_TEST_API && HAS_FULLSCREEN_API;
 
 export const IS_MOBILE = (() => {

--- a/src/test/model-viewer-base-spec.js
+++ b/src/test/model-viewer-base-spec.js
@@ -133,9 +133,9 @@ suite('ModelViewerElementBase', () => {
         const loaded = elements.map(e => waitForEvent(e, 'load'));
 
         for (let element of elements) {
-          element.style.height = '200vh';
-          element.style.width = '100vw';
           element.autoRotate = true;
+          element.style.position = 'relative';
+          element.style.marginBottom = '100vh';
           element.src = assetPath('cube.gltf');
           document.body.appendChild(element);
         }
@@ -145,7 +145,16 @@ suite('ModelViewerElementBase', () => {
 
       teardown(() => {
         elements.forEach(
-            e => e.parentNode != null && e.parentNode.removeChild(element));
+            element => element.parentNode != null &&
+                element.parentNode.removeChild(element));
+      });
+
+      test('sets a model within viewport to be visible', async () => {
+        await until(() => {
+          return elements[0][$scene].isVisible;
+        });
+
+        expect(elements[0][$scene].isVisible).to.be.true;
       });
 
       test.skip('only models visible in the viewport', async () => {

--- a/src/types/intersectionobserver.d.ts
+++ b/src/types/intersectionobserver.d.ts
@@ -1,0 +1,9 @@
+interface IntersectionObserver {
+  observe(element: Element): void;
+  unobserve(element: Element): void;
+  disconnect(): void;
+}
+
+interface Window {
+  IntersectionObserver?: Constructor<IntersectionObserver>
+}

--- a/test/legacy.html
+++ b/test/legacy.html
@@ -30,19 +30,6 @@
   <!-- Web Components polyfill is required to support Edge and Firefox < 63: -->
   <script src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 
-  <!-- Intersection Observer polyfill is required for Safari and IE11 -->
-  <script src="../node_modules/intersection-observer/intersection-observer.js"></script>
-
-  <script>
-    // NOTE: This is needed in tests so that we don't have to manually trigger
-    // the IntersectionObserver polyfill in Safari. Ordinarily, it would be
-    // triggered by a resize or scroll event.
-    // @see https://github.com/w3c/IntersectionObserver/tree/master/polyfill#configuring-the-polyfill
-    if ('POLL_INTERVAL' in IntersectionObserver.prototype) {
-      IntersectionObserver.prototype.POLL_INTERVAL = 100;
-    }
-  </script>
-
   <!-- EventTarget polyfill is *only* needed for running the tests -->
   <script src="../node_modules/@jsantell/event-target/dist/event-target.js"></script>
 


### PR DESCRIPTION
This change proposes that `IntersectionObserver` should be an optional, performance-enhancing feature rather than a required feature to make `<model-viewer>` work (as it is now). Documentation updates related to this change are in progress, and will be included in a forthcoming PR.

Fixes #386 