### PR TITLE
Renderer: Disable alpha by default.

### DIFF
--- a/src/three-components/Renderer.js
+++ b/src/three-components/Renderer.js
@@ -46,7 +46,7 @@ export default class Renderer extends EventDispatcher {
   constructor() {
     super();
 
-    const webGlOptions = {antialias: true};
+    const webGlOptions = {alpha: false, antialias: true};
 
     // Only enable certain options when Web XR capabilities are detected:
     if (IS_AR_CANDIDATE) {


### PR DESCRIPTION
We were creating transparent webgl context and forcing the browser do extra compositing work.
