### PR TITLE
Disable Auto Rotate On Interaction

### DIFF
--- a/src/features/animation.ts
+++ b/src/features/animation.ts
@@ -16,7 +16,7 @@
 import {property} from 'lit-element';
 
 import ModelViewerElementBase, {$needsRender, $onModelLoad, $scene, $tick, $updateSource} from '../model-viewer-base.js';
-import {Constructor} from '../utils.js';
+import {Constructor} from '../utilities.js';
 
 const MILLISECONDS_PER_SECOND = 1000.0
 

--- a/src/features/ar.ts
+++ b/src/features/ar.ts
@@ -17,7 +17,7 @@ import {property} from 'lit-element';
 
 import {IS_ANDROID, IS_AR_QUICKLOOK_CANDIDATE, IS_IOS, IS_WEBXR_AR_CANDIDATE} from '../constants.js';
 import ModelViewerElementBase, {$container, $renderer, $scene} from '../model-viewer-base.js';
-import {Constructor, deserializeUrl} from '../utils.js';
+import {Constructor, deserializeUrl} from '../utilities.js';
 
 /**
  * Takes a URL to a USDZ file and sets the appropriate fields so that Safari

--- a/src/features/controls.ts
+++ b/src/features/controls.ts
@@ -14,13 +14,13 @@
  */
 
 import {property} from 'lit-element';
-import {PerspectiveCamera, Spherical} from 'three';
+import {PerspectiveCamera, Spherical, Event} from 'three';
 
 import {deserializeSpherical} from '../conversions.js';
-import ModelViewerElementBase, {$ariaLabel, $needsRender, $onModelLoad, $onResize, $scene, $tick} from '../model-viewer-base.js';
+import ModelViewerElementBase, {$ariaLabel, $needsRender, $onModelLoad, $onResize, $scene, $tick, $onUserModelOrbit} from '../model-viewer-base.js';
 import {FRAMED_HEIGHT} from '../three-components/ModelScene.js';
-import {SmoothControls} from '../three-components/SmoothControls.js';
-import {Constructor} from '../utils.js';
+import {SmoothControls, ChangeEvent} from '../three-components/SmoothControls.js';
+import {Constructor} from '../utilities.js';
 
 export interface SphericalPosition {
   theta: number;
@@ -101,7 +101,8 @@ export const ControlsMixin = (ModelViewerElement:
 
         protected[$lastSpherical]: Spherical = new Spherical();
 
-        protected[$changeHandler]: () => void = () => this[$onChange]();
+        protected[$changeHandler]: (event: Event) => void = (event: Event) => this[$onChange](event as ChangeEvent);
+
         protected[$focusHandler]: () => void = () => this[$onFocus]();
         protected[$blurHandler]: () => void = () => this[$onBlur]();
 
@@ -140,6 +141,7 @@ export const ControlsMixin = (ModelViewerElement:
           this[$promptTransitionendHandler]();
           this[$promptElement].addEventListener(
               'transitionend', this[$promptTransitionendHandler]);
+              
           this[$controls].addEventListener('change', this[$changeHandler]);
         }
 
@@ -361,10 +363,14 @@ export const ControlsMixin = (ModelViewerElement:
           this[$promptElement].classList.remove('visible');
         }
 
-        [$onChange]() {
+        [$onChange]({source}: ChangeEvent) {
           this[$deferInteractionPrompt]();
           this[$updateAria]();
           this[$needsRender]();
+
+          if (source === 'user-interaction') {
+            this[$onUserModelOrbit]();
+          }
         }
       }
 

--- a/src/features/loading.ts
+++ b/src/features/loading.ts
@@ -17,7 +17,7 @@ import {property} from 'lit-element';
 
 import ModelViewerElementBase, {$ariaLabel, $canvas, $progressTracker, $updateSource} from '../model-viewer-base.js';
 import {CachingGLTFLoader} from '../three-components/CachingGLTFLoader.js';
-import {Constructor, debounce, deserializeUrl, throttle} from '../utils.js';
+import {Constructor, debounce, deserializeUrl, throttle} from '../utilities.js';
 
 import {LoadingStatusAnnouncer} from './loading/status-announcer.js';
 

--- a/src/features/loading/status-announcer.ts
+++ b/src/features/loading/status-announcer.ts
@@ -15,7 +15,7 @@
 
 import {EventDispatcher} from 'three';
 import ModelViewerElementBase from '../../model-viewer-base.js';
-import {debounce, getFirstMapKey} from '../../utils.js';
+import {debounce, getFirstMapKey} from '../../utilities.js';
 
 export const INITIAL_STATUS_ANNOUNCEMENT =
     'This page includes one or more 3D models that are loading';

--- a/src/model-viewer-base.ts
+++ b/src/model-viewer-base.ts
@@ -21,7 +21,7 @@ import {makeTemplate} from './template.js';
 import ModelScene from './three-components/ModelScene.js';
 import Renderer from './three-components/Renderer.js';
 import {ProgressTracker} from './utilities/progress-tracker.js';
-import {debounce, deserializeUrl, resolveDpr} from './utils.js';
+import {debounce, deserializeUrl, resolveDpr} from './utilities.js';
 
 let renderer = new Renderer();
 
@@ -46,6 +46,7 @@ export const $needsRender = Symbol('needsRender');
 export const $tick = Symbol('tick');
 export const $onModelLoad = Symbol('onModelLoad');
 export const $onResize = Symbol('onResize');
+export const $onUserModelOrbit = Symbol('onUserModelOrbit');
 export const $renderer = Symbol('renderer');
 export const $resetRenderer = Symbol('resetRenderer');
 export const $progressTracker = Symbol('progressTracker');
@@ -303,6 +304,8 @@ export default class ModelViewerElementBase extends UpdatingElement {
     this[$scene].setSize(e.width, e.height);
     this[$needsRender]();
   }
+
+  [$onUserModelOrbit]() {}
 
   /**
    * Parses the element for an appropriate source URL and

--- a/src/model-viewer.ts
+++ b/src/model-viewer.ts
@@ -21,7 +21,7 @@ import {LoadingMixin} from './features/loading.js';
 import {MagicLeapMixin} from './features/magic-leap.js';
 import {StagingMixin} from './features/staging.js';
 import ModelViewerElementBase from './model-viewer-base.js';
-import {Constructor} from './utils.js';
+import {Constructor} from './utilities.js';
 
 type ModelViewerMixin =
     (ModelViewerElement: Constructor<ModelViewerElementBase>) =>

--- a/src/test/features/controls-spec.js
+++ b/src/test/features/controls-spec.js
@@ -14,7 +14,7 @@
  */
 
 import {$controls, $promptElement, ControlsMixin, DEFAULT_INTERACTION_PROMPT_THRESHOLD, INTERACTION_PROMPT} from '../../features/controls.js';
-import ModelViewerElementBase, {$scene} from '../../model-viewer-base.js';
+import ModelViewerElementBase, {$scene, $onUserModelOrbit} from '../../model-viewer-base.js';
 import {FRAMED_HEIGHT} from '../../three-components/ModelScene.js';
 import {assetPath, dispatchSyntheticEvent, rafPasses, timePasses, until, waitForEvent} from '../helpers.js';
 import {BasicSpecTemplate} from '../templates.js';
@@ -360,6 +360,7 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
                   .to.be.equal('View from stage lower-front');
             });
       });
+
     });
   });
 });

--- a/src/test/features/staging-spec.ts
+++ b/src/test/features/staging-spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google Inc. All Rights Reserved.
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -15,8 +15,8 @@
 
 import {Vector3} from 'three';
 
-import {StagingMixin} from '../../features/staging.js';
-import ModelViewerElementBase, {$scene} from '../../model-viewer-base.js';
+import {StagingMixin, AUTO_ROTATE_DELAY_AFTER_USER_INTERACTION} from '../../features/staging.js';
+import ModelViewerElementBase, {$scene, $onUserModelOrbit} from '../../model-viewer-base.js';
 import {assetPath, timePasses, waitForEvent} from '../helpers.js';
 import {BasicSpecTemplate} from '../templates.js';
 
@@ -127,6 +127,20 @@ suite('ModelViewerElementBase with StagingMixin', () => {
                                  // rAF though
           expect(element.turntableRotation).to.be.equal(turntableRotation);
         });
+      });
+
+      test('pauses rotate after user interaction', async () => {
+        const {turntableRotation: initialTurntableRotation} = element;
+
+        element[$onUserModelOrbit]();
+
+        await timePasses(50);  // An arbitrary amount of time, greater than one
+                               // rAF though
+        expect(element.turntableRotation).to.be.equal(initialTurntableRotation);
+
+        await timePasses(AUTO_ROTATE_DELAY_AFTER_USER_INTERACTION);
+
+        expect(element.turntableRotation).to.be.greaterThan(initialTurntableRotation);
       });
     });
   });

--- a/src/test/utilities/timer-spec.ts
+++ b/src/test/utilities/timer-spec.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Timer from '../../utilities/timer';
+
+const expect = chai.expect;
+
+export default () => {
+  suite('Timer', () => {
+    test('has not ended by default', () => {
+      const timer = new Timer(20);
+
+      expect(timer.hasStopped).to.be.false;
+    });
+
+    test('can tick', () => {
+      const timer = new Timer(20);
+
+      expect(timer.hasStopped).to.be.false;
+
+      timer.tick(30);
+  
+      expect(timer.hasStopped).to.be.true;
+    });
+  
+    test('can reset', () => {
+      const timer = new Timer(20);
+
+      expect(timer.hasStopped).to.be.false;
+
+      timer.tick(30);
+  
+      expect(timer.hasStopped).to.be.true;
+  
+      timer.reset();
+  
+      expect(timer.hasStopped).to.be.false;
+    });
+
+    test('can stop', () => {
+      const timer = new Timer(20);
+
+      expect(timer.hasStopped).to.be.false;
+
+      timer.stop();
+
+      expect(timer.hasStopped).to.be.true;
+      expect(timer.time).to.equal(20);
+      expect(timer.timeScale).to.equal(1);
+
+      timer.reset();
+
+      expect(timer.hasStopped).to.be.false;
+    });
+
+    test('can get time', () => {
+      const timer = new Timer(20);
+
+      expect(timer.time).to.equal(0);
+      expect(timer.timeScale).to.equal(0);
+
+      timer.tick(10);
+
+      expect(timer.time).to.equal(10);
+      expect(timer.timeScale).to.equal(0.5);
+
+      timer.tick(10);
+
+      expect(timer.time).to.equal(20);
+      expect(timer.timeScale).to.equal(1);
+
+      timer.tick(10);
+
+      expect(timer.time).to.equal(20);
+      expect(timer.timeScale).to.equal(1);
+    });
+  });
+};

--- a/src/test/utils-spec.js
+++ b/src/test/utils-spec.js
@@ -15,9 +15,10 @@
 
 import {Box3, BoxBufferGeometry, Mesh, Vector3} from 'three';
 
-import {CAPPED_DEVICE_PIXEL_RATIO, clamp, deserializeUrl, resolveDpr, step} from '../utils.js';
+import {CAPPED_DEVICE_PIXEL_RATIO, clamp, deserializeUrl, resolveDpr, step} from '../utilities.js';
 
 import {timePasses} from './helpers.js';
+import timerSpec from './utilities/timer-spec';
 
 const expect = chai.expect;
 
@@ -86,4 +87,6 @@ suite('utils', () => {
       expect(clamp(2.5, 2.0, 3.0)).to.be.equal(2.5);
     });
   });
+
+  timerSpec();
 });

--- a/src/three-components/ARRenderer.js
+++ b/src/three-components/ARRenderer.js
@@ -1,6 +1,6 @@
 import {EventDispatcher, Matrix4, Object3D, PerspectiveCamera, Raycaster, Scene, Vector3, WebGLRenderer} from 'three';
 
-import {assertIsArCandidate} from '../utils.js';
+import {assertIsArCandidate} from '../utilities.js';
 
 import Reticle from './Reticle.js';
 import Shadow from './Shadow.js';

--- a/src/three-components/ModelScene.js
+++ b/src/three-components/ModelScene.js
@@ -15,7 +15,7 @@
 
 import {Box3, Color, DirectionalLight, HemisphereLight, Mesh, MeshBasicMaterial, Object3D, PerspectiveCamera, Scene, SphereBufferGeometry, Vector3} from 'three';
 
-import {resolveDpr} from '../utils.js';
+import {resolveDpr} from '../utilities.js';
 
 import Model from './Model.js';
 import StaticShadow from './StaticShadow.js';

--- a/src/three-components/Renderer.js
+++ b/src/three-components/Renderer.js
@@ -17,7 +17,7 @@ import {ACESFilmicToneMapping, EventDispatcher, WebGLRenderer} from 'three';
 
 import {IS_WEBXR_AR_CANDIDATE} from '../constants.js';
 import {$tick} from '../model-viewer-base.js';
-import {resolveDpr} from '../utils.js';
+import {resolveDpr} from '../utilities.js';
 
 import {ARRenderer} from './ARRenderer.js';
 import TextureUtils from './TextureUtils.js';

--- a/src/three-components/SmoothControls.ts
+++ b/src/three-components/SmoothControls.ts
@@ -13,9 +13,9 @@
  * limitations under the License.
  */
 
-import {Camera, EventDispatcher, Quaternion, Spherical, Vector2, Vector3} from 'three';
+import {Camera, EventDispatcher, Quaternion, Spherical, Vector2, Vector3, Event} from 'three';
 
-import {clamp, step} from '../utils.js';
+import {clamp, step} from '../utilities.js';
 
 export type EventHandlingBehavior = 'prevent-all'|'prevent-handled';
 export type InteractionPolicy = 'always-allow'|'allow-when-focused';
@@ -90,6 +90,8 @@ const $touchMode = Symbol('touchMode');
 const $previousPosition = Symbol('previousPosition');
 const $canInteract = Symbol('canInteract');
 const $interactionEnabled = Symbol('interactionEnabled');
+const $userAdjustOrbit = Symbol('userAdjustOrbit');
+const $isUserChange = Symbol('isUserChange');
 
 // Pointer state
 const $pointerIsDown = Symbol('pointerIsDown');
@@ -118,6 +120,8 @@ const $handleWheel = Symbol('handleWheel');
 const $handleKey = Symbol('handleKey');
 
 // Constants
+const USER_INTERACTION_CHANGE_SOURCE = 'user-interaction';
+const DEFAULT_INTERACTION_CHANGE_SOURCE = 'none';
 const TOUCH_EVENT_RE = /^touch(start|end|move)$/;
 const KEYBOARD_ORBIT_INCREMENT = Math.PI / 8;
 const ORBIT_STEP_EDGE = 0.001;
@@ -136,6 +140,15 @@ export const KeyCode = {
   DOWN: 40
 };
 
+/**
+ * ChangEvents are dispatched whenever the camera position or orientation has changed
+ */
+export interface ChangeEvent extends Event {
+  /**
+   * determines what was the originating reason for the change event eg user or none 
+   */
+  source: string,
+}
 
 /**
  * SmoothControls is a Three.js helper for adding delightful pointer and
@@ -164,6 +177,7 @@ export class SmoothControls extends EventDispatcher {
   private[$spherical]: Spherical = new Spherical();
   private[$targetSpherical]: Spherical = new Spherical();
   private[$previousPosition]: Vector3 = new Vector3();
+  private[$isUserChange]: boolean = false;
 
   private[$pointerIsDown]: boolean = false;
   private[$lastPointerPosition]: Vector2 = new Vector2();
@@ -327,6 +341,8 @@ export class SmoothControls extends EventDispatcher {
     this[$targetSpherical].radius = nextRadius;
     this[$targetSpherical].makeSafe();
 
+    this[$isUserChange] = false;
+
     return true;
   }
 
@@ -341,7 +357,7 @@ export class SmoothControls extends EventDispatcher {
     const targetTheta = theta - deltaTheta;
     const targetPhi = phi - deltaPhi;
     const targetRadius = radius + deltaRadius;
-
+    
     return this.setOrbit(targetTheta, targetPhi, targetRadius);
   }
 
@@ -409,7 +425,10 @@ export class SmoothControls extends EventDispatcher {
     // the spherical->position derivation:
     if (!this[$previousPosition].equals(this.camera.position)) {
       this[$previousPosition].copy(this.camera.position);
-      this.dispatchEvent({type: 'change'});
+
+      const source = this[$isUserChange] ? USER_INTERACTION_CHANGE_SOURCE : DEFAULT_INTERACTION_CHANGE_SOURCE;
+
+      this.dispatchEvent({type: 'change', source});
     } else {
       this[$targetSpherical].copy(this[$spherical]);
     }
@@ -428,6 +447,14 @@ export class SmoothControls extends EventDispatcher {
     return MINIMUM_DAMPENING_FACTOR -
         this[$options].dampeningScale! *
         (MINIMUM_DAMPENING_FACTOR - MAXIMUM_DAMPENING_FACTOR)
+  }
+
+  private[$userAdjustOrbit](deltaTheta: number, deltaPhi: number, deltaRadius: number): boolean {
+    const handled = this.adjustOrbit(deltaTheta, deltaPhi, deltaRadius);
+
+    this[$isUserChange] = true;
+
+    return handled;
   }
 
   private[$pixelLengthToSphericalAngle](pixelLength: number): number {
@@ -478,7 +505,7 @@ export class SmoothControls extends EventDispatcher {
                 this[$twoTouchDistance](touches[0], touches[1]);
             const radiusDelta = -1 * (touchDistance - lastTouchDistance) / 10.0;
 
-            handled = this.adjustOrbit(0, 0, radiusDelta);
+            handled = this[$userAdjustOrbit](0, 0, radiusDelta);
           }
 
           break;
@@ -489,7 +516,7 @@ export class SmoothControls extends EventDispatcher {
           const deltaTheta = this[$pixelLengthToSphericalAngle](xTwo - xOne);
           const deltaPhi = this[$pixelLengthToSphericalAngle](yTwo - yOne);
 
-          handled = this.adjustOrbit(deltaTheta, deltaPhi, 0)
+          handled = this[$userAdjustOrbit](deltaTheta, deltaPhi, 0)
 
           break;
       }
@@ -503,7 +530,7 @@ export class SmoothControls extends EventDispatcher {
       const deltaPhi =
           this[$pixelLengthToSphericalAngle](y - this[$lastPointerPosition].y);
 
-      handled = this.adjustOrbit(deltaTheta, deltaPhi, 0.0);
+      handled = this[$userAdjustOrbit](deltaTheta, deltaPhi, 0.0);
 
       this[$lastPointerPosition].set(x, y);
     }
@@ -550,7 +577,7 @@ export class SmoothControls extends EventDispatcher {
 
     const deltaRadius = (event as WheelEvent).deltaY / 10.0;
 
-    if ((this.adjustOrbit(0, 0, deltaRadius) ||
+    if ((this[$userAdjustOrbit](0, 0, deltaRadius) ||
          this[$options].eventHandlingBehavior === 'prevent-all') &&
         event.cancelable) {
       event.preventDefault();
@@ -567,27 +594,27 @@ export class SmoothControls extends EventDispatcher {
     switch (event.keyCode) {
       case KeyCode.PAGE_UP:
         relevantKey = true;
-        handled = this.adjustOrbit(0, 0, 1);
+        handled = this[$userAdjustOrbit](0, 0, 1);
         break;
       case KeyCode.PAGE_DOWN:
         relevantKey = true;
-        handled = this.adjustOrbit(0, 0, -1);
+        handled = this[$userAdjustOrbit](0, 0, -1);
         break;
       case KeyCode.UP:
         relevantKey = true;
-        handled = this.adjustOrbit(0, -KEYBOARD_ORBIT_INCREMENT, 0);
+        handled = this[$userAdjustOrbit](0, -KEYBOARD_ORBIT_INCREMENT, 0);
         break;
       case KeyCode.DOWN:
         relevantKey = true;
-        handled = this.adjustOrbit(0, KEYBOARD_ORBIT_INCREMENT, 0);
+        handled = this[$userAdjustOrbit](0, KEYBOARD_ORBIT_INCREMENT, 0);
         break;
       case KeyCode.LEFT:
         relevantKey = true;
-        handled = this.adjustOrbit(-KEYBOARD_ORBIT_INCREMENT, 0, 0);
+        handled = this[$userAdjustOrbit](-KEYBOARD_ORBIT_INCREMENT, 0, 0);
         break;
       case KeyCode.RIGHT:
         relevantKey = true;
-        handled = this.adjustOrbit(KEYBOARD_ORBIT_INCREMENT, 0, 0);
+        handled = this[$userAdjustOrbit](KEYBOARD_ORBIT_INCREMENT, 0, 0);
         break;
     }
 

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -14,6 +14,11 @@
  */
 
 import {HAS_FULLSCREEN_API, HAS_WEBXR_DEVICE_API, HAS_WEBXR_HIT_TEST_API, IS_WEBXR_AR_CANDIDATE} from './constants.js';
+import Timer from './utilities/timer';
+
+export {
+  Timer,
+};
 
 export type Constructor<T = object> = {
   new (...args: any[]): T,

--- a/src/utilities/progress-tracker.ts
+++ b/src/utilities/progress-tracker.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import {clamp} from '../utils.js';
+import {clamp} from '../utilities.js';
 
 interface OngoingActivity {
   progress: number;

--- a/src/utilities/timer.ts
+++ b/src/utilities/timer.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const $time = Symbol('time');
+const $duration = Symbol('duration');
+
+/**
+ * The Timer class can be used power delays and animations
+ */
+class Timer {
+  /**
+   * total time incremented by the tick method. time is initialized to 0
+   */
+  get time(): number {
+    return this[$time];
+  }
+
+  /**
+   * a calculation of `time / duration` which can be used for animations
+   */
+  get timeScale(): number {
+    return this[$time] / this[$duration];
+  }
+
+  /**
+   * duration of the timer
+   */
+  get duration(): number {
+    return this[$duration];
+  }
+
+  /**
+   * whether the timer has run fully or stop has been called
+   */
+  get hasStopped(): boolean {
+    return this[$time] >= this[$duration];
+  }
+
+  private [$time]: number;
+  private [$duration]: number;
+
+  /**
+   * Creates a new timer
+   * 
+   * @param duration the total duration for the timer
+   */
+  constructor(duration: number) {
+    this[$duration] = duration;
+    this[$time] = 0;
+  }
+
+  /**
+   * reset the time back to 0
+   */
+  reset(): void {
+    this[$time] = 0;
+  }
+
+  /**
+   * sets time to duration meaning the timer has completed and hasStopped will return true
+   */
+  stop(): void {
+    this[$time] = this[$duration];
+  }
+
+  /**
+   * pass deltaTime to the tick method to tick/increment the timer forward
+   * 
+   * @param deltaTime delta time since last tick was called
+   */
+  tick(deltaTime: number) {
+    this[$time] += deltaTime;
+
+    if (this.time >= this[$duration]) {
+      this[$time] = this[$duration];
+    }
+  }
+}
+
+export default Timer;


### PR DESCRIPTION
<!-- Instructions: https://github.com/GoogleWebComponents/model-viewer/blob/master/CONTRIBUTING.md#code-reviews -->
### Reference Issue
<!-- Example: Fixes #1234 -->
#459 

While I was acquainting myself with the `<model-viewer>` codebase I realized there's very little shared state.

In order to implement this fix `StagingMixin` and `ControlsMixin` need to either:

1. Have some shared state on `ModelViewerBase`
2. Somehow via events or callbacks be notified that interaction has started/ended

Since this project seems to avoid global state I opted for Option 2.

I do think that if someone is building custom UI around `<model-viewer>` they do need to know of interaction start and end so this why dispatching these events from `<model-viewer>` might make sense.

On the downside. I HATE wiring application logic via internal events. It general is not good for the long term.

Anyway would love to hear some thoughts.

To make this PR not be *[WIP]*. I'll need to do the following:

- [x] Make interactions via Keyboard Events dispatch the same events
- [x] Write tests
- [x] Write tests around disabling `autoRotate` when the user is interacting with `ModelViewer`.

In a subsequent PR I can implement `auto-rotate-delay`. I think if I do `auto-rotate-delay` in this PR it'll balloon to be too large.

