### PR TITLE
StaticShadow: Avoid rendering shadow mesh when opacity is 0.

### DIFF
--- a/src/three-components/StaticShadow.js
+++ b/src/three-components/StaticShadow.js
@@ -76,6 +76,8 @@ export default class StaticShadow extends Mesh {
 
     this.material.opacity =
         BASE_SHADOW_OPACITY * (intensityIsNumber ? intensity : 0.0);
+    
+    this.visible = this.material.opacity > 0;
   }
 
   /**


### PR DESCRIPTION
We're sending unneeded commands to the GPU and making it rasterise two invisible triangles.