### PR TITLE
switched HDR env map from half float to RGBM16

### DIFF
--- a/src/three-components/EnvironmentMapGenerator.ts
+++ b/src/three-components/EnvironmentMapGenerator.ts
@@ -152,9 +152,7 @@ export default class EnvironmentMapGenerator extends EventDispatcher {
         uniform samplerCube tCube;
         varying vec3 vWorldDirection;
         void main() {
-          vec4 texColor = textureCube( tCube, vec3( - vWorldDirection.x, vWorldDirection.yz ), 2.0 );
-          vec4 texColorLinear = mapTexelToLinear( texColor );
-          gl_FragColor = linearToOutputTexel( texColorLinear );
+          gl_FragColor = textureCube( tCube, vec3( - vWorldDirection.x, vWorldDirection.yz ), 2.0 );
         }
       `,
       side: BackSide,

--- a/src/three-components/EnvironmentMapGenerator.ts
+++ b/src/three-components/EnvironmentMapGenerator.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import {BackSide, BoxBufferGeometry, CubeCamera, EventDispatcher, HalfFloatType, LinearMipMapLinearFilter, LinearToneMapping, Mesh, MeshBasicMaterial, MeshStandardMaterial, PointLight, RGBAFormat, Scene, ShaderMaterial, Texture, WebGLRenderer, WebGLRenderTargetCube} from 'three';
+import {BackSide, BoxBufferGeometry, CubeCamera, EventDispatcher, LinearMipMapLinearFilter, LinearToneMapping, Mesh, MeshBasicMaterial, MeshStandardMaterial, PointLight, RGBAFormat, RGBM16Encoding, Scene, ShaderMaterial, Texture, UnsignedByteType, WebGLRenderer, WebGLRenderTargetCube} from 'three';
 
 const rendererTextureCache = new Map<WebGLRenderer, Texture>();
 
@@ -126,8 +126,9 @@ export default class EnvironmentMapGenerator extends EventDispatcher {
     scene.add(light5);
 
     this.camera = new CubeCamera(0.1, 100, 256);
-    this.camera.renderTarget.texture.type = HalfFloatType;
+    this.camera.renderTarget.texture.type = UnsignedByteType;
     this.camera.renderTarget.texture.format = RGBAFormat;
+    this.camera.renderTarget.texture.encoding = RGBM16Encoding;
     this.camera.renderTarget.texture.minFilter = LinearMipMapLinearFilter;
     this.camera.renderTarget.texture.generateMipmaps = true;
 
@@ -152,7 +153,8 @@ export default class EnvironmentMapGenerator extends EventDispatcher {
         varying vec3 vWorldDirection;
         void main() {
           vec4 texColor = textureCube( tCube, vec3( - vWorldDirection.x, vWorldDirection.yz ), 2.0 );
-          gl_FragColor = mapTexelToLinear( texColor );
+          vec4 texColorLinear = mapTexelToLinear( texColor );
+          gl_FragColor = linearToOutputTexel( texColorLinear );
         }
       `,
       side: BackSide,
@@ -163,8 +165,9 @@ export default class EnvironmentMapGenerator extends EventDispatcher {
     this.blurScene.add(new Mesh(geometry, this.blurMaterial));
 
     this.blurCamera = new CubeCamera(0.1, 100, 256);
-    this.blurCamera.renderTarget.texture.type = HalfFloatType;
+    this.blurCamera.renderTarget.texture.type = UnsignedByteType;
     this.blurCamera.renderTarget.texture.format = RGBAFormat;
+    this.blurCamera.renderTarget.texture.encoding = RGBM16Encoding;
     this.blurCamera.renderTarget.texture.minFilter = LinearMipMapLinearFilter;
     this.blurCamera.renderTarget.texture.generateMipmaps = true;
 


### PR DESCRIPTION
### Reference Issue
Fixes #565 

It seems some android devices don't support linear interpolation of float or half float textures, which also means they can't generate mipmaps for those. In order to make our generated HDR environment map work on those devices, we convert it to RGBM16, which looks like 8-bit RGBA, but gets 16x dynamic range with only moderate nonlinearity so that linear interpolation still does a reasonably decent job. 

We may be able to extend this approach to RGBELoader to convert that highly nonlinear format into RGBM16 to enable linear interpolation of background images.
