### PR TITLE
Fix for procedural resizing

### DIFF
--- a/src/features/controls.ts
+++ b/src/features/controls.ts
@@ -388,6 +388,9 @@ export const ControlsMixin = (ModelViewerElement:
         [$onResize](event: any) {
           super[$onResize](event);
           this[$updateCamera]();
+          // Render a frame right away
+          this[$scene].isDirty = true;
+          this[$scene].renderer.render(performance.now());
         }
 
         [$onModelLoad](event: any) {

--- a/src/features/controls.ts
+++ b/src/features/controls.ts
@@ -389,7 +389,6 @@ export const ControlsMixin = (ModelViewerElement:
           super[$onResize](event);
           this[$updateCamera]();
           // Render a frame right away
-          this[$scene].isDirty = true;
           this[$scene].renderer.render(performance.now());
         }
 

--- a/src/features/controls.ts
+++ b/src/features/controls.ts
@@ -388,8 +388,6 @@ export const ControlsMixin = (ModelViewerElement:
         [$onResize](event: any) {
           super[$onResize](event);
           this[$updateCamera]();
-          // Render a frame right away
-          this[$scene].renderer.render(performance.now());
         }
 
         [$onModelLoad](event: any) {

--- a/src/model-viewer-base.ts
+++ b/src/model-viewer-base.ts
@@ -320,7 +320,6 @@ export default class ModelViewerElementBase extends UpdatingElement {
 
   [$onResize](e: {width: number, height: number}) {
     this[$scene].setSize(e.width, e.height);
-    this[$needsRender]();
   }
 
   /**

--- a/src/model-viewer-base.ts
+++ b/src/model-viewer-base.ts
@@ -320,6 +320,7 @@ export default class ModelViewerElementBase extends UpdatingElement {
 
   [$onResize](e: {width: number, height: number}) {
     this[$scene].setSize(e.width, e.height);
+    this[$needsRender]();
   }
 
   /**

--- a/src/model-viewer-base.ts
+++ b/src/model-viewer-base.ts
@@ -278,9 +278,6 @@ export default class ModelViewerElementBase extends UpdatingElement {
     const intWidth = parseInt(width, 10);
     const intHeight = parseInt(height, 10);
 
-    this[$container].style.width = `${width}px`;
-    this[$container].style.height = `${height}px`;
-
     if (forceApply || (prevWidth !== intWidth || prevHeight !== intHeight)) {
       this[$onResize]({width: intWidth, height: intHeight});
     }

--- a/src/template.ts
+++ b/src/template.ts
@@ -39,6 +39,8 @@ template.innerHTML = `
 
     .container {
       position: relative;
+      width: 100%;
+      height: 100%;
     }
 
     canvas {

--- a/src/template.ts
+++ b/src/template.ts
@@ -38,9 +38,13 @@ template.innerHTML = `
     }
 
     .container {
+      display: flex;
       position: relative;
+      align-items: center;
+      justify-content: center;
       width: 100%;
       height: 100%;
+      overflow: hidden;
     }
 
     canvas {

--- a/src/three-components/ModelScene.ts
+++ b/src/three-components/ModelScene.ts
@@ -16,7 +16,6 @@
 import {Camera, Color, DirectionalLight, HemisphereLight, Object3D, PerspectiveCamera, Scene, Vector3} from 'three';
 
 import ModelViewerElementBase from '../model-viewer-base.js';
-import {resolveDpr} from '../utilities.js';
 
 import Model from './Model.js';
 import Renderer from './Renderer.js';
@@ -69,6 +68,7 @@ export default class ModelScene extends Scene {
   public modelDepth: number = 1;
   public isVisible: boolean = false;
   public isDirty: boolean = false;
+  public isResized: boolean = true;
   public element: ModelViewerElementBase;
   public context: CanvasRenderingContext2D;
   public exposure: number;
@@ -195,6 +195,14 @@ export default class ModelScene extends Scene {
     if (width !== this.width || height !== this.height) {
       this.width = Math.max(width, 1);
       this.height = Math.max(height, 1);
+
+      // If we were to update the canvas (non-CSS) width/height here, it would
+      // cause the canvas contents to be cleared for a frame. Instead, we set
+      // the "isResized" flag to inform the renderer of the change at render
+      // time.
+      // @see https://github.com/GoogleWebComponents/model-viewer/pull/555
+      this.isResized = true;
+
       // In practice, invocations of setSize are throttled at the element level,
       // so no need to throttle here:
       this.updateFraming();
@@ -210,11 +218,6 @@ export default class ModelScene extends Scene {
    * fov exactly covers the front face of this box when looking down the Z-axis.
    */
   updateFraming() {
-    const dpr = resolveDpr();
-    this.canvas.width = this.width * dpr;
-    this.canvas.height = this.height * dpr;
-    this.canvas.style.width = `${this.width}px`;
-    this.canvas.style.height = `${this.height}px`;
     this.aspect = this.width / this.height;
 
     const {boundingBox, position, size} = this.model;

--- a/src/three-components/ModelScene.ts
+++ b/src/three-components/ModelScene.ts
@@ -76,6 +76,13 @@ export default class ModelScene extends Scene {
   public camera: PerspectiveCamera;
   public activeCamera: Camera;
 
+  onAfterRender = () => {
+    this.isDirty = false;
+    this.isResized = false;
+
+    this.canvas.style.width = `${this.width}px`;
+    this.canvas.style.height = `${this.height}px`;
+  };
 
   /**
    * @param {ModelViewerElementBase} options.element
@@ -304,6 +311,7 @@ export default class ModelScene extends Scene {
   setCamera(camera: Camera) {
     this.activeCamera = camera;
   }
+
 
   /**
    * Called when the model's contents have loaded, or changed.

--- a/src/three-components/Renderer.ts
+++ b/src/three-components/Renderer.ts
@@ -164,7 +164,7 @@ export default class Renderer extends EventDispatcher {
     }
 
     for (let scene of this.scenes) {
-      const {element, width, height, context} = scene;
+      const {element, width, height, context, canvas} = scene;
       element[$tick](t, delta);
 
       if (!scene.isVisible || !scene.isDirty || scene.paused) {
@@ -194,6 +194,12 @@ export default class Renderer extends EventDispatcher {
 
       const widthDPR = width * dpr;
       const heightDPR = height * dpr;
+
+      if (scene.isResized) {
+        canvas.width = widthDPR;
+        canvas.height = heightDPR;
+      }
+
       context.drawImage(
           this.renderer.domElement,
           0,
@@ -206,6 +212,7 @@ export default class Renderer extends EventDispatcher {
           heightDPR);
 
       scene.isDirty = false;
+      scene.isResized = false;
     }
     this.lastTick = t;
   }

--- a/src/three-components/Renderer.ts
+++ b/src/three-components/Renderer.ts
@@ -179,6 +179,14 @@ export default class Renderer extends EventDispatcher {
         this.setRendererSize(maxWidth, maxHeight);
       }
 
+      const widthDPR = width * dpr;
+      const heightDPR = height * dpr;
+
+      if (scene.isResized) {
+        canvas.width = widthDPR;
+        canvas.height = heightDPR;
+      }
+
       const {exposure} = scene;
       const exposureIsNumber =
           typeof exposure === 'number' && !(self as any).isNaN(exposure);
@@ -192,14 +200,6 @@ export default class Renderer extends EventDispatcher {
       this.renderer.setViewport(0, 0, width, height);
       this.renderer.render(scene, camera);
 
-      const widthDPR = width * dpr;
-      const heightDPR = height * dpr;
-
-      if (scene.isResized) {
-        canvas.width = widthDPR;
-        canvas.height = heightDPR;
-      }
-
       context.drawImage(
           this.renderer.domElement,
           0,
@@ -210,10 +210,8 @@ export default class Renderer extends EventDispatcher {
           0,
           widthDPR,
           heightDPR);
-
-      scene.isDirty = false;
-      scene.isResized = false;
     }
+
     this.lastTick = t;
   }
 


### PR DESCRIPTION
Fixes #618 

This is an adjustment to #555, which ensures that reframing also occurs before render. Proof it works: https://model-viewer-scratch.glitch.me/resize-fixed.html
