### PR TITLE
Update AR glyph

### DIFF
--- a/src/assets/view-in-ar-material-svg.js
+++ b/src/assets/view-in-ar-material-svg.js
@@ -1,14 +1,17 @@
 export default `
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="24px" height="24px" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve" focusable="false" aria-hidden="true">
-<rect fill="none" width="24" height="24"/>
-<g>
-	<path d="M18.25,7.6l-5.5-3.18c-0.46-0.27-1.04-0.27-1.5,0L5.75,7.6C5.29,7.87,5,8.36,5,8.9v6.35c0,0.54,0.29,1.03,0.75,1.3
-		l5.5,3.18c0.46,0.27,1.04,0.27,1.5,0l5.5-3.18c0.46-0.27,0.75-0.76,0.75-1.3V8.9C19,8.36,18.71,7.87,18.25,7.6z M7,14.96v-4.62
-		l4,2.32v4.61L7,14.96z M12,10.93L8,8.61l4-2.31l4,2.31L12,10.93z M13,17.27v-4.61l4-2.32v4.62L13,17.27z"/>
-	<path d="M20.05,20.05H17v1.9h3.45c0.83,0,1.5-0.67,1.5-1.5V17h-1.9V20.05z"/>
-	<path d="M3.95,17h-1.9v3.45c0,0.83,0.67,1.5,1.5,1.5H7v-1.9H3.95V17z"/>
-	<path d="M3.95,3.95H7v-1.9H3.55c-0.83,0-1.5,0.67-1.5,1.5V7h1.9V3.95z"/>
-	<path d="M17,2.05v1.9h3.05V7h1.9V3.55c0-0.83-0.67-1.5-1.5-1.5H17z"/>
+<svg version="1.1" id="view_x5F_in_x5F_AR_x5F_icon"
+	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="24px" height="24px"
+	 viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+<rect id="Bounding_Box" x="0" y="0" fill="none" width="24" height="24"/>
+<g id="Art_layer">
+	<path d="M3,4c0-0.55,0.45-1,1-1h2V1H4C2.35,1,1,2.35,1,4v2h2V4z"/>
+	<path d="M20,3c0.55,0,1,0.45,1,1v2h2V4c0-1.65-1.35-3-3-3h-2v2H20z"/>
+	<path d="M4,21c-0.55,0-1-0.45-1-1v-2H1v2c0,1.65,1.35,3,3,3h2v-2H4z"/>
+	<path d="M20,21c0.55,0,1-0.45,1-1v-2h2v2c0,1.65-1.35,3-3,3h-2v-2H20z"/>
+	<g>
+		<path d="M18.25,7.6l-5.5-3.18c-0.46-0.27-1.04-0.27-1.5,0L5.75,7.6C5.29,7.87,5,8.36,5,8.9v6.35c0,0.54,0.29,1.03,0.75,1.3
+			l5.5,3.18c0.46,0.27,1.04,0.27,1.5,0l5.5-3.18c0.46-0.27,0.75-0.76,0.75-1.3V8.9C19,8.36,18.71,7.87,18.25,7.6z M7,14.96v-4.62
+			l4,2.32v4.61L7,14.96z M12,10.93L8,8.61l4-2.31l4,2.31L12,10.93z M13,17.27v-4.61l4-2.32v4.62L13,17.27z"/>
+	</g>
 </g>
 </svg>`;


### PR DESCRIPTION
This brings our AR glyph up to date with the latest Material version.

Old | New
--- | ---
![image](https://user-images.githubusercontent.com/240083/56769204-595aee00-6765-11e9-87cb-bf764af93188.png) | ![image](https://user-images.githubusercontent.com/240083/56769180-48aa7800-6765-11e9-82d0-9fb8b1681fbd.png)
