### PR TITLE
Basic screenshot API via toDataURL

### DIFF
--- a/index.html
+++ b/index.html
@@ -307,6 +307,15 @@
               current animation to the beginning, you should also set the
               currentTime property to 0.</p>
             </li>
+            <li>
+              <div>toDataURL(type, encoderOptions)</div>
+              <p>Returns a screenshot of the current model render in the format
+              specified by <i>type</i> (defaults to image/png). The screenshot is
+              encoded as a data URL string. In formats that support a sliding scale
+              of quality (such as image/jpeg and image/webp) you can also specify a
+              value for <i>encoderOptions</i> between 0 and 1 (<i>encoderOptions</i>
+              defaults to 0.92 otherwise).</p>
+            </li>
           </ul>
 
         </div>

--- a/src/model-viewer-base.ts
+++ b/src/model-viewer-base.ts
@@ -259,6 +259,10 @@ export default class ModelViewerElementBase extends UpdatingElement {
     }
   }
 
+  toDataURL(type?: string, encoderOptions?: number): string {
+    return this[$canvas].toDataURL(type, encoderOptions);
+  }
+
   get[$ariaLabel]() {
     return (this.alt == null || this.alt === 'null') ? this[$defaultAriaLabel] :
                                                        this.alt;

--- a/src/test/model-viewer-base-spec.ts
+++ b/src/test/model-viewer-base-spec.ts
@@ -146,7 +146,7 @@ suite('ModelViewerElementBase', () => {
       });
     });
 
-    suite.only('capturing screenshots', () => {
+    suite('capturing screenshots', () => {
       let element: ModelViewerElementBase;
       setup(async () => {
         element = new ModelViewerElement();

--- a/src/test/model-viewer-base-spec.ts
+++ b/src/test/model-viewer-base-spec.ts
@@ -171,7 +171,8 @@ suite('ModelViewerElementBase', () => {
 
       suite('toDataURL', () => {
         test('produces a URL-compatible string', () => {
-          expect(/^data\:image\//.test(element.toDataURL())).to.be.true;
+          const dataUrlMatcher = /^data\:image\//;
+          expect(dataUrlMatcher.test(element.toDataURL())).to.be.true;
         });
       });
     });

--- a/src/test/model-viewer-base-spec.ts
+++ b/src/test/model-viewer-base-spec.ts
@@ -146,6 +146,36 @@ suite('ModelViewerElementBase', () => {
       });
     });
 
+    suite.only('capturing screenshots', () => {
+      let element: ModelViewerElementBase;
+      setup(async () => {
+        element = new ModelViewerElement();
+
+        // Avoid testing our memory ceiling in CI by limiting the size
+        // of the screenshots we produce in these tests:
+        element.style.width = '64px';
+        element.style.height = '64px';
+
+        document.body.appendChild(element);
+
+        const modelLoads = waitForEvent(element, 'load');
+        element.src = assetPath('cube.gltf');
+        await modelLoads;
+      });
+
+      teardown(() => {
+        if (element.parentNode != null) {
+          element.parentNode.removeChild(element);
+        }
+      });
+
+      suite('toDataURL', () => {
+        test('produces a URL-compatible string', () => {
+          expect(/^data\:image\//.test(element.toDataURL())).to.be.true;
+        });
+      });
+    });
+
     suite('orchestrates rendering', () => {
       let elements: Array<ModelViewerElementBase> = [];
 


### PR DESCRIPTION
This change proposes that we forward invocations of `toDataURL` to our internal `<canvas>` element so that users can take advantage of one of `<canvas>`'s built-in screenshot capabilities without reaching through `<model-viewer>`'s shadow root.

The semantics of `toDataURL` are the same as the native `<canvas>` one. Screenshots will only display what is rendered to the canvas.

~Depends on #586~

Fixes #596 

cc @pushmatrix 