### PR TITLE
Auto-rotate doesn't rotate the model pivot if no model is loaded

### DIFF
--- a/src/features/loading.js
+++ b/src/features/loading.js
@@ -61,6 +61,10 @@ export const LoadingMixin = (ModelViewerElement) => {
           (this.src && CachingGLTFLoader.hasFinishedLoading(this.src));
     }
 
+    get modelIsVisible() {
+      return super.modelIsVisible && this[$posterHidden];
+    }
+
     constructor() {
       super();
 

--- a/src/features/staging.ts
+++ b/src/features/staging.ts
@@ -84,7 +84,7 @@ export const StagingMixin = (ModelViewerElement:
         [$tick](time: number, delta: number) {
           super[$tick](time, delta);
 
-          if (this.autoRotate) {
+          if (this.autoRotate && (this as any)[$scene].model.hasModel()) {
             (this as any)[$scene].pivot.rotation.y +=
                 ROTATION_SPEED * delta * 0.001;
             this[$needsRender]();

--- a/src/features/staging.ts
+++ b/src/features/staging.ts
@@ -84,7 +84,7 @@ export const StagingMixin = (ModelViewerElement:
         [$tick](time: number, delta: number) {
           super[$tick](time, delta);
 
-          if (this.autoRotate && (this as any)[$scene].model.hasModel()) {
+          if (this.autoRotate && this.modelIsVisible) {
             (this as any)[$scene].pivot.rotation.y +=
                 ROTATION_SPEED * delta * 0.001;
             this[$needsRender]();

--- a/src/model-viewer-base.js
+++ b/src/model-viewer-base.js
@@ -80,6 +80,10 @@ export default class ModelViewerElementBase extends UpdatingElement {
     return renderer;
   }
 
+  get modelIsVisible() {
+      return true;
+  }
+
   /**
    * Creates a new ModelViewerElement.
    */

--- a/src/test/features/staging-spec.ts
+++ b/src/test/features/staging-spec.ts
@@ -116,4 +116,28 @@ suite('ModelViewerElementBase with StagingMixin', () => {
       });
     });
   });
+
+  suite('without a loaded model', () => {
+    setup(async () => {
+      element = new ModelViewerElement();
+      document.body.appendChild(element);
+    });
+
+    teardown(() => {
+      document.body.removeChild(element);
+    });
+
+    suite('auto-rotate', () => {
+      setup(() => {
+        element.autoRotate = true;
+      });
+
+      test('does not cause the model root to rotate over time', async () => {
+        const {turntableRotation} = element;
+        await timePasses(50);  // An arbitrary amount of time, greater than one
+                               // rAF though
+        expect(element.turntableRotation).to.be.equal(turntableRotation);
+      });
+    });
+  });
 });

--- a/src/test/features/staging-spec.ts
+++ b/src/test/features/staging-spec.ts
@@ -114,29 +114,19 @@ suite('ModelViewerElementBase with StagingMixin', () => {
                                // rAF though
         expect(element.turntableRotation).to.be.greaterThan(turntableRotation);
       });
-    });
-  });
 
-  suite('without a loaded model', () => {
-    setup(async () => {
-      element = new ModelViewerElement();
-      document.body.appendChild(element);
-    });
+      suite('when the model is not visible', () => {
+        setup(() => {
+          Object.defineProperty(
+            element, 'modelIsVisible', {value:false});
+        });
 
-    teardown(() => {
-      document.body.removeChild(element);
-    });
-
-    suite('auto-rotate', () => {
-      setup(() => {
-        element.autoRotate = true;
-      });
-
-      test('does not cause the model root to rotate over time', async () => {
-        const {turntableRotation} = element;
-        await timePasses(50);  // An arbitrary amount of time, greater than one
-                               // rAF though
-        expect(element.turntableRotation).to.be.equal(turntableRotation);
+        test('does not cause the model to rotate over time', async () => {
+          const {turntableRotation} = element;
+          await timePasses(50);  // An arbitrary amount of time, greater than one
+                                 // rAF though
+          expect(element.turntableRotation).to.be.equal(turntableRotation);
+        });
       });
     });
   });


### PR DESCRIPTION
### Fixes #467

This fix checks to make sure that auto-rotation only starts once the poster is no longer visible and the model is interactable.

One thing is that this will not prevent the small stutter that happens when the poster transitions into 3D. That's because the rotation will start when the poster is dismissed, but the poster has a 0.3 second opacity transition. So during the transition you'll see the model rotation while the poster which is an image of the first frame will be fading away. It's not super noticeable, but it's also not perfectly smooth. 

It may be more trouble than it's worth solving that case since we'd have to listen for when the opacity transition ends before triggering the rotation. And since the loading mixin and the staging mixin don't know about each other, that could be tricky.

