### PR TITLE
Progress bars

### DIFF
--- a/examples/lazy-loading.html
+++ b/examples/lazy-loading.html
@@ -16,13 +16,14 @@
 -->
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <title>&lt;model-viewer&gt; Lazy Loading</title>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, user-scalable=no,
     minimum-scale=1.0, maximum-scale=1.0">
   <link type="text/css" href="styles/examples.css" rel="stylesheet" />
-  <link rel="shortcut icon" type="image/png" href="assets/favicon.png"/>
+  <link rel="shortcut icon" type="image/png" href="assets/favicon.png" />
 
   <!-- The following libraries and polyfills are recommended to maximize browser support -->
 
@@ -36,12 +37,13 @@
   <script src="../node_modules/resize-observer-polyfill/dist/ResizeObserver.js"></script>
 
   <!-- 💁 OPTIONAL: Fullscreen polyfill is required for experimental AR features in Canary -->
-  <script src="../node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>
+  <!--<script src="../node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>-->
 
   <!-- 💁 OPTIONAL: Include prismatic.js for Magic Leap support -->
   <!--<script src="../node_modules/@magicleap/prismatic/prismatic.min.js"></script>-->
 
 </head>
+
 <body>
 
   <div class="sample">
@@ -50,28 +52,25 @@
 
       <div id="header">
         <a class="icon-button icon-modelviewer" href="../index.html"></a>
-        <a class="icon-github icon-button" href="https://github.com/GoogleWebComponents/model-viewer/blob/master/examples/lazy-loading.html"></a>
+        <a class="icon-github icon-button"
+          href="https://github.com/GoogleWebComponents/model-viewer/blob/master/examples/lazy-loading.html"></a>
       </div>
 
       <div class="wrapper">
 
         <div id="intro">
           <h3>Lazy Loading</h3>
-          <p>Improve UX with these cost-saving &lt;model-viewer&gt; configurations. This page tests usages of the <span class="attribute">&lt;model-viewer&gt;</span> element using the poster attribute.</p>
+          <p>Improve UX with these cost-saving &lt;model-viewer&gt; configurations. This page tests usages of the <span
+              class="attribute">&lt;model-viewer&gt;</span> element using the poster attribute.</p>
         </div>
 
-        <h2 class="demo-title">Display poster until loaded</h2>
+        <h2 class="demo-title">Display a poster until loaded</h2>
         <example-snippet stamp-to="demo-container-1" highlight-as="html">
           <template>
-<model-viewer id="reveal" reveal-when-loaded preload poster="assets/poster.png" src="assets/shishkebab.glb" alt="A 3D model of a shishkebab"></model-viewer>
-<script>
-  $('#reveal').addEventListener('load', e => {
-    // Display a red border to illustrate load timing
-    e.target.style.border = '2px solid #ccc';
-  }, { once: true });
-</script>
-              </template>
-          </example-snippet>
+            <model-viewer id="reveal" preload poster="assets/poster.png" src="assets/shishkebab.glb"
+              alt="A 3D model of a shishkebab"></model-viewer>
+          </template>
+        </example-snippet>
       </div>
     </div>
   </div>
@@ -84,14 +83,9 @@
         <h2 class="demo-title">Preload with poster and show model on interaction</h2>
         <example-snippet stamp-to="demo-container-2" highlight-as="html">
           <template>
-<!-- use unique asset to ensure preloading -->
-<model-viewer id="interaction" preload poster="assets/poster.png" src="assets/reflective-sphere.gltf" alt="A 3D model of a reflective sphere"></model-viewer>
-<script>
-  $('#interaction').addEventListener('load', e => {
-    // Display a red border to illustrate load timing
-    e.target.style.border = '2px solid #ccc';
-  }, { once: true });
-</script>
+            <!-- use unique asset to ensure preloading -->
+            <model-viewer id="interaction" preload reveal="interaction" poster="assets/poster.png"
+              src="assets/reflective-sphere.gltf" alt="A 3D model of a reflective sphere"></model-viewer>
           </template>
         </example-snippet>
       </div>
@@ -106,14 +100,9 @@
         <h2 class="demo-title">Lazy load with poster until interaction</h2>
         <example-snippet stamp-to="demo-container-3" highlight-as="html">
           <template>
-<!-- use unique asset to ensure lazy loading -->
-<model-viewer id="lazy-load" poster="assets/poster.png" src="assets/DamagedHelmet/DamagedHelmet.gltf" alt="A 3D model of a damaged helmet"></model-viewer>
-<script>
-$('#lazy-load').addEventListener('load', e => {
-  // Display a red border to illustrate load timing
-  e.target.style.border = '2px solid #ccc';
-}, { once: true });
-</script>
+            <!-- use unique asset to ensure lazy loading -->
+            <model-viewer id="lazy-load" poster="assets/poster.png" reveal="interaction"
+              src="assets/DamagedHelmet/DamagedHelmet.gltf" alt="A 3D model of a damaged helmet"></model-viewer>
           </template>
         </example-snippet>
       </div>
@@ -125,10 +114,10 @@ $('#lazy-load').addEventListener('load', e => {
     <div class="content">
       <div class="wrapper">
 
-        <h2 class="demo-title">Model with poster and preload</h2>
+        <h2 class="demo-title">Poster with invalid model</h2>
         <example-snippet stamp-to="demo-container-4" highlight-as="html">
           <template>
-            <model-viewer poster="assets/poster.png" src="assets/Astronaut.glb" alt="A 3D model of an astronaut"></model-viewer>
+            <model-viewer poster="assets/poster.png" src="i-do-not-exist.glb" alt="An invalid model"></model-viewer>
           </template>
         </example-snippet>
       </div>
@@ -140,31 +129,17 @@ $('#lazy-load').addEventListener('load', e => {
     <div class="content">
       <div class="wrapper">
 
-        <h2 class="demo-title">Poster with invalid model</h2>
+        <h2 class="demo-title">Cycling between posters</h2>
         <example-snippet stamp-to="demo-container-5" highlight-as="html">
           <template>
-              <model-viewer poster="assets/poster.png" src="i-do-not-exist.glb" alt="An invalid model"></model-viewer>
-          </template>
-        </example-snippet>
-      </div>
-    </div>
-  </div>
-
-  <div class="sample">
-    <div class="demo" id="demo-container-6"></div>
-    <div class="content">
-      <div class="wrapper">
-
-        <h2 class="demo-title">Cycling between posters</h2>
-        <example-snippet stamp-to="demo-container-6" highlight-as="html">
-          <template>
-<model-viewer id="toggle-poster" poster="assets/poster2.png" src="assets/Astronaut.glb" alt="A 3D model of an astronaut"></model-viewer>
-<script>
-  const posters = ['poster.png', 'poster2.png'];
-  let i = 0;
-  setInterval(() =>
-    $('#toggle-poster').setAttribute('poster', `assets/${posters[i++ % 2]}`), 2000);
-</script>
+            <model-viewer id="toggle-poster" reveal="interaction" poster="assets/poster2.png" src="assets/Astronaut.glb"
+              alt="A 3D model of an astronaut"></model-viewer>
+            <script>
+              const posters = ['poster.png', 'poster2.png'];
+              let i = 0;
+              setInterval(() =>
+                $('#toggle-poster').setAttribute('poster', `assets/${posters[i++ % 2]}`), 2000);
+            </script>
           </template>
         </example-snippet>
       </div>
@@ -174,12 +149,14 @@ $('#lazy-load').addEventListener('load', e => {
   <div class="footer">
     <ul>
       <li class="attribution">
-        <a href="https://poly.google.com/view/dLHpzNdygsg">Astronaut</a> by <a href="https://poly.google.com/user/4aEd8rQgKu2">Poly</a>,
+        <a href="https://poly.google.com/view/dLHpzNdygsg">Astronaut</a> by <a
+          href="https://poly.google.com/user/4aEd8rQgKu2">Poly</a>,
         licensed under <a href="https://creativecommons.org/licenses/by/2.0/">CC-BY</a>
       </li>
 
       <li class="attribution">
-        <a href="https://poly.google.com/view/6uTsH2jqgVn">Shishkebab</a> by <a href="https://poly.google.com/user/4aEd8rQgKu2">Poly</a>,
+        <a href="https://poly.google.com/view/6uTsH2jqgVn">Shishkebab</a> by <a
+          href="https://poly.google.com/user/4aEd8rQgKu2">Poly</a>,
         licensed under <a href="https://creativecommons.org/licenses/by/2.0/">CC-BY</a>
       </li>
     </ul>
@@ -189,22 +166,19 @@ $('#lazy-load').addEventListener('load', e => {
   <script src="./scripts/helpers.js"></script>
 
   <!-- Documentation-specific dependencies: -->
-  <script type="module"
-      src="./built/dependencies.js">
+  <script type="module" src="./built/dependencies.js">
   </script>
-  <script nomodule
-      src="./built/dependencies-legacy.js">
+  <script nomodule src="./built/dependencies-legacy.js">
   </script>
 
   <!-- Loads <model-viewer> only on modern browsers: -->
-  <script type="module"
-      src="../dist/model-viewer.js">
+  <script type="module" src="../dist/model-viewer.js">
   </script>
 
   <!-- Loads <model-viewer> only on old browsers like IE11: -->
-  <script nomodule
-      src="../dist/model-viewer-legacy.js">
+  <script nomodule src="../dist/model-viewer-legacy.js">
   </script>
 
 </body>
+
 </html>

--- a/examples/styles/examples.css
+++ b/examples/styles/examples.css
@@ -31,6 +31,7 @@
   --button-size: 56px;
   --icon-size: 32px;
   --header-height: 72px;
+  --poster-color: #455A64;
 }
 
 body {

--- a/index.html
+++ b/index.html
@@ -187,15 +187,25 @@
           </li>
           <li>
             <div>poster</div>
-            <p>Displays an image instead of the model. See <a href="https://github.com/GoogleWebComponents/model-viewer#on-loading">On Loading</a> for more information.</p>
+            <p>Configure to display an image while the model is still loading.
+            This attribute will override the corresponding --poster-image CSS
+            property if both are set.
           </li>
           <li>
             <div>preload</div>
-            <p>When poster is also enabled, the model will be downloaded before user action. See <a href="https://github.com/GoogleWebComponents/model-viewer#on-loading">On Loading</a> for more information.</p>
+            <p>When set, &lt;model-viewer&gt; will attempt to preload a model
+            even if other attributes indicate that model does not need to be
+            loaded yet.</p>
           </li>
           <li>
-            <div>reveal-when-loaded</div>
-            <p>When poster and preload are specified, hide the poster and show the model once the model has been loaded. See <a href="https://github.com/GoogleWebComponents/model-viewer#on-loading">On Loading</a> for more information.</p>
+            <div>reveal</div>
+            <p>This attribute controls whether or not the model should be
+            automatically revealed when loaded. It currently supports two
+            values: "auto" and "interaction". If reveal is set to "interaction",
+            &lt;model-viewer&gt; will wait until the user interacts with the
+            poster before loading and revealing the model. Otherwise, the model
+            will be revealed as soon as it is done loading and rendering.
+            Defaults to "auto".</p>
           </li>
           <li>
             <div>shadow-intensity</div>
@@ -262,6 +272,11 @@
             current animation to the beginning, you should also set the
             currentTime property to 0.</p>
           </li>
+          <li>
+            <div>dismissPoster()</div>
+            <p>Causes the model to load (if it has not already preloaded) and
+            render, and then be immediately revealed.</p>
+          </li>
         </ul>
 
         <h3 class="grouping-title">Events</h3>
@@ -297,6 +312,17 @@
           <li>
             <div>preload</div>
             <p>When preload is enabled this event is fired when preloading is done.</p>
+          </li>
+          <li>
+            <div>progress</div>
+            <p>This event is dispatched whenever there is loading or rendering
+            work occurring in preparation to display a model. Progress events
+            can be dispatched for any number of reasons (loading the environment
+            map, changing the model, applying one-time rendering effects etc).
+            They indicate that the model is being prepared to be rendered.
+            The model will be obscured by the poster until the progress events
+            have indicated that the work is done. You can measure an estimation
+            of total progress by looking at event.detail.totalProgress.</p>
           </li>
         </ul>
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -57,106 +57,103 @@ const outputOptions = [{
   onwarn,
 }];
 
-if (NODE_ENV === 'production') {
-  plugins.unshift(
-    cleanup({
-      // Ideally we'd also clean third_party/three, which saves
-      // ~45kb in filesize alone... but takes 2 minutes to build
-      include: ['lib/**'],
-      comments: 'none',
-    }),
-  );
+if (NODE_ENV !== 'development') {
+  plugins.unshift(cleanup({
+    // Ideally we'd also clean third_party/three, which saves
+    // ~45kb in filesize alone... but takes 2 minutes to build
+    include: ['lib/**'],
+    comments: 'none',
+  }));
 
   outputOptions.push(
-    {
-      input: './lib/model-viewer.js',
-      output: {
-        file: './dist/model-viewer-umd.js',
-        sourcemap: true,
-        format: 'umd',
-        name: 'ModelViewerElement'
+      {
+        input: './lib/model-viewer.js',
+        output: {
+          file: './dist/model-viewer-umd.js',
+          sourcemap: true,
+          format: 'umd',
+          name: 'ModelViewerElement'
+        },
+        watch: {
+          include: 'lib/**',
+        },
+        plugins,
+        onwarn,
       },
-      watch: {
-        include: 'lib/**',
+      {
+        input: './lib/test/index.js',
+        output: {
+          file: './dist/unit-tests.js',
+          format: 'esm',
+          name: 'ModelViewerElementUnitTests'
+        },
+        watch: {
+          include: 'lib/**',
+        },
+        plugins,
+        onwarn,
       },
-      plugins,
-      onwarn,
-    },
-    {
-      input: './lib/test/index.js',
-      output: {
-        file: './dist/unit-tests.js',
-        format: 'esm',
-        name: 'ModelViewerElementUnitTests'
+      {
+        input: './lib/test/index.js',
+        output: {
+          file: './dist/unit-tests-umd.js',
+          format: 'umd',
+          name: 'ModelViewerElementUnitTests'
+        },
+        watch: {
+          include: 'lib/**',
+        },
+        plugins,
+        onwarn,
       },
-      watch: {
-        include: 'lib/**',
+      {
+        input: './lib/test/fidelity/components/image-comparison-app.js',
+        output: {
+          file: './dist/image-comparison-app.js',
+          sourcemap: true,
+          format: 'iife',
+          name: 'ImageComparisonApp'
+        },
+        watch: {
+          include: '{lib/test/fidelity/**,lib/third_party/**}',
+        },
+        plugins,
+        onwarn,
       },
-      plugins,
-      onwarn,
-    },
-    {
-      input: './lib/test/index.js',
-      output: {
-        file: './dist/unit-tests-umd.js',
-        format: 'umd',
-        name: 'ModelViewerElementUnitTests'
+      {
+        input: './lib/test/fidelity/image-comparison-worker.js',
+        output: {
+          file: './dist/image-comparison-worker.js',
+          sourcemap: true,
+          format: 'iife',
+          name: 'ImageComparisonWorker'
+        },
+        watch: {
+          include: '{lib/test/fidelity/**,lib/third_party/**}',
+        },
+        plugins,
+        onwarn,
       },
-      watch: {
-        include: 'lib/**',
+      {
+        input: './lib/documentation/components/example-snippet.js',
+        output: {
+          file: './examples/built/dependencies.js',
+          format: 'esm',
+          name: 'DocumentationDependencies'
+        },
+        plugins,
+        onwarn,
       },
-      plugins,
-      onwarn,
-    },
-    {
-      input: './lib/test/fidelity/components/image-comparison-app.js',
-      output: {
-        file: './dist/image-comparison-app.js',
-        sourcemap: true,
-        format: 'iife',
-        name: 'ImageComparisonApp'
-      },
-      watch: {
-        include: '{lib/test/fidelity/**,lib/third_party/**}',
-      },
-      plugins,
-      onwarn,
-    },
-    {
-      input: './lib/test/fidelity/image-comparison-worker.js',
-      output: {
-        file: './dist/image-comparison-worker.js',
-        sourcemap: true,
-        format: 'iife',
-        name: 'ImageComparisonWorker'
-      },
-      watch: {
-        include: '{lib/test/fidelity/**,lib/third_party/**}',
-      },
-      plugins,
-      onwarn,
-    },
-    {
-      input: './lib/documentation/components/example-snippet.js',
-      output: {
-        file: './examples/built/dependencies.js',
-        format: 'esm',
-        name: 'DocumentationDependencies'
-      },
-      plugins,
-      onwarn,
-    },
-    {
-      input: './lib/documentation/components/example-snippet.js',
-      output: {
-        file: './examples/built/dependencies-umd.js',
-        format: 'umd',
-        name: 'DocumentationDependencies'
-      },
-      plugins,
-      onwarn,
-    }
-  );
+      {
+        input: './lib/documentation/components/example-snippet.js',
+        output: {
+          file: './examples/built/dependencies-umd.js',
+          format: 'umd',
+          name: 'DocumentationDependencies'
+        },
+        plugins,
+        onwarn,
+      });
 }
 
 export default outputOptions;

--- a/src/features/animation.ts
+++ b/src/features/animation.ts
@@ -89,6 +89,8 @@ export const AnimationMixin =
             }
 
             [$tick](_time: number, delta: number) {
+              super[$tick](_time, delta);
+
               if (this[$paused]) {
                 return;
               }

--- a/src/features/controls.ts
+++ b/src/features/controls.ts
@@ -322,13 +322,13 @@ export const ControlsMixin = (ModelViewerElement:
           }
         }
 
-        [$onResize](e: Event) {
-          super[$onResize](e);
+        [$onResize](event: any) {
+          super[$onResize](event);
           this[$updateOrbitCamera]();
         }
 
-        [$onModelLoad](e: Event) {
-          super[$onModelLoad](e);
+        [$onModelLoad](event: any) {
+          super[$onModelLoad](event);
           this[$updateOrbitCamera]();
         }
 

--- a/src/features/environment.js
+++ b/src/features/environment.js
@@ -15,9 +15,9 @@
 
 import {BackSide, BoxBufferGeometry, Color, Mesh, ShaderLib, ShaderMaterial, UniformsUtils} from 'three';
 
-import {$needsRender, $onModelLoad, $renderer, $scene, $tick} from '../model-viewer-base.js';
-
+import {$container, $needsRender, $onModelLoad, $progressTracker, $renderer, $scene, $tick} from '../model-viewer-base.js';
 import {IlluminationRole} from '../three-components/ModelScene.js';
+
 const DEFAULT_BACKGROUND_COLOR = '#ffffff';
 const DEFAULT_SHADOW_STRENGTH = 0.0;
 const DEFAULT_EXPOSURE = 1.0;
@@ -122,7 +122,9 @@ export const EnvironmentMixin = (ModelViewerElement) => {
         const {environmentMap, skybox} =
             await new Promise(async (resolve, reject) => {
               const texturesLoad = textureUtils.generateEnvironmentMapAndSkybox(
-                  backgroundImage, environmentImage, {pmrem});
+                  backgroundImage,
+                  environmentImage,
+                  {pmrem, progressTracker: this[$progressTracker]});
               this[$cancelEnvironmentUpdate] = () => reject(texturesLoad);
               resolve(await texturesLoad);
             });
@@ -139,6 +141,12 @@ export const EnvironmentMixin = (ModelViewerElement) => {
 
           const parsedColor = new Color(backgroundColor);
           this[$scene].background = parsedColor;
+          // Set the container node's background color so that it matches the
+          // background color configured for the scene. It's important to do
+          // this because we round the size of the canvas off to the nearest
+          // pixel, so it is possible (indeed likely) that there is a marginal
+          // gap around one or two edges of the canvas.
+          this[$container].style.backgroundColor = backgroundColor;
           this[$setShadowLightColor](parsedColor);
         }
 

--- a/src/features/loading.ts
+++ b/src/features/loading.ts
@@ -305,7 +305,7 @@ export const LoadingMixin = (ModelViewerElement:
 
     get[$shouldRevealModel](): boolean {
       return this.reveal === RevealStrategy.AUTO ||
-          this.reveal === this[$posterDismissalSource];
+          !!this[$posterDismissalSource];
     }
 
     get[$shouldAttemptPreload](): boolean {

--- a/src/features/loading.ts
+++ b/src/features/loading.ts
@@ -15,54 +15,135 @@
 
 import {property} from 'lit-element';
 
-import ModelViewerElementBase, {$ariaLabel, $canvas, $updateSource} from '../model-viewer-base.js';
+import ModelViewerElementBase, {$ariaLabel, $canvas, $progressTracker, $updateSource} from '../model-viewer-base.js';
 import {CachingGLTFLoader} from '../three-components/CachingGLTFLoader.js';
-import {Constructor, deserializeUrl} from '../utils.js';
+import {Constructor, debounce, deserializeUrl, throttle} from '../utils.js';
 
 import {LoadingStatusAnnouncer} from './loading/status-announcer.js';
 
-export const $posterContainerElement = Symbol('posterContainerElement');
-export const $defaultPosterElement = Symbol('defaultPosterElement');
+export type RevealAttributeValue = 'auto'|'interaction';
+type DismissalSource = 'interaction';
 
-const $showPoster = Symbol('showPoster');
-const $hidePoster = Symbol('hidePoster');
-const $posterHidden = Symbol('posterHidden');
-const $userDismissedPoster = Symbol('userDismissedPoster');
-const $shouldDismissPoster = Symbol('shouldDismissPoster');
-const $shouldAttemptPreload = Symbol('shouldAttemptPreload');
-const $ensurePreloaded = Symbol('ensurePreloaded');
-const $preloadAnnounced = Symbol('preloadAnnounced');
-const $ariaLabelCallToAction = Symbol('ariaLabelCallToAction');
+export const POSTER_TRANSITION_TIME = 300;
+export const PROGRESS_BAR_UPDATE_THRESHOLD = 100;
+const PROGRESS_MASK_BASE_OPACITY = 0.2;
+const ANNOUNCE_MODEL_VISIBILITY_DEBOUNCE_THRESHOLD = 0;
 
-const $clickHandler = Symbol('clickHandler');
-const $keydownHandler = Symbol('keydownHandler');
-const $onClick = Symbol('onClick');
-const $onKeydown = Symbol('onKeydown');
+const SPACE_KEY = 32;
+const ENTER_KEY = 13;
+
+const RevealStrategy: {[index: string]: RevealAttributeValue} = {
+  AUTO: 'auto',
+  INTERACTION: 'interaction'
+};
+
+const PosterDismissalSource: {[index: string]: DismissalSource} = {
+  INTERACTION: 'interaction'
+};
 
 const loader = new CachingGLTFLoader();
 const loadingStatusAnnouncer = new LoadingStatusAnnouncer();
 
-export const POSTER_TRANSITION_TIME = 300;
-const SPACE_KEY = 32;
-const ENTER_KEY = 13;
+export const $defaultProgressBarElement = Symbol('defaultProgressBarElement');
+export const $defaultProgressMaskElement = Symbol('defaultProgressMaskElement');
+
+export const $posterContainerElement = Symbol('posterContainerElement');
+export const $defaultPosterElement = Symbol('defaultPosterElement');
+
+const $posterDismissalSource = Symbol('posterDismissalSource');
+
+const $announceModelVisibility = Symbol('announceModelVisibility');
+const $modelIsReadyForReveal = Symbol('modelIsReadyForReveal');
+const $shouldAttemptPreload = Symbol('shouldAttemptPreload');
+const $shouldRevealModel = Symbol('shouldRevealModel');
+const $showPoster = Symbol('showPoster');
+const $hidePoster = Symbol('hidePoster');
+const $modelIsVisible = Symbol('modelIsVisible');
+const $preloadAttempted = Symbol('preloadAttempted');
+const $sourceUpdated = Symbol('sourceUpdated');
+
+const $updateLoadingAndVisibility = Symbol('updateLoadingAndVisibility');
+
+const $updateProgressBar = Symbol('updateProgressBar');
+const $lastReportedProgress = Symbol('lastReportedProgress');
+
+const $ariaLabelCallToAction = Symbol('ariaLabelCallToAction');
+
+const $clickHandler = Symbol('clickHandler');
+const $keydownHandler = Symbol('keydownHandler');
+const $progressHandler = Symbol('processHandler');
+const $onClick = Symbol('onClick');
+const $onKeydown = Symbol('onKeydown');
+const $onProgress = Symbol('onProgress');
 
 
+/**
+ * LoadingMixin implements features related to lazy loading, as well as
+ * presentation details related to the pre-load / pre-render presentation of a
+ * <model-viewer>
+ */
 export const LoadingMixin = (ModelViewerElement:
                                  Constructor<ModelViewerElementBase>) => {
   class LoadingModelViewerElement extends ModelViewerElement {
-    @property({type: deserializeUrl}) poster: string|null = null;
+    /**
+     * A URL pointing to the image to use as a poster in scenarios where the
+     * <model-viewer> is not ready to reveal a rendered model to the viewer.
+     */
+    @property({converter: {fromAttribute: deserializeUrl}})
+    poster: string|null = null;
 
+    /**
+     * An enumerable attribute describing under what conditions the
+     * <model-viewer> should reveal a model to the viewer.
+     *
+     * The default value is "auto". The only supported alternative value as of
+     * now is "interaction".
+     */
+    @property({type: String})
+    reveal: RevealAttributeValue = RevealStrategy.AUTO;
+
+    /**
+     * If true, a configured model file will be aggressively loaded, even if the
+     * <model-viewer> is only configured to reveal upon interaction.
+     */
     @property({type: Boolean}) preload: boolean = false;
 
-    @property({type: Boolean, attribute: 'reveal-when-loaded'})
-    revealWhenLoaded: boolean = false;
+    /**
+     * True if the model has finished loading. Note that a model can be loaded,
+     * but not yet be rendered.
+     */
+    get loaded(): boolean {
+      const src = this.src;
+      return super.loaded ||
+          !!(src && CachingGLTFLoader.hasFinishedLoading(src));
+    }
 
-    protected[$posterHidden]: boolean = true;
-    protected[$preloadAnnounced]: boolean = false;
+    /**
+     * True if the model is visible. Visibility implies that a model has
+     * finished loading, that it has rendered at least once and that the poster
+     * is no longer obscuring it.
+     */
+    get modelIsVisible(): boolean {
+      return super.modelIsVisible && this[$modelIsVisible];
+    }
 
-    // Used to determine whether or not to display a poster image or
-    // to load the model if not preloaded.
-    protected[$userDismissedPoster]: boolean = false;
+    /**
+     * Dismisses the poster, causing the model to load and render if necessary.
+     * This is currently effectively the same as interacting with the poster via
+     * user input.
+     */
+    dismissPoster() {
+      this[$posterDismissalSource] = PosterDismissalSource.INTERACTION;
+      this.requestUpdate();
+    }
+
+    protected[$modelIsVisible] = false;
+    protected[$preloadAttempted] = false;
+    protected[$sourceUpdated] = false;
+
+    protected[$lastReportedProgress]: number = 0;
+
+    protected[$posterDismissalSource]: DismissalSource|null = null;
 
     // TODO: Add this to the shadow root as part of this mixin's
     // implementation:
@@ -72,21 +153,51 @@ export const LoadingMixin = (ModelViewerElement:
     protected[$defaultPosterElement]: HTMLElement =
         this.shadowRoot!.querySelector('#default-poster') as HTMLElement;
 
+    protected[$defaultProgressBarElement]: HTMLElement =
+        this.shadowRoot!.querySelector('#default-progress-bar > .bar') as
+        HTMLElement;
+
+    protected[$defaultProgressMaskElement]: HTMLElement =
+        this.shadowRoot!.querySelector('#default-progress-bar > .mask') as
+        HTMLElement;
+
     protected[$ariaLabelCallToAction] =
         this[$defaultPosterElement].getAttribute('aria-label');
 
     protected[$clickHandler]: () => void = () => this[$onClick]();
     protected[$keydownHandler]:
         (event: KeyboardEvent) => void = (event) => this[$onKeydown](event);
+    protected[$progressHandler]:
+        (event: Event) => void = (event) => this[$onProgress](event);
 
-    get loaded(): boolean {
-      const src = (this as any).src;
-      return super.loaded || (src && CachingGLTFLoader.hasFinishedLoading(src));
-    }
+    protected[$announceModelVisibility] = debounce((visible: boolean) => {
+      this.dispatchEvent(
+          new CustomEvent('model-visibility', {detail: {visible}}));
+    }, ANNOUNCE_MODEL_VISIBILITY_DEBOUNCE_THRESHOLD);
 
-    get modelIsVisible(): boolean {
-      return super.modelIsVisible && this[$posterHidden];
-    }
+    protected[$updateProgressBar] = throttle((progress: number) => {
+      const parentNode = this[$defaultProgressBarElement].parentNode as Element;
+
+      requestAnimationFrame(() => {
+        this[$defaultProgressMaskElement].style.opacity =
+            `${(1.0 - progress) * PROGRESS_MASK_BASE_OPACITY}`;
+
+        this[$defaultProgressBarElement].style.transform =
+            `scaleX(${progress})`;
+
+        if (progress === 0) {
+          // NOTE(cdata): We remove and re-append the progress bar in this
+          // condition so that the progress bar does not appear to transition
+          // backwards from the right when we reset to 0 (or otherwise <1)
+          // progress after having already reached 1 progress previously.
+          parentNode.removeChild(this[$defaultProgressBarElement]);
+          parentNode.appendChild(this[$defaultProgressBarElement]);
+        }
+
+        this[$defaultProgressBarElement].classList.toggle(
+            'hide', progress === 1.0);
+      });
+    }, PROGRESS_BAR_UPDATE_THRESHOLD);
 
     connectedCallback() {
       super.connectedCallback();
@@ -98,6 +209,8 @@ export const LoadingMixin = (ModelViewerElement:
           'click', this[$clickHandler]);
       this[$posterContainerElement].addEventListener(
           'keydown', this[$keydownHandler]);
+      this[$progressTracker].addEventListener(
+          'progress', this[$progressHandler]);
 
       loadingStatusAnnouncer.registerInstance(this);
     }
@@ -109,121 +222,116 @@ export const LoadingMixin = (ModelViewerElement:
           'click', this[$clickHandler]);
       this[$posterContainerElement].removeEventListener(
           'keydown', this[$keydownHandler]);
+      this[$progressTracker].removeEventListener(
+          'progress', this[$progressHandler]);
 
-      loadingStatusAnnouncer.unregisterInstance(this);
+      loadingStatusAnnouncer.unregisterInstance(this)
     }
 
-    dismissPoster() {
-      this[$userDismissedPoster] = true;
-      this.requestUpdate();
-    }
-
-    showPoster() {
-      this[$userDismissedPoster] = false;
-      this.requestUpdate();
-    }
-
-    [$hidePoster]() {
-      const posterContainerElement = this[$posterContainerElement];
-      const defaultPosterElement = this[$defaultPosterElement];
-
-      const posterOpacity =
-          parseFloat(self.getComputedStyle(posterContainerElement).opacity!);
-      const onPosterHidden = () => {
-        requestAnimationFrame(() => {
-          this.dispatchEvent(
-              new CustomEvent('poster-visibility', {detail: {visible: false}}));
-          (this as any)[$canvas].focus();
-        });
-      };
-
-      this[$posterHidden] = true;
-
-      if (posterOpacity > 0) {
-        // NOTE(cdata): The canvas cannot receive focus until the poster has
-        // been completely hidden:
-        posterContainerElement.addEventListener(
-            'transitionend', onPosterHidden, {once: true});
-      } else {
-        // NOTE(cdata): Depending on timing, the opacity may already be 0, in
-        // which case we will never receive a transitionend event. So, just
-        // focus on the next animation frame:
-        onPosterHidden();
-      }
-
-      posterContainerElement.classList.remove('show');
-
-      defaultPosterElement.setAttribute('aria-hidden', 'true');
-      defaultPosterElement.removeAttribute('tabindex');
-    }
-
-    [$showPoster]() {
-      const posterContainerElement = this[$posterContainerElement];
-      const defaultPosterElement = this[$defaultPosterElement];
-
-      posterContainerElement.classList.add('show');
-
-      defaultPosterElement.setAttribute('aria-hidden', 'false');
-      defaultPosterElement.tabIndex = 1;
-
-      this[$posterHidden] = false;
-
-      this.dispatchEvent(
-          new CustomEvent('poster-visibility', {detail: {visible: true}}));
-    }
-
-    [$onClick]() {
-      this.dismissPoster();
-    }
-
-    [$onKeydown](event: KeyboardEvent) {
-      switch (event.keyCode) {
-        // NOTE(cdata): Links and buttons can typically be activated with both
-        // spacebar and enter to produce a synthetic click action
-        case SPACE_KEY:
-        case ENTER_KEY:
-          this.dismissPoster();
-          break;
-        default:
-          break;
-      }
-    }
-
-    get[$shouldDismissPoster]() {
-      const src = (this as any).src;
-      return !this.poster ||
-          (CachingGLTFLoader.hasFinishedLoading(src) &&
-           (this.revealWhenLoaded || this[$userDismissedPoster]));
-    }
-
-    get[$shouldAttemptPreload]() {
-      return (this[$userDismissedPoster] || this.preload) &&
-          (this as any).src && !this[$preloadAnnounced];
-    }
-
-    updated(changedProperties: Map<string, any>) {
+    async updated(changedProperties: Map<string, any>) {
       super.updated(changedProperties);
 
-      const defaultPosterElement = this[$defaultPosterElement];
+      if (changedProperties.has('poster') && this.poster != null) {
+        this[$defaultPosterElement].style.backgroundImage =
+            `url(${this.poster})`;
+      }
+
+      if (changedProperties.has('src')) {
+        this[$posterDismissalSource] = null;
+        this[$preloadAttempted] = false;
+        this[$lastReportedProgress] = 0;
+        this[$sourceUpdated] = false;
+      }
 
       if (changedProperties.has('alt')) {
-        defaultPosterElement.setAttribute(
+        this[$defaultPosterElement].setAttribute(
             'aria-label',
             `${this[$ariaLabel]}. ${this[$ariaLabelCallToAction]}`);
       }
 
-      if (changedProperties.has('poster') && this.poster) {
-        defaultPosterElement.style.backgroundImage = `url("${this.poster}")`;
+      this[$updateLoadingAndVisibility]()
+    }
+
+    [$onClick]() {
+      this[$posterDismissalSource] = PosterDismissalSource.INTERACTION;
+      this.requestUpdate();
+    }
+
+    [$onKeydown](event: KeyboardEvent) {
+      switch (event.keyCode) {
+        // NOTE(cdata): Links and buttons can typically be activated with
+        // both spacebar and enter to produce a synthetic click action
+        case SPACE_KEY:
+        case ENTER_KEY:
+          this[$posterDismissalSource] = PosterDismissalSource.INTERACTION;
+          break;
+        default:
+          break;
       }
 
-      if (changedProperties.has('src')) {
-        this[$preloadAnnounced] = false;
+      this.requestUpdate();
+    }
+
+    [$onProgress](event: Event) {
+      const progress = (event as any).detail.totalProgress;
+
+      this.requestUpdate();
+
+      if (progress === 1.0) {
+        this[$updateProgressBar].flush();
       }
 
-      this[$ensurePreloaded]();
+      this[$updateProgressBar](progress);
 
-      if (this[$shouldDismissPoster]) {
-        if (!this[$posterHidden]) {
+      this.dispatchEvent(
+          new CustomEvent('progress', {detail: {totalProgress: progress}}));
+
+      this[$lastReportedProgress] =
+          Math.max(progress, this[$lastReportedProgress]);
+    }
+
+    get[$modelIsReadyForReveal](): boolean {
+      const {src} = this;
+
+      return !!src && CachingGLTFLoader.hasFinishedLoading(src) &&
+          this[$lastReportedProgress] === 1.0 && this[$shouldRevealModel]
+    }
+
+    get[$shouldRevealModel](): boolean {
+      return this.reveal === RevealStrategy.AUTO ||
+          this.reveal === this[$posterDismissalSource];
+    }
+
+    get[$shouldAttemptPreload](): boolean {
+      const {src} = this;
+
+      return !!src && !CachingGLTFLoader.hasFinishedLoading(src) &&
+          (this.preload || this[$shouldRevealModel]);
+    }
+
+    async[$updateLoadingAndVisibility]() {
+      if (this[$shouldAttemptPreload] && !this[$preloadAttempted]) {
+        this[$preloadAttempted] = true;
+
+        const updatePreloadProgress = this[$progressTracker].beginActivity();
+
+        try {
+          const src = this.src!;
+          const detail = {url: src};
+
+          await loader.preload(src, updatePreloadProgress);
+          this.dispatchEvent(new CustomEvent('preload', {detail}));
+        } catch (error) {
+          this.dispatchEvent(new CustomEvent(
+              'error', {detail: {type: 'preload', sourceError: error}}));
+        } finally {
+          updatePreloadProgress(1.0);
+          this.requestUpdate();
+        }
+      }
+
+      if (this[$modelIsReadyForReveal]) {
+        if (!this[$sourceUpdated]) {
           this[$updateSource]();
           this[$hidePoster]();
         }
@@ -232,37 +340,63 @@ export const LoadingMixin = (ModelViewerElement:
       }
     }
 
-    async[$ensurePreloaded]() {
-      const preloaded = CachingGLTFLoader.hasFinishedLoading((this as any).src);
+    [$showPoster]() {
+      const posterContainerElement = this[$posterContainerElement];
+      const defaultPosterElement = this[$defaultPosterElement];
+      const posterContainerOpacity =
+          parseFloat(self.getComputedStyle(posterContainerElement).opacity!);
 
-      if (this[$shouldAttemptPreload]) {
-        const src = (this as any).src;
-        const detail = {url: src};
+      defaultPosterElement.tabIndex = 1;
+      defaultPosterElement.removeAttribute('aria-hidden');
+      posterContainerElement.classList.add('show');
 
-        this[$preloadAnnounced] = true;
+      if (posterContainerOpacity < 1.0) {
+        posterContainerElement.addEventListener('transitionend', () => {
+          this[$modelIsVisible] = false;
+          this[$announceModelVisibility](false);
+        }, {once: true});
+      }
+    }
 
-        if (preloaded) {
-          this.dispatchEvent(new CustomEvent('preload', {detail}));
-        } else {
-          try {
-            await loader.preload(src);
+    [$hidePoster]() {
+      const posterContainerElement = this[$posterContainerElement];
+      const defaultPosterElement = this[$defaultPosterElement];
 
-            this.dispatchEvent(new CustomEvent('preload', {detail}));
-            this.requestUpdate();
-          } catch (error) {
-            this.dispatchEvent(new CustomEvent(
-                'error', {detail: {type: 'preload', sourceError: error}}));
-          }
-        }
+      if (posterContainerElement.classList.contains('show')) {
+        posterContainerElement.classList.remove('show');
+
+        // We might need to forward focus to our internal canvas, but that
+        // cannot happen until the poster has completely transitioned away
+        posterContainerElement.addEventListener('transitionend', () => {
+          this[$announceModelVisibility](true);
+          requestAnimationFrame(() => {
+            this[$modelIsVisible] = true;
+
+            const root = this.getRootNode();
+
+            // If the <model-viewer> is still focused, forward the focus to the
+            // canvas that has just been revealed
+            if (root &&
+                (root as Document | ShadowRoot).activeElement === this) {
+              this[$canvas].focus();
+            }
+
+            // Ensure that the poster is no longer focusable or visible to
+            // screen readers
+            defaultPosterElement.setAttribute('aria-hidden', 'true');
+            defaultPosterElement.removeAttribute('tabindex');
+          });
+        }, {once: true});
       }
     }
 
     async[$updateSource]() {
-      if (this[$shouldDismissPoster]) {
+      if (this[$modelIsReadyForReveal]) {
+        this[$sourceUpdated] = true;
         await super[$updateSource]();
       }
     }
-  };
+  }
 
   return LoadingModelViewerElement;
-}
+};

--- a/src/features/loading.ts
+++ b/src/features/loading.ts
@@ -194,8 +194,14 @@ export const LoadingMixin = (ModelViewerElement:
           parentNode.appendChild(this[$defaultProgressBarElement]);
         }
 
-        this[$defaultProgressBarElement].classList.toggle(
-            'hide', progress === 1.0);
+        // NOTE(cdata): IE11 does not properly respect the second parameter of
+        // classList.toggle, which this implementation originally used.
+        // @see https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11865865/
+        if (progress === 1.0) {
+          this[$defaultProgressBarElement].classList.add('hide');
+        } else {
+          this[$defaultProgressBarElement].classList.remove('hide');
+        }
       });
     }, PROGRESS_BAR_UPDATE_THRESHOLD);
 

--- a/src/model-viewer-base.ts
+++ b/src/model-viewer-base.ts
@@ -113,13 +113,20 @@ export default class ModelViewerElementBase extends UpdatingElement {
   constructor() {
     super();
 
-    this.attachShadow({mode: 'open', delegatesFocus: true});
+    // NOTE(cdata): It is *very important* to access this template first so that
+    // the ShadyCSS template preparation steps happen before element styling in
+    // IE11:
+    const template = (this.constructor as any).template as HTMLTemplateElement;
 
     if ((window as any).ShadyCSS) {
-      (window as any).ShadyCSS.styleElement(this);
+      (window as any).ShadyCSS.styleElement(this, {});
     }
+
+    // NOTE(cdata): The canonical ShadyCSS examples suggest that the Shadow Root
+    // should be created after the invocation of ShadyCSS.styleElement
+    this.attachShadow({mode: 'open', delegatesFocus: true});
+
     const shadowRoot = this.shadowRoot!;
-    const template = (this.constructor as any).template as HTMLTemplateElement;
 
     shadowRoot.appendChild(template.content.cloneNode(true));
 
@@ -256,8 +263,6 @@ export default class ModelViewerElementBase extends UpdatingElement {
     this[$container].style.height = `${height}px`;
 
     if (forceApply || (prevWidth !== intWidth || prevHeight !== intHeight)) {
-      // this[$container].style.width = `${width}px`;
-      // this[$container].style.height = `${height}px`;
       this[$onResize]({width: intWidth, height: intHeight});
     }
   }

--- a/src/template.ts
+++ b/src/template.ts
@@ -21,6 +21,7 @@ template.innerHTML = `
   <style>
     :host {
       display: block;
+      position: relative;
       contain: strict;
       width: 300px;
       height: 150px;
@@ -68,13 +69,21 @@ template.innerHTML = `
 
     .slot {
       position: absolute;
+      pointer-events: none;
       top: 0;
       left: 0;
+      width: 100%;
+      height: 100%;
     }
+
+    .slot > * {
+      pointer-events: initial;
+    }
+
 
     .slot.poster {
       opacity: 0;
-      transition: opacity 0.3s;
+      transition: opacity 0.3s 0.3s;
     }
 
     .slot.poster.show {
@@ -82,7 +91,11 @@ template.innerHTML = `
       transition: none;
     }
 
-    .slot.poster:not(.show) {
+    .slot.poster > * {
+      pointer-events: initial;
+    }
+
+    .slot.poster:not(.show) > * {
       pointer-events: none;
     }
 
@@ -90,8 +103,65 @@ template.innerHTML = `
       width: 100%;
       height: 100%;
       position: absolute;
-      background-size: cover;
-      background-position: center;
+      background-size: var(--poster-size, cover);
+      background-position: var(--poster-position, center);
+      background-color: var(--poster-color, var(--background-color, #fff));
+      background-image: var(--poster-image, none);
+    }
+
+    #default-progress-bar {
+      display: block;
+      position: relative;
+      width: 100%;
+      height: 100%;
+      pointer-events: none;
+      overflow: hidden;
+    }
+
+    #default-progress-bar > .mask {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background-size: var(--progress-mask-size, auto);
+      background-position: var(--progress-mask-position, auto);
+      background-color: var(--progress-mask-color, #fff);
+      background-image: var(--progress-mask-image, none);
+      transition: opacity 0.3s;
+      opacity: 0.2;
+    }
+
+    #default-progress-bar > .bar {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 5px;
+      transition: transform 0.09s;
+      transform-origin: top left;
+      transform: scaleX(0);
+      overflow: hidden;
+    }
+
+    #default-progress-bar > .bar:before {
+      content: '';
+      display: block;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+
+      background-color: var(--progress-bar-color, rgba(0, 0, 0, 0.4));
+
+      transition: none;
+      transform-origin: top left;
+      transform: translateY(0);
+    }
+
+    #default-progress-bar > .bar.hide:before {
+      transition: transform 0.3s 1s;
+      transform: translateY(-100%);
     }
 
     .slot.controls-prompt {
@@ -110,6 +180,10 @@ template.innerHTML = `
       transition: transform 0.3s, opacity 0.3s;
     }
 
+    .slot.controls-prompt > * {
+      pointer-events: none;
+    }
+
     .slot.controls-prompt svg {
       transform: scale(0.5);
     }
@@ -123,6 +197,14 @@ template.innerHTML = `
     <div class="slot poster">
       <slot name="poster">
         <div id="default-poster" aria-hidden="true" aria-label="Activate to view in 3D!"></div>
+      </slot>
+    </div>
+    <div class="slot progress-bar">
+      <slot name="progress-bar">
+        <div id="default-progress-bar" aria-hidden="true">
+          <div class="mask"></div>
+          <div class="bar"></div>
+        </div>
       </slot>
     </div>
     <a tabindex="2"

--- a/src/template.ts
+++ b/src/template.ts
@@ -25,42 +25,11 @@ template.innerHTML = `
       width: 300px;
       height: 150px;
     }
+
     .container {
       position: relative;
     }
-    .poster {
-      width: 100%;
-      height: 100%;
-      position: absolute;
-      background-size: cover;
-      background-position: center;
-      opacity: 0;
-      transition: opacity 0.3s;
-    }
 
-    .poster.show {
-      opacity: 1;
-      transition: none;
-    }
-
-    .poster:not(.show) {
-      pointer-events: none;
-    }
-
-    .click-to-view {
-      display: none;
-      position: absolute;
-      z-index: 9999;
-      width: 100%;
-      margin: 0 auto;
-      bottom: 20px;
-      background-color: rgba(0, 0, 0, 0.2);
-      color: white;
-      font-size: 120%;
-    }
-    .click-to-view.show {
-      display: block;
-    }
 
     a.enter-ar {
       width: 40px;
@@ -71,11 +40,13 @@ template.innerHTML = `
       top: 10px;
       display: none;
     }
+
     a.enter-ar svg {
       position: absolute;
       top: calc(50% - 12px);
       left: calc(50% - 12px);
     }
+
     a.enter-ar .disc {
       width: 100%;
       height: 100%;
@@ -84,13 +55,43 @@ template.innerHTML = `
       background-color: #fff;
       box-shadow: 0px 0px 1px 0px rgba(0,0,0,0.2);
     }
+
     canvas {
       width: 100%;
       height: 100%;
       display: none;
     }
+
     canvas.show {
       display: block;
+    }
+
+    .slot {
+      position: absolute;
+      top: 0;
+      left: 0;
+    }
+
+    .slot.poster {
+      opacity: 0;
+      transition: opacity 0.3s;
+    }
+
+    .slot.poster.show {
+      opacity: 1;
+      transition: none;
+    }
+
+    .slot.poster:not(.show) {
+      pointer-events: none;
+    }
+
+    #default-poster {
+      width: 100%;
+      height: 100%;
+      position: absolute;
+      background-size: cover;
+      background-position: center;
     }
 
     .slot.controls-prompt {
@@ -119,6 +120,11 @@ template.innerHTML = `
     }
   </style>
   <div class="container">
+    <div class="slot poster">
+      <slot name="poster">
+        <div id="default-poster" aria-hidden="true" aria-label="Activate to view in 3D!"></div>
+      </slot>
+    </div>
     <a tabindex="2"
         class="enter-ar"
         href="#"
@@ -126,7 +132,6 @@ template.innerHTML = `
       <div class="disc"></div>
       ${ARGlyph}
     </a>
-    <div class="poster" aria-hidden="true" aria-label="Activate to view in 3D!"></div>
     <canvas tabindex="1"
         aria-label="A depiction of a 3D model"
         aria-live="polite">
@@ -144,11 +149,11 @@ template.innerHTML = `
 
 export default template;
 
-export const makeTemplate = (tagName) => {
+export const makeTemplate = (tagName: string) => {
   const clone = document.createElement('template');
   clone.innerHTML = template.innerHTML;
-  if (window.ShadyCSS) {
-    window.ShadyCSS.prepareTemplate(clone, tagName);
+  if ((window as any).ShadyCSS) {
+    (window as any).ShadyCSS.prepareTemplate(clone, tagName);
   }
   return clone;
 };

--- a/src/template.ts
+++ b/src/template.ts
@@ -31,7 +31,6 @@ template.innerHTML = `
       position: relative;
     }
 
-
     a.enter-ar {
       width: 40px;
       height: 40px;
@@ -79,7 +78,6 @@ template.innerHTML = `
     .slot > * {
       pointer-events: initial;
     }
-
 
     .slot.poster {
       opacity: 0;

--- a/src/template.ts
+++ b/src/template.ts
@@ -101,9 +101,9 @@ template.innerHTML = `
       width: 100%;
       height: 100%;
       position: absolute;
-      background-size: var(--poster-size, cover);
-      background-position: var(--poster-position, center);
-      background-color: var(--poster-color, var(--background-color, #fff));
+      background-size: cover;
+      background-position: center;
+      background-color: var(--poster-color, #fff);
       background-image: var(--poster-image, none);
     }
 
@@ -122,10 +122,7 @@ template.innerHTML = `
       left: 0;
       width: 100%;
       height: 100%;
-      background-size: var(--progress-mask-size, auto);
-      background-position: var(--progress-mask-position, auto);
-      background-color: var(--progress-mask-color, #fff);
-      background-image: var(--progress-mask-image, none);
+      background: var(--progress-mask, #fff);
       transition: opacity 0.3s;
       opacity: 0.2;
     }

--- a/src/test/helpers.js
+++ b/src/test/helpers.js
@@ -84,7 +84,7 @@ export const dispatchSyntheticEvent = (element, type, properties = {
   clientY: 0,
   deltaY: 1.0
 }) => {
-  const event = new CustomEvent(type, {cancelable: true});
+  const event = new CustomEvent(type, {cancelable: true, bubbles: true});
   Object.assign(event, properties);
   element.dispatchEvent(event);
   return event;
@@ -124,4 +124,3 @@ export const isInDocumentTree = (element) => {
 
   return false;
 };
-

--- a/src/test/index.js
+++ b/src/test/index.js
@@ -24,6 +24,7 @@ import './three-components/SmoothControls-spec.js';
 import './three-components/TextureUtils-spec.js';
 import './three-components/CachingGLTFLoader-spec.js';
 import './three-components/ModelUtils-spec.js';
+import './utilities/progress-tracker-spec.js';
 import './features/animation-spec.js';
 import './features/staging-spec.js';
 import './features/controls-spec.js';

--- a/src/test/utilities/progress-tracker-spec.ts
+++ b/src/test/utilities/progress-tracker-spec.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Activity, ProgressDetails, ProgressTracker} from '../../utilities/progress-tracker.js';
+import {waitForEvent} from '../helpers.js';
+
+const expect = chai.expect;
+
+suite('ProgressTracker', () => {
+  let progressTracker: ProgressTracker;
+  setup(() => {
+    progressTracker = new ProgressTracker();
+  });
+
+  test('starts out with zero ongoing activities', () => {
+    expect(progressTracker.ongoingActivityCount).to.be.equal(0);
+  });
+
+  suite('an activity', () => {
+    let firstActivity: Activity;
+
+    setup(() => {
+      firstActivity = progressTracker.beginActivity();
+    });
+
+    test('increases the ongoing activities count', () => {
+      expect(progressTracker.ongoingActivityCount).to.be.equal(1);
+    });
+
+    suite('with partial progress', () => {
+      test(
+          'causes the ProgressTracker to dispatch a progress event',
+          async () => {
+            const progressEventDispatches =
+                waitForEvent(progressTracker, 'progress');
+            firstActivity(0.5);
+            const event: CustomEvent<ProgressDetails> =
+                await progressEventDispatches;
+
+            expect(event.detail.totalProgress).to.be.greaterThan(0);
+          });
+
+      test('only allows progress to advance', () => {
+        const initialProgress = firstActivity(0.5);
+        const nextProgress = firstActivity(0.2);
+
+        expect(nextProgress).to.be.equal(initialProgress);
+      });
+
+      suite('a late-added activity', () => {
+        setup(() => {
+          firstActivity(0.5);
+        });
+
+        test('is added to the current stack of activities', () => {
+          progressTracker.beginActivity();
+          expect(progressTracker.ongoingActivityCount).to.be.equal(2);
+        });
+
+        test('defers marking all activities completed', () => {
+          progressTracker.beginActivity();
+          firstActivity(1.0);
+          expect(progressTracker.ongoingActivityCount).to.be.equal(2);
+        });
+      });
+    });
+
+    suite('completed', () => {
+      test('ProgressTracker dispatches a final progress event', async () => {
+        const progressEventDispatches =
+            waitForEvent(progressTracker, 'progress');
+        firstActivity(1.0);
+        const event: CustomEvent<ProgressDetails> =
+            await progressEventDispatches;
+
+        expect(event.detail.totalProgress).to.be.equal(1);
+      });
+
+      test('ProgressTracker resets ongoing activity count', () => {
+        firstActivity(1.0);
+        expect(progressTracker.ongoingActivityCount).to.be.equal(0);
+      });
+    });
+
+    suite('with another activity', () => {
+      let secondActivity: Activity;
+
+      setup(() => {
+        secondActivity = progressTracker.beginActivity();
+      });
+
+      test('increases the ongoing activity count', () => {
+        expect(progressTracker.ongoingActivityCount).to.be.equal(2);
+      });
+
+      test('each activity progresses independently', () => {
+        let firstProgress = firstActivity(0.2);
+        let secondProgress = secondActivity(0.1);
+
+        expect(firstProgress).to.be.equal(0.2);
+        expect(secondProgress).to.be.equal(0.1);
+
+        secondProgress = secondActivity(1.0);
+        firstProgress = firstActivity(0.3);
+
+        expect(firstProgress).to.be.equal(0.3);
+        expect(secondProgress).to.be.equal(1.0);
+      });
+
+      suite('all activities completed', () => {
+        test('ProgressTracker resets ongoing activity count', () => {
+          firstActivity(1.0);
+          secondActivity(1.0);
+          expect(progressTracker.ongoingActivityCount).to.be.equal(0);
+        });
+
+        test(
+            'ProgressTracker dispatches a final progress event after the last activity is completed',
+            async () => {
+              secondActivity(1.0);
+              const progressEventDispatches =
+                  waitForEvent(progressTracker, 'progress');
+              firstActivity(1.0);
+              const event: CustomEvent<ProgressDetails> =
+                  await progressEventDispatches;
+
+              expect(event.detail.totalProgress).to.be.equal(1);
+            });
+      });
+    });
+  });
+});

--- a/src/third_party/three/GLTFLoader.d.ts
+++ b/src/third_party/three/GLTFLoader.d.ts
@@ -1,0 +1,27 @@
+import {AnimationClip, Camera, LoadingManager, Scene} from 'three';
+
+export interface GLTF {
+  animations: AnimationClip[];
+  scene: Scene;
+  scenes: Scene[];
+  cameras: Camera[];
+  asset: object;
+}
+
+export default class GLTFLoader {
+  constructor(manager?: LoadingManager);
+  manager: LoadingManager;
+  path: string;
+
+  load(
+      url: string, onLoad: (gltf: GLTF) => void,
+      onProgress?: (event: ProgressEvent) => void,
+      onError?: (event: ErrorEvent) => void): void;
+  setPath(path: string): GLTFLoader;
+  setResourcePath(path: string): GLTFLoader;
+  setCrossOrigin(value: string): void;
+  setDRACOLoader(dracoLoader: object): void;
+  parse(
+      data: ArrayBuffer, path: string, onLoad: (gltf: GLTF) => void,
+      onError?: (event: ErrorEvent) => void): void;
+}

--- a/src/three-components/CachingGLTFLoader.ts
+++ b/src/three-components/CachingGLTFLoader.ts
@@ -14,15 +14,25 @@
  */
 
 import GLTFLoader from '../third_party/three/GLTFLoader.js';
-import {cloneGltf} from './ModelUtils.js';
 
-export const loadWithLoader = (url, loader) =>
-    new Promise((resolve, reject) => {
-      loader.load(url, resolve, () => {}, reject);
-    });
+import {cloneGltf, Gltf} from './ModelUtils.js';
 
-const cache = new Map();
-const preloaded = new Map();
+export type ProgressCallback = (loaded: number, total: number) => void;
+
+export const loadWithLoader =
+    (url: string,
+     loader: any,
+     progressCallback: ProgressCallback|null = null) => {
+      const onProgress = progressCallback != null ? (event: ProgressEvent) => {
+        progressCallback!(event.loaded, event.total);
+      } : () => {};
+      return new Promise<Gltf>((resolve, reject) => {
+        loader.load(url, resolve, onProgress, reject);
+      });
+    }
+
+const cache = new Map<string, Promise<Gltf>>();
+const preloaded = new Map<string, boolean>();
 
 export class CachingGLTFLoader {
   static clearCache() {
@@ -30,7 +40,7 @@ export class CachingGLTFLoader {
     preloaded.clear();
   }
 
-  static has(url) {
+  static has(url: string) {
     return cache.has(url);
   }
 
@@ -38,21 +48,19 @@ export class CachingGLTFLoader {
    * Returns true if the model that corresponds to the specified url is
    * available in our local cache.
    */
-  static hasFinishedLoading(url) {
+  static hasFinishedLoading(url: string) {
     return !!preloaded.get(url);
   }
 
-  constructor() {
-    this.loader = new GLTFLoader();
-  }
+  protected loader: GLTFLoader = new GLTFLoader();
 
   /**
    * Preloads a glTF, populating the cache. Returns a promise that resolves
    * when the cache is populated.
    */
-  async preload(url) {
+  async preload(url: string, progressCallback: ProgressCallback|null = null) {
     if (!cache.has(url)) {
-      cache.set(url, loadWithLoader(url, this.loader));
+      cache.set(url, loadWithLoader(url, this.loader, progressCallback));
     }
 
     await cache.get(url);
@@ -65,10 +73,10 @@ export class CachingGLTFLoader {
    * glTF. If the glTF has already been loaded, makes a clone of the cached
    * copy.
    */
-  async load(url) {
-    await this.preload(url);
+  async load(url: string, progressCallback: ProgressCallback|null = null) {
+    await this.preload(url, progressCallback);
 
-    const gltf = cloneGltf(await cache.get(url));
+    const gltf = cloneGltf(await cache.get(url)!);
     const model = gltf.scene ? gltf.scene : null;
 
     if (model != null) {

--- a/src/three-components/Model.js
+++ b/src/three-components/Model.js
@@ -117,9 +117,13 @@ export default class Model extends Object3D {
 
   /**
    * @param {String} url
+   * @param {Function?} progressCallback
    */
-  async setSource(url) {
+  async setSource(url, progressCallback) {
     if (!url || url === this.url) {
+      if (progressCallback) {
+        progressCallback(1);
+      }
       return;
     }
 
@@ -138,7 +142,7 @@ export default class Model extends Object3D {
       scene = await new Promise(async (resolve, reject) => {
         this[$cancelPendingSourceChange] = () => reject();
         try {
-          const result = await this.loader.load(url);
+          const result = await this.loader.load(url, progressCallback);
           resolve(result);
         } catch (error) {
           reject(error);

--- a/src/three-components/ModelScene.js
+++ b/src/three-components/ModelScene.js
@@ -153,10 +153,11 @@ export default class ModelScene extends Scene {
    * Sets the model via URL.
    *
    * @param {String?} source
+   * @param {Function?} progressCallback
    */
-  async setModelSource(source) {
+  async setModelSource(source, progressCallback) {
     try {
-      await this.model.setSource(source);
+      await this.model.setSource(source, progressCallback);
     } catch (e) {
       throw new Error(
           `Could not set model source to '${source}': ${e.message}`);

--- a/src/three-components/ModelScene.js
+++ b/src/three-components/ModelScene.js
@@ -152,7 +152,7 @@ export default class ModelScene extends Scene {
   /**
    * Sets the model via URL.
    *
-   * @param {String} source
+   * @param {String?} source
    */
   async setModelSource(source) {
     try {

--- a/src/types/resizeobserver.d.ts
+++ b/src/types/resizeobserver.d.ts
@@ -1,4 +1,17 @@
-interface ResizeObserver {
+interface ResizeObserverSize {
+  inlineSize: number;
+  blockSize: number;
+}
+
+interface ResizeObserverEntry {
+  target: Element;
+  contentRect: DOMRectReadOnly;
+  borderBoxSize: ResizeObserverSize;
+  contentBoxSize: ResizeObserverSize;
+}
+
+declare class ResizeObserver {
+  constructor(callback: (entries: Array<ResizeObserverEntry>) => void);
   observe(element: Element): void;
   unobserve(element: Element): void;
   disconnect(): void;

--- a/src/utilities/progress-tracker.ts
+++ b/src/utilities/progress-tracker.ts
@@ -1,0 +1,141 @@
+import {clamp} from '../utils.js';
+
+interface OngoingActivity {
+  progress: number;
+}
+const $ongoingActivities = Symbol('ongoingActivities');
+const $announceTotalProgress = Symbol('announceTotalProgress');
+const $eventDelegate = Symbol('eventDelegate');
+
+const ACTIVITY_PROGRESS_WEIGHT = 0.5;
+
+/**
+ * An Activity is represented by a callback that accepts values from 0 to 1,
+ * where 1 represents the completion of the activity. The callback returns the
+ * actual progress as it is stored by the ProgressTracker (which may be clamped,
+ * and can never be lower than its previous value).
+ */
+export type Activity = (progress: number) => number;
+
+/**
+ * A progress event contains the total progress of all ongoing activities in the
+ * ProgressTracker. The progress is a heuristic, should not be considered an
+ * absolute representation of progress across any or all events.
+ */
+export interface ProgressDetails {
+  totalProgress: number;
+}
+
+/**
+ * ProgressTracker is an event emitter that helps to track the ongoing progress
+ * of many simultaneous actions.
+ *
+ * ProgressTracker reports progress activity in the form of a progress event.
+ * The event.detail.totalProgress value indicates the elapsed progress of all
+ * activities being tracked by the ProgressTracker.
+ *
+ * The value of totalProgress is a number that progresses from 0 to 1. The
+ * ProgressTracker allows for the lazy accumulation of tracked actions, so the
+ * total progress represents a abstract, non-absolute progress towards the
+ * completion of all currently tracked events.
+ *
+ * When all currently tracked activities are finished, the ProgressTracker
+ * emits one final progress event and then resets the list of its currently
+ * tracked activities. This means that from an observer's perspective,
+ * ongoing activities will accumulate and collectively contribute to the notion
+ * of total progress until all currently tracked ongoing activities have
+ * completed.
+ */
+export class ProgressTracker implements EventTarget {
+  // NOTE(cdata): This eventDelegate hack is a quick trick to let us get the
+  // EventTarget interface without implementing or requiring a full polyfill. We
+  // should remove this once EventTarget is inheritable everywhere.
+  protected[$eventDelegate]: DocumentFragment =
+      document.createDocumentFragment();
+
+  // NOTE(cdata): We declare each of these methods independently here so that we
+  // can inherit the correct types from EventTarget's interface. Maybe there is
+  // a better way to do this dynamically so that we don't repeat ourselves?
+  public addEventListener: typeof EventTarget.prototype.addEventListener =
+      (...args) => this[$eventDelegate].addEventListener(...args);
+  public removeEventListener: typeof EventTarget.prototype.removeEventListener =
+      (...args) => this[$eventDelegate].removeEventListener(...args);
+  public dispatchEvent: typeof EventTarget.prototype.dispatchEvent =
+      (...args) => this[$eventDelegate].dispatchEvent(...args);
+
+
+  protected[$ongoingActivities]: Set<OngoingActivity> = new Set();
+
+  /**
+   * The total number of activities currently being tracked.
+   */
+  get ongoingActivityCount(): number {
+    return this[$ongoingActivities].size;
+  }
+
+  /**
+   * Registers a new activity to be tracked by the progress tracker. The method
+   * returns a special callback that should be invoked whenever new progress is
+   * ready to be reported. The progress should be reported as a value between 0
+   * and 1, where 0 would represent the beginning of the action and 1 would
+   * represent its completion.
+   *
+   * There is no built-in notion of a time-out for ongoing activities, so once
+   * an ongoing activity is begun, it is up to the consumer of this API to
+   * update the progress until that activity is no longer ongoing.
+   *
+   * Progress is only allowed to move forward for any given activity. If a lower
+   * progress is reported than the previously reported progress, it will be
+   * ignored.
+   */
+  beginActivity(): Activity {
+    const activity: OngoingActivity = {progress: 0};
+
+    this[$ongoingActivities].add(activity);
+
+    if (this.ongoingActivityCount === 1) {
+      // Announce the first progress event (which should always be 0 / 1
+      // total progress):
+      this[$announceTotalProgress]();
+    }
+
+    return (progress: number): number => {
+      let nextProgress: number;
+
+      nextProgress = Math.max(clamp(progress, 0, 1), activity.progress);
+
+      if (nextProgress !== activity.progress) {
+        activity.progress = nextProgress;
+        this[$announceTotalProgress]();
+      }
+
+      return activity.progress;
+    };
+  }
+
+  [$announceTotalProgress]() {
+    let totalProgress = 0;
+    let statusCount = 0;
+    let completedActivities = 0;
+
+    for (const activity of this[$ongoingActivities]) {
+      const {progress} = activity;
+      const compoundWeight =
+          ACTIVITY_PROGRESS_WEIGHT / Math.pow(2, statusCount++);
+
+      totalProgress += progress * compoundWeight;
+
+      if (progress === 1.0) {
+        completedActivities++;
+      }
+    }
+
+    if (completedActivities === this.ongoingActivityCount) {
+      totalProgress = 1.0;
+      this[$ongoingActivities].clear();
+    }
+
+    this.dispatchEvent(new CustomEvent<ProgressDetails>(
+        'progress', {detail: {totalProgress}}));
+  }
+}

--- a/src/utilities/progress-tracker.ts
+++ b/src/utilities/progress-tracker.ts
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {clamp} from '../utils.js';
 
 interface OngoingActivity {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,6 +61,36 @@ export const toFullUrl = (partialUrl: string): string => {
 };
 
 
+/**
+ * Returns a throttled version of a given function that is only invoked at most
+ * once within a given threshold of time in milliseconds.
+ *
+ * The throttled version of the function has a "flush" property that resets the
+ * threshold for cases when immediate invokation is desired.
+ */
+export const throttle = (fn: (...args: Array<any>) => any, ms: number) => {
+  let timer: number|null = null;
+
+  const throttled = (...args: Array<any>) => {
+    if (timer != null) {
+      return;
+    }
+
+    fn(...args);
+
+    timer = self.setTimeout(() => timer = null, ms);
+  };
+
+  throttled.flush = () => {
+    if (timer != null) {
+      self.clearTimeout(timer);
+      timer = null;
+    }
+  };
+
+  return throttled;
+};
+
 export const debounce = (fn: (...args: Array<any>) => any, ms: number) => {
   let timer: number|null = null;
 


### PR DESCRIPTION
# Progress Bars

This change proposes the addition of the notion of instance-wide loading progress, as well as corresponding customizable visualizations and API. In other words: progress bars.

Some highlights of this change include:

 - A new `progress` event is introduced, maps directly to our internal notion of progress
 - A built in progress bar UI has been introduced
   - Can be customized by adding child nodes to `slot="progress-bar"`
   - Can also be customized with CSS custom properties
 - The poster now has a default background color, and is always displayed before the model is loaded
   - Can now be customized by adding child nodes to `slot="poster"`
   - Can also be customized with CSS custom properties
 - A new `reveal` attribute has been introduced to control model visibility
   - Default configuration is equivalent to `reveal-when-loaded` semantics
   - `reveal="interaction"` defers loading / revealing model until user interaction
 - **🚨 BREAKING CHANGE:** `reveal-when-loaded` has been removed in favor of new `reveal` attribute and related semantics
 - A new `ProgressTracker` utility class has been introduced to assist in tracking progress across multiple, uncoordinated, asynchronous actions at once
 - Several modules have been converted to TypeScript, including: `model-viewer-base`, `features/loading`, `template` and `three-components/CachingGLTFLoader`
 - Asynchronous actors have been instrumented with progress callback support throughout
 - Type declarations for `GLTFLoader` have been copied over from the Three.js project
 - A bug was fixed relating to how DPR was applied when zooming
 - A bug was fixed that caused `<model-viewer>` to have 1px-wide empty margins sometimes

## New CSS custom properties

In keeping with our goal of enabling as much idiomatic customization as we can, the following CSS custom properties have been introduced by this change:

CSS property                         | Description
---------------------------- | ------------
`--poster-color`                    | Sets the `background-color` of the poster. Falls back to `--background-color` if set. Defaults to `#fff`.
`--poster-image`                  | Sets the `background-image` of the poster. **This is currently overridden by the `poster` attribute if it is set.** Defaults to `none`.
`--progress-bar-color`         | Sets the `background-color` of the progress bar. Defaults to `rgba(0, 0, 0, 0.4)`.
`--progress-mask` &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;      | Sets the `background` of the progress mask. Defaults to `#fff`.

## Tracking progress

In order to present the model at the correct time, we must take into account an uncertain number of possible network actions (environment map, glTF w/ multiple sub-resources etc) as well as an uncertain number of script/GPU processing steps (env map generation, skybox, PMREM etc) in order for the model to be considered presentable. The notion of "progress" introduced by this change encompasses all such actions that are implemented today.

Here is an example of how complex the process of presenting one model can be. Note that this is a fairly heavy configuration, resulting in almost 70MB of total assets transferred before we reveal the model:

![Artboard 1@4x](https://user-images.githubusercontent.com/240083/56242270-c0cdbb00-604c-11e9-9ab9-46a9c8433b0b.png)

## Examples

Basic progress bar w/ poster  | `reveal="interaction"`
----------------------------- | -----------------------------------
![progressbar](https://user-images.githubusercontent.com/240083/56242322-db079900-604c-11e9-9cd5-989246c73e7c.gif) | ![progressbar-reveal-interaction](https://user-images.githubusercontent.com/240083/56261722-f72d2980-6090-11e9-9bc8-9d36d77a870f.gif)

`src` attribute changing over time | Custom progress bar
---------------------------------- | ---------------------
![progressbar-src-changing](https://user-images.githubusercontent.com/240083/56262142-72430f80-6092-11e9-99f4-57c1498b75db.gif) | ![progressbar-custom-bar](https://user-images.githubusercontent.com/240083/56262147-75d69680-6092-11e9-8bdd-02d651da0682.gif)

The following is an abbreviated form of the markup used to create the custom progress bar example above:

```html

<style>
  #progress {
    position: absolute;
    width: calc(100% / 3);
    height: 10px;
    color: rgba(255, 255, 255, 0.75);
    box-shadow: 0px 0px 8px 6px rgba(0, 0, 0, 0.25);
    border: 2px solid currentColor;
    border-radius: 10px;
    top: calc(50% - 5px);
    left: calc(50% - 100% / 6);
    opacity: 0;
    transition: opacity 0.3s 0.3s;
  }

  #progress.show {
    transition-delay: 0s;
    opacity: 1;
  }

  #progress>.bar {
    width: 100%;
    height: 100%;
    background-color: currentColor;
    transform-origin: top left;
    transform: scaleX(0);
  }
</style>

<!-- ... -->

<model-viewer src="./any.gltf">
  <div id="progress" slot="progress-bar">
    <div class="bar"></div>
  </div>
</model-viewer>

<script>
  const modelViewer = document.querySelector('model-viewer');
  const progress = document.querySelector('#progress');
  const bar = progress.querySelector('.bar');

  modelViewer.addEventListener('progress', (event) => {
    const {totalProgress} = event.detail;
    progress.classList.toggle('show', totalProgress < 1);
    bar.style.transform = `scaleX(${totalProgress})`;
  });
</script>
```

## Future work

 - Use a dynamically colored linear-gradient for progress mask #486 
 - Add CSS custom property details to docs site (@yuinchien is working on this) #488 
 - Make it possible to load environment map lazily #490
 - Make it possible to configure background color with CSS https://github.com/GoogleWebComponents/model-viewer/issues/492
 - A pretty bad Chrome bug related to `delegatesFocus` was discovered in the course of this change [crbug.com/950357](https://bugs.chromium.org/p/chromium/issues/detail?id=950357)

Fixes #335 
Fixes #489 
