### PR TITLE
Fix overhanging focus ring in Chrome

### DIFF
--- a/src/features/loading/status-announcer.ts
+++ b/src/features/loading/status-announcer.ts
@@ -74,10 +74,15 @@ export class LoadingStatusAnnouncer extends EventDispatcher {
 
   constructor() {
     super();
-    this.statusElement.setAttribute('role', 'status');
-    this.statusElement.style.position = 'absolute';
-    this.statusElement.style.color = 'transparent';
-    this.statusElement.style.pointerEvents = 'none';
+    const {statusElement} = this;
+    const {style} = statusElement;
+
+    statusElement.setAttribute('role', 'status');
+
+    style.position = 'absolute';
+    style.color = 'transparent';
+    style.top = style.left = style.margin = '0';
+    style.pointerEvents = 'none';
   }
 
   /**


### PR DESCRIPTION
When we added the status element in #345 , its styles left it hanging outside the box boundary of its `<model-viewer>` host element. The unfortunate side-effect of this is that the status element receives a focus ring in Chrome.

This change tweaks the styles of the status element so that it no longer receives a separate focus ring from its host element.

Before style change | After style change
-------------------- | ------------------
![image](https://user-images.githubusercontent.com/240083/53856810-85899800-3f88-11e9-9a33-974ec40ba60a.png) | ![image](https://user-images.githubusercontent.com/240083/53856858-ca153380-3f88-11e9-854b-258c001d0362.png)

