### PR TITLE
Make interaction prompt independent of focus

### DIFF
--- a/src/test/features/controls-spec.ts
+++ b/src/test/features/controls-spec.ts
@@ -281,10 +281,12 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
         });
 
         test(
-            'does not prompt users to interact before a model is loaded',
+            'does not prompt users to interact before a model is visible',
             async () => {
               Object.defineProperty(
-                  element, 'loaded', {value: false, configurable: true});
+                  element,
+                  'modelIsVisible',
+                  {value: false, configurable: true});
 
               element.interactionPromptThreshold = 500;
 
@@ -304,7 +306,7 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
                   .to.be.equal(false);
 
               Object.defineProperty(
-                  element, 'loaded', {value: true, configurable: true});
+                  element, 'modelIsVisible', {value: true, configurable: true});
 
               await timePasses(element.interactionPromptThreshold + 100);
 


### PR DESCRIPTION
Fixes #529 

Now the prompt is activated by the interactionPromptThreshold seconds after modelIsVisible, and canceled by a user-interaction, never to be shown again. This also allowed the logic to be simplified quite a bit. I think I may be hitting a small issue with #524, as on a page with several models, like lighting-and-environment.html, once the prompt is up for the first model, it's also up for all the other models, even though they haven't scrolled into view yet. 