### PR TITLE
Hotfix for PMREM environment map regression

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@google/model-viewer",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/three-components/TextureUtils.js
+++ b/src/three-components/TextureUtils.js
@@ -199,10 +199,14 @@ export default class TextureUtils extends EventDispatcher {
         // Apply the PMREM pass to the environment, which produces a distinct
         // texture from the source:
         const nonPmremEnvironmentMap = environmentMap;
-        environmentMap = this.pmremPass(
-            nonPmremEnvironmentMap,
-            this.config.defaultEnvironmentPmremSamples,
-            this.config.defaultEnvironmentPmremSize)
+        const samples = environmentMapWasGenerated ?
+            this.config.defaultEnvironmentPmremSamples :
+            this.config.pmremSamples;
+        const size = environmentMapWasGenerated ?
+            this.config.defaultEnvironmentPmremSize :
+            this.config.pmremSize;
+
+        environmentMap = this.pmremPass(nonPmremEnvironmentMap, samples, size);
 
         // If the source was generated, then we should dispose of it right away
         if (environmentMapWasGenerated) {


### PR DESCRIPTION
We experienced an untracked regression after the environment map refactor in #392 . The regression manifested as artifacts shown when using an environment map that we are currently excluding from our fidelity tests while we investigate PMREM generation quirks. Here is the rendering before and after this hotfix:

Without hotfix | With hotfix
---------------|-----------
![image](https://user-images.githubusercontent.com/240083/53850967-e194f200-3f71-11e9-9391-bc21249da122.png)|![image](https://user-images.githubusercontent.com/240083/53850977-ea85c380-3f71-11e9-85f5-90bd540055dc.png)

