### PR TITLE
[WIP] Interpolate HDR textures

### DIFF
--- a/src/three-components/TextureUtils.js
+++ b/src/three-components/TextureUtils.js
@@ -13,7 +13,8 @@
  * limitations under the License.
  */
 
-import {Cache, CubeTexture, EventDispatcher, GammaEncoding, NearestFilter, RGBEEncoding, TextureLoader} from 'three';
+import {Cache, CubeTexture, EventDispatcher, FloatType, GammaEncoding, LinearEncoding, RGBEEncoding, TextureLoader} from 'three';
+import {LinearFilter} from 'three';
 import {PMREMCubeUVPacker} from 'three/examples/jsm/pmrem/PMREMCubeUVPacker.js';
 import {PMREMGenerator} from 'three/examples/jsm/pmrem/PMREMGenerator.js';
 
@@ -29,6 +30,7 @@ Cache.enabled = true;
 const HDR_FILE_RE = /\.hdr$/;
 const ldrLoader = new TextureLoader();
 const hdrLoader = new RGBELoader();
+hdrLoader.setType(FloatType);
 
 const $cubeGenerator = Symbol('cubeGenerator');
 
@@ -110,9 +112,8 @@ export default class TextureUtils extends EventDispatcher {
       };
 
       if (isHDR) {
-        texture.encoding = RGBEEncoding;
-        texture.minFilter = NearestFilter;
-        texture.magFilter = NearestFilter;
+        texture.encoding = LinearEncoding;
+        texture.generateMipmaps = true;
         texture.flipY = true;
       } else {
         texture.encoding = GammaEncoding;


### PR DESCRIPTION
### Reference Issue
Fixes #528 (also the issue noted in the comments of #565)

I switched the HDR texture loader to load them as float textures instead of RGBE (the code was already there), and for some reason I had to manually toggle generateMipmaps to true, which then got more or less the expected results on desktop (more on that later). However, now on Android the environment is black because I gets an incomplete framebuffer when trying to render the equirectangular environment map into a cubemap. Sadly I haven't found a way to get it to tell me what the CheckFramebufferStatus message is, so if anyone knows how, that'd be great. But considering that it found support for OES_texture_float_linear, it seems like this should all work.

As for the desktop results, I don't think this is physically wrong, but it sure is different, so I figured I'd include a rendering so we can discuss:
![Screenshot from 2019-05-28 16-21-30](https://user-images.githubusercontent.com/1649964/58518619-b54dd380-8164-11e9-8599-5ffe627ec41f.png)



