### PR TITLE
Model and shadow alignment

### DIFF
--- a/src/features/controls.ts
+++ b/src/features/controls.ts
@@ -22,8 +22,8 @@ import {ChangeEvent, SmoothControls} from '../three-components/SmoothControls.js
 import {Constructor} from '../utilities.js';
 
 export interface SphericalPosition {
-  theta: number;  // equator angle around the y (up) axis. Default is 0.
-  phi: number;    // polar angle from the y (up) axis. Default is 0.
+  theta: number;  // equator angle around the y (up) axis.
+  phi: number;    // polar angle from the y (up) axis.
   radius: number;
 }
 

--- a/src/features/controls.ts
+++ b/src/features/controls.ts
@@ -22,8 +22,8 @@ import {ChangeEvent, SmoothControls} from '../three-components/SmoothControls.js
 import {Constructor} from '../utilities.js';
 
 export interface SphericalPosition {
-  theta: number;
-  phi: number;
+  theta: number;  // equator angle around the y (up) axis. Default is 0.
+  phi: number;    // polar angle from the y (up) axis. Default is 0.
   radius: number;
 }
 
@@ -268,7 +268,7 @@ export const ControlsMixin = (ModelViewerElement:
           controls.applyOptions({minimumRadius, maximumRadius});
           controls.updateFramedHeight(scene.framedHeight);
 
-          controls.target.set(0, 0, 0);
+          controls.target.copy(scene.target);
 
           controls.setRadius(zoom * this[$idealCameraDistance]);
           controls.jumpToDestination();

--- a/src/test/features/staging-spec.ts
+++ b/src/test/features/staging-spec.ts
@@ -25,7 +25,7 @@ const expect = chai.expect;
 const ODD_SHAPE_GLB_PATH = assetPath('odd-shape.glb');
 const CENTER_OFFSET = new Vector3(0.5, 1.0, 0.5);
 const ORIGIN_OFFSET = new Vector3();
-const SIZE = new Vector3(4, 4.5, 4);
+const FRAMED_SIZE = new Vector3(5, 4.5, 5);
 
 suite('ModelViewerElementBase with StagingMixin', () => {
   let nextId = 0;
@@ -79,13 +79,9 @@ suite('ModelViewerElementBase with StagingMixin', () => {
         });
 
         test('places shadow under a non-centered model', () => {
-          const shadowPosition = (element as any)[$scene].shadow.position;
-          expect(shadowPosition)
-              .to.be.deep.equal(
-                  new Vector3(-CENTER_OFFSET.x, 0, -CENTER_OFFSET.z));
           const shadowSize = (element as any)[$scene].shadow.scale;
-          expect(shadowSize.x).to.be.equal(SIZE.x);
-          expect(shadowSize.z).to.be.equal(SIZE.z);
+          expect(shadowSize.x).to.be.equal(FRAMED_SIZE.x);
+          expect(shadowSize.z).to.be.equal(FRAMED_SIZE.z);
         });
       });
 

--- a/src/test/features/staging-spec.ts
+++ b/src/test/features/staging-spec.ts
@@ -25,6 +25,7 @@ const expect = chai.expect;
 const ODD_SHAPE_GLB_PATH = assetPath('odd-shape.glb');
 const CENTER_OFFSET = new Vector3(0.5, 1.0, 0.5);
 const ORIGIN_OFFSET = new Vector3();
+const SIZE = new Vector3(4, 4.5, 4);
 
 suite('ModelViewerElementBase with StagingMixin', () => {
   let nextId = 0;
@@ -75,6 +76,16 @@ suite('ModelViewerElementBase with StagingMixin', () => {
           // -0 values as 0
           const offset = (element as any)[$scene].model.position.clone();
           expect(offset).to.be.deep.equal(ORIGIN_OFFSET);
+        });
+
+        test('places shadow under a non-centered model', () => {
+          const shadowPosition = (element as any)[$scene].shadow.position;
+          expect(shadowPosition)
+              .to.be.deep.equal(
+                  new Vector3(-CENTER_OFFSET.x, 0, -CENTER_OFFSET.z));
+          const shadowSize = (element as any)[$scene].shadow.scale;
+          expect(shadowSize.x).to.be.equal(SIZE.x);
+          expect(shadowSize.z).to.be.equal(SIZE.z);
         });
       });
 

--- a/src/test/features/staging-spec.ts
+++ b/src/test/features/staging-spec.ts
@@ -15,15 +15,15 @@
 
 import {Vector3} from 'three';
 
-import {StagingMixin, AUTO_ROTATE_DELAY_AFTER_USER_INTERACTION} from '../../features/staging.js';
-import ModelViewerElementBase, {$scene, $onUserModelOrbit} from '../../model-viewer-base.js';
+import {AUTO_ROTATE_DELAY_AFTER_USER_INTERACTION, StagingMixin} from '../../features/staging.js';
+import ModelViewerElementBase, {$onUserModelOrbit, $scene} from '../../model-viewer-base.js';
 import {assetPath, timePasses, waitForEvent} from '../helpers.js';
 import {BasicSpecTemplate} from '../templates.js';
 
 const expect = chai.expect;
 
 const ODD_SHAPE_GLB_PATH = assetPath('odd-shape.glb');
-const CENTER_OFFSET = new Vector3(0.5, -1.25, 0.5);
+const CENTER_OFFSET = new Vector3(0.5, 1.0, 0.5);
 const ORIGIN_OFFSET = new Vector3();
 
 suite('ModelViewerElementBase with StagingMixin', () => {
@@ -139,7 +139,8 @@ suite('ModelViewerElementBase with StagingMixin', () => {
 
         await timePasses(AUTO_ROTATE_DELAY_AFTER_USER_INTERACTION);
 
-        expect(element.turntableRotation).to.be.greaterThan(initialTurntableRotation);
+        expect(element.turntableRotation)
+            .to.be.greaterThan(initialTurntableRotation);
       });
     });
   });

--- a/src/test/three-components/ModelScene-spec.js
+++ b/src/test/three-components/ModelScene-spec.js
@@ -26,6 +26,7 @@ const expect = chai.expect;
 suite('ModelScene', () => {
   let element;
   let scene;
+  let dummyRadius;
   let dummyMesh;
   let renderer;
   let ModelViewerElement = class extends ModelViewerElementBase {};
@@ -43,7 +44,8 @@ suite('ModelScene', () => {
   setup(() => {
     // Set the radius of the sphere to 0.5 so that it's size is 1
     // for testing scaling.
-    dummyMesh = new Mesh(new SphereBufferGeometry(0.5, 32, 32));
+    dummyRadius = 0.5;
+    dummyMesh = new Mesh(new SphereBufferGeometry(dummyRadius, 32, 32));
     element = new ModelViewerElement();
     scene = new ModelScene({
       element: element,
@@ -138,14 +140,15 @@ suite('ModelScene', () => {
       scene.alignModel();
     });
 
-    test('updates object position to center its volume within box', () => {
+    test('updates object position to center it on the floor', () => {
       scene.setSize(1000, 500);
       dummyMesh.geometry.applyMatrix(new Matrix4().makeTranslation(5, 10, 20));
       scene.model.setObject(dummyMesh);
 
       scene.alignModel();
 
-      expect(scene.model.position).to.be.eql(new Vector3(-5, -10, -20));
+      expect(scene.model.position)
+          .to.be.eql(new Vector3(-5, dummyRadius - 10, -20));
     });
   });
 });

--- a/src/three-components/ModelScene.js
+++ b/src/three-components/ModelScene.js
@@ -317,5 +317,11 @@ export default class ModelScene extends Scene {
     // a generated texture.
     this.pivot.add(this.shadow);
     this.pivot.rotation.y = currentRotation;
+
+    // TODO(#453) When we add a configurable camera target we should put the
+    // floor back at y=0 for a consistent coordinate system.
+    if (this[$modelAlignmentMask].y == 0) {
+      this.shadow.position.y = modelPosition.y - this.model.size.y / 2;
+    }
   }
 }

--- a/src/three-components/ModelScene.js
+++ b/src/three-components/ModelScene.js
@@ -199,23 +199,24 @@ export default class ModelScene extends Scene {
 
     if (this.model.size.x != 0 || this.model.size.y != 0 ||
         this.model.size.z != 0) {
-      let cameraBoundingBox =
-          this.model.boundingBox.clone().translate(this.model.position);
+      const boxHalfX = Math.max(
+          Math.abs(this.model.boundingBox.min.x + this.model.position.x),
+          Math.abs(this.model.boundingBox.max.x + this.model.position.x));
+      const boxHalfZ = Math.max(
+          Math.abs(this.model.boundingBox.min.z + this.model.position.z),
+          Math.abs(this.model.boundingBox.max.z + this.model.position.z));
 
-      const modelMinY = Math.min(0, cameraBoundingBox.min.y);
-      const modelMaxY = Math.max(0, cameraBoundingBox.max.y);
+      const modelMinY =
+          Math.min(0, this.model.boundingBox.min.y + this.model.position.y);
+      const modelMaxY =
+          Math.max(0, this.model.boundingBox.max.y + this.model.position.y);
       this.target.y = this[$modelAlignmentMask].y * (modelMaxY + modelMinY) / 2;
-
-      const mirrorBoundingBox = cameraBoundingBox.clone().translate(
-          cameraBoundingBox.getCenter(new Vector3()).multiplyScalar(-2));
-      cameraBoundingBox.union(mirrorBoundingBox);
-      let boxHalfSize = cameraBoundingBox.max;
-      boxHalfSize.y =
+      const boxHalfY =
           Math.max(modelMaxY - this.target.y, this.target.y - modelMinY);
 
-      this.modelDepth = 2 * Math.max(boxHalfSize.x, boxHalfSize.z);
+      this.modelDepth = 2 * Math.max(boxHalfX, boxHalfZ);
       this.framedHeight = ROOM_PADDING_SCALE *
-          Math.max(2 * boxHalfSize.y, this.modelDepth / this.aspect);
+          Math.max(2 * boxHalfY, this.modelDepth / this.aspect);
       this.modelDepth *= ROOM_PADDING_SCALE;
     }
   }
@@ -307,9 +308,9 @@ export default class ModelScene extends Scene {
     const currentRotation = this.pivot.rotation.y;
     this.pivot.rotation.y = 0;
 
-    const modelPos = this.model.boundingBox.getCenter(new Vector3())
-                         .add(this.model.position);
-    this.shadow.position.set(modelPos.x, 0, modelPos.z);
+    const modelPosition = this.model.boundingBox.getCenter(new Vector3())
+                              .add(this.model.position);
+    this.shadow.position.set(modelPosition.x, 0, modelPosition.z);
     this.shadow.scale.x = this.model.size.x;
     this.shadow.scale.z = this.model.size.z;
 

--- a/src/three-components/ModelScene.js
+++ b/src/three-components/ModelScene.js
@@ -197,19 +197,17 @@ export default class ModelScene extends Scene {
     this.canvas.style.height = `${this.height}px`;
     this.aspect = this.width / this.height;
 
-    if (this.model.size.x != 0 || this.model.size.y != 0 ||
-        this.model.size.z != 0) {
+    const {boundingBox, position, size} = this.model;
+    if (size.x != 0 || size.y != 0 || size.z != 0) {
       const boxHalfX = Math.max(
-          Math.abs(this.model.boundingBox.min.x + this.model.position.x),
-          Math.abs(this.model.boundingBox.max.x + this.model.position.x));
+          Math.abs(boundingBox.min.x + position.x),
+          Math.abs(boundingBox.max.x + position.x));
       const boxHalfZ = Math.max(
-          Math.abs(this.model.boundingBox.min.z + this.model.position.z),
-          Math.abs(this.model.boundingBox.max.z + this.model.position.z));
+          Math.abs(boundingBox.min.z + position.z),
+          Math.abs(boundingBox.max.z + position.z));
 
-      const modelMinY =
-          Math.min(0, this.model.boundingBox.min.y + this.model.position.y);
-      const modelMaxY =
-          Math.max(0, this.model.boundingBox.max.y + this.model.position.y);
+      const modelMinY = Math.min(0, boundingBox.min.y + position.y);
+      const modelMaxY = Math.max(0, boundingBox.max.y + position.y);
       this.target.y = this[$modelAlignmentMask].y * (modelMaxY + modelMinY) / 2;
       const boxHalfY =
           Math.max(modelMaxY - this.target.y, this.target.y - modelMinY);
@@ -310,9 +308,8 @@ export default class ModelScene extends Scene {
 
     const modelPosition = this.model.boundingBox.getCenter(new Vector3())
                               .add(this.model.position);
-    this.shadow.position.set(modelPosition.x, 0, modelPosition.z);
-    this.shadow.scale.x = this.model.size.x;
-    this.shadow.scale.z = this.model.size.z;
+    this.shadow.scale.x = 2 * Math.abs(modelPosition.x) + this.model.size.x;
+    this.shadow.scale.z = 2 * Math.abs(modelPosition.z) + this.model.size.z;
 
     this.shadow.render(this.renderer.renderer, this, this.shadowLight);
 


### PR DESCRIPTION
### Reference Issue
Fixes #520 

As part of fixing the misaligned shadow, I found that our handling of align to origin was a bit confusing. This change makes Y=0 the floor (the plane of the shadow) always, thus centered objects are moved above the floor while objects aligned to origin assume their coordinates also use Y=0 as the floor. Additionally, for non-centered models, we now use a larger framing, such that the model is still in view as it is rotated. 