### PR TITLE
Fixed missing frames when resizing component

### DIFF
--- a/src/model-viewer-base.ts
+++ b/src/model-viewer-base.ts
@@ -302,7 +302,6 @@ export default class ModelViewerElementBase extends UpdatingElement {
 
   [$onResize](e: {width: number, height: number}) {
     this[$scene].setSize(e.width, e.height);
-    this[$needsRender]();
   }
 
   [$onUserModelOrbit]() {}

--- a/src/three-components/ModelScene.js
+++ b/src/three-components/ModelScene.js
@@ -177,6 +177,11 @@ export default class ModelScene extends Scene {
       // In practice, invocations of setSize are throttled at the element level,
       // so no need to throttle here:
       this.updateFraming();
+      // Render a frame right away
+      this.isDirty = true;
+      this.camera.aspect = this.aspect;
+      this.camera.updateProjectionMatrix();
+      this.renderer.render(performance.now());
     }
   }
 


### PR DESCRIPTION
Before this PR we were setting `scene.isDirty` after resizing and `Renderer` would render it in the next animation frame. That means that we would have to wait up to 16ms until a new frame was rendered so we ended up with a white frame after resizing.

https://model-viewer-tests.glitch.me/resize.html
https://model-viewer-tests.glitch.me/resize-horizontal.html
https://model-viewer-tests.glitch.me/resize-vertical.html

After this PR we are rendering a frame right when the component gets resized.

https://model-viewer-tests.glitch.me/resize-fixed.html
https://model-viewer-tests.glitch.me/resize-horizontal-fixed.html
https://model-viewer-tests.glitch.me/resize-vertical-fixed.html


This PR is built on top of #552.