### PR TITLE
fixed flex syntax

### DIFF
--- a/src/test/fidelity/components/rendering-scenario.ts
+++ b/src/test/fidelity/components/rendering-scenario.ts
@@ -120,7 +120,7 @@ h2 {
 
 .screenshot > img {
   max-width: 256px;
-  flex: 1;
+  flex: 1 1 auto;
 }
 
 .check {


### PR DESCRIPTION
### Reference Issue
Fixes #511 

Looking at https://www.w3schools.com/cssref/css3_pr_flex.asp, it seems like their example code doesn't really match with their CSS syntax. I changed it from the example way to the CSS way, and it seems to be happy now. If someone has some other browsers handy, it'd be good to double check they all like it too.