### PR TITLE
Cull test suite memory bloat

### DIFF
--- a/src/model-viewer-base.js
+++ b/src/model-viewer-base.js
@@ -21,7 +21,7 @@ import ModelScene from './three-components/ModelScene.js';
 import Renderer from './three-components/Renderer.js';
 import {debounce, deserializeUrl} from './utils.js';
 
-const renderer = new Renderer();
+let renderer = new Renderer();
 
 const FALLBACK_SIZE_UPDATE_THRESHOLD_MS = 50;
 
@@ -42,6 +42,7 @@ export const $tick = Symbol('tick');
 export const $onModelLoad = Symbol('onModelLoad');
 export const $onResize = Symbol('onResize');
 export const $renderer = Symbol('renderer');
+export const $resetRenderer = Symbol('resetRenderer');
 
 /**
  * Definition for a basic <model-viewer> element.
@@ -64,6 +65,11 @@ export default class ModelViewerElementBase extends UpdatingElement {
     }
 
     return this[$template];
+  }
+
+  static[$resetRenderer]() {
+    renderer.dispose();
+    renderer = new Renderer();
   }
 
   get loaded() {

--- a/src/test/templates.ts
+++ b/src/test/templates.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import ModelViewerElementBase from '../model-viewer-base.js';
+import ModelViewerElementBase, {$resetRenderer} from '../model-viewer-base.js';
 import {timePasses} from './helpers.js';
 
 export type Constructor<T = object> = {
@@ -25,6 +25,11 @@ const expect = chai.expect;
 export const BasicSpecTemplate =
     (ModelViewerElementAccessor: () => Constructor<ModelViewerElementBase>,
      tagNameAccessor: () => string) => {
+      teardown(() => {
+        // Ensure that the renderer is disposed across every test run:
+        ModelViewerElementBase[$resetRenderer]();
+      });
+
       test('can be directly instantiated', () => {
         const ModelViewerElement = ModelViewerElementAccessor();
         const element = new ModelViewerElement();

--- a/src/three-components/Renderer.js
+++ b/src/three-components/Renderer.js
@@ -219,12 +219,15 @@ export default class Renderer extends EventDispatcher {
   }
 
   dispose() {
-    super.dispose();
-
     if (this.textureUtils != null) {
       this.textureUtils.dispose();
     }
 
+    if (this.renderer != null) {
+      this.renderer.dispose();
+    }
+
     this.textureUtils = null;
+    this.renderer = null;
   }
 }


### PR DESCRIPTION
We have been experiencing intermittent timeouts in our iOS test target, as well as "GPU out of memory" errors in IE11 on every test run.

This change ensures that renderer-related memory allocations are properly cleaned up across every test run. There may be additional memory leaks, but I have not performed a deeper trace to uncover any at this time.

Fixes #433