### PR TITLE
Renderer: Fixed vertical alignment regression.

### DIFF
--- a/src/three-components/Renderer.js
+++ b/src/three-components/Renderer.js
@@ -191,6 +191,7 @@ export default class Renderer extends EventDispatcher {
           this.renderer.domElement,
           0,
           0,
+          this.canvas.height - heightDPR,
           widthDPR,
           heightDPR,
           0,

--- a/src/three-components/Renderer.js
+++ b/src/three-components/Renderer.js
@@ -190,7 +190,6 @@ export default class Renderer extends EventDispatcher {
       context.drawImage(
           this.renderer.domElement,
           0,
-          0,
           this.canvas.height - heightDPR,
           widthDPR,
           heightDPR,


### PR DESCRIPTION
This regression was introduced when upgrading to r104 in #536.

Thanks to @DavidPeicho for investigating and [figuring out](https://github.com/GoogleWebComponents/model-viewer/issues/546#issuecomment-493088841) the [root cause](https://github.com/mrdoob/three.js/pull/13593).

Fixes #546.