### PR TITLE
Change default interaction policy to always-allow

### DIFF
--- a/index.html
+++ b/index.html
@@ -183,6 +183,14 @@
               any value between 20 and 45 degrees. Defaults to "45deg".</p>
             </li>
             <li>
+              <div>interaction-policy</div>
+              <p>Allows you to change whether the viewer requires focus before interacting with it.
+              If set to "allow-when-focused", the user must focus on the viewer (click / tap)
+              before being able to control it. If set to "always-allow", the user can 
+              control it even if the viewer is not the focused element on the page. 
+              Defaults to "always-allow".</p>
+            </li>
+            <li>
               <div>interaction-prompt</div>
               <p>Allows you to change the conditions under which the visual and
               audible interaction prompt will display. Allowed values are "auto"

--- a/src/features/controls.ts
+++ b/src/features/controls.ts
@@ -32,11 +32,18 @@ export interface SphericalPosition {
 }
 
 export type InteractionPromptStrategy = 'auto'|'when-focused';
+export type InteractionPolicy = 'always-allow'|'allow-when-focused';
 
 const InteractionPromptStrategy:
     {[index: string]: InteractionPromptStrategy} = {
       AUTO: 'auto',
       WHEN_FOCUSED: 'when-focused'
+    };
+
+const InteractionPolicy:
+    {[index: string]: InteractionPolicy} = {
+      ALWAYS: 'always-allow',
+      WHEN_FOCUSED: 'allow-when-focused'
     };
 
 export const DEFAULT_CAMERA_ORBIT = '0deg 75deg auto';
@@ -87,6 +94,7 @@ export interface ControlsInterface {
   cameraOrbit: string;
   fieldOfView: string;
   interactionPrompt: InteractionPromptStrategy;
+  interactionPolicy: InteractionPolicy;
   interactionPromptThreshold: number;
   getCameraOrbit(): SphericalPosition;
   getFieldOfView(): number;
@@ -115,6 +123,10 @@ export const ControlsMixin = (ModelViewerElement:
         @property({type: String, attribute: 'interaction-prompt'})
         interactionPrompt: InteractionPromptStrategy =
             InteractionPromptStrategy.WHEN_FOCUSED;
+
+        @property({type: String, attribute: 'interaction-policy'})
+        interactionPolicy: InteractionPolicy =
+            InteractionPolicy.ALWAYS;
 
         protected[$promptElement]: Element;
 
@@ -205,6 +217,11 @@ export const ControlsMixin = (ModelViewerElement:
             if (this.interactionPrompt === InteractionPromptStrategy.AUTO) {
               this[$waitingToPromptUser] = true;
             }
+          }
+
+          if (changedProperties.has('interactionPolicy')) {
+            const interactionPolicy = this.interactionPolicy;
+            controls.applyOptions({interactionPolicy});
           }
 
           if (changedProperties.has('cameraOrbit')) {

--- a/src/features/controls.ts
+++ b/src/features/controls.ts
@@ -42,7 +42,7 @@ const InteractionPromptStrategy:
 
 const InteractionPolicy:
     {[index: string]: InteractionPolicy} = {
-      ALWAYS: 'always-allow',
+      ALWAYS_ALLOW: 'always-allow',
       WHEN_FOCUSED: 'allow-when-focused'
     };
 
@@ -126,7 +126,7 @@ export const ControlsMixin = (ModelViewerElement:
 
         @property({type: String, attribute: 'interaction-policy'})
         interactionPolicy: InteractionPolicy =
-            InteractionPolicy.ALWAYS;
+            InteractionPolicy.ALWAYS_ALLOW;
 
         protected[$promptElement]: Element;
 

--- a/src/test/features/controls-spec.ts
+++ b/src/test/features/controls-spec.ts
@@ -254,6 +254,18 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
         expect(controls).to.be.ok;
       });
 
+      test('requires focus to interact if policy is set to allow-when-focused', async  () => {
+        element.interactionPolicy = 'allow-when-focused';
+        await timePasses();
+        expect(controls.options.interactionPolicy).to.be.equal('allow-when-focused');
+      });
+
+      test('does not require focus to interact if policy is set to always-allow', async () => {
+        element.interactionPolicy = 'always-allow';
+        await timePasses();
+        expect(controls.options.interactionPolicy).to.be.equal('always-allow');
+      });
+
       test('sets max radius to the camera framed distance', () => {
         const cameraDistance = element[$scene].camera.position.distanceTo(
             element[$scene].model.position);

--- a/src/three-components/SmoothControls.ts
+++ b/src/three-components/SmoothControls.ts
@@ -54,7 +54,7 @@ export const DEFAULT_OPTIONS = Object.freeze<SmoothControlsOptions>({
   minimumFov: 20,
   maximumFov: 45,
   eventHandlingBehavior: 'prevent-all',
-  interactionPolicy: 'allow-when-focused'
+  interactionPolicy: 'always-allow'
 });
 
 const $velocity = Symbol('v');


### PR DESCRIPTION
From all of our user testing it seems clear that requiring focus on mobile to interact is not intuitive. @mrdoob said the same thing over at https://github.com/GoogleWebComponents/model-viewer/issues/479.

I do think we need a better heuristic for mobile (https://github.com/GoogleWebComponents/model-viewer/issues/479), and we should have the interaction policy be configurable (https://github.com/GoogleWebComponents/model-viewer/issues/500), but a sensible default should favor making it easy to interact with.

Thoughts?