### PR TITLE
Opt-in to Quick Look for iOS Chrome

### DIFF
--- a/index.html
+++ b/index.html
@@ -199,6 +199,13 @@
               <p>When poster is also enabled, the model will be downloaded before user action. See <a href="https://github.com/GoogleWebComponents/model-viewer#on-loading">On Loading</a> for more information.</p>
             </li>
             <li>
+              <div>quick-look-browsers</div>
+              <p>Set this attribute to control which iOS browsers will be allowed
+              to launch AR Quick Look on iOS. Allowed values are "safari" and
+              "chrome". You can specify any number of browsers separated by
+              whitespace, for example: "safari chrome". Defaults to "safari".</p>
+            </li>
+            <li>
               <div>reveal</div>
               <p>This attribute controls whether or not the model should be
             automatically revealed when loaded. It currently supports two

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -59,3 +59,7 @@ export const IS_AR_QUICKLOOK_CANDIDATE = (() => {
       tempAnchor.relList && tempAnchor.relList.supports &&
       tempAnchor.relList.supports('ar'));
 })();
+
+// @see https://developer.chrome.com/multidevice/user-agent
+export const IS_IOS_CHROME = IS_IOS && /CriOS\//.test(navigator.userAgent);
+export const IS_IOS_SAFARI = IS_IOS && /Safari\//.test(navigator.userAgent);

--- a/src/conversions.ts
+++ b/src/conversions.ts
@@ -142,9 +142,16 @@ export const deserializeAngleToDeg = (angleString: string): number|null => {
 export const enumerationDeserializer = <T extends string>(allowedNames: T[]) =>
     (valueString: string): Set<T> => {
       try {
-        return new Set(parseValues(valueString)
-                           .map(valueNode => valueNode.value as T)
-                           .filter((name) => allowedNames.indexOf(name) > -1));
+        const names = parseValues(valueString)
+                          .map(valueNode => valueNode.value as T)
+                          .filter((name) => allowedNames.indexOf(name) > -1);
+        // NOTE(cdata): IE11 does not support constructing a Set directly from
+        // an iterable, so we need to manually add all the items:
+        const result = new Set<T>();
+        for (const name of names) {
+          result.add(name);
+        }
+        return result;
       } catch (_error) {
       }
       return new Set();

--- a/src/conversions.ts
+++ b/src/conversions.ts
@@ -118,3 +118,14 @@ export const deserializeAngleToDeg = (angleString: string): number|null => {
 
   return null;
 };
+
+export const enumerationDeserializer = <T extends string>(allowedNames: T[]) =>
+    (valueString: string): Set<T> => {
+      try {
+        return new Set(parseValues(valueString)
+                           .map(valueNode => valueNode.value as T)
+                           .filter((name) => allowedNames.indexOf(name) > -1));
+      } catch (_error) {
+      }
+      return new Set();
+    };

--- a/src/conversions.ts
+++ b/src/conversions.ts
@@ -119,6 +119,26 @@ export const deserializeAngleToDeg = (angleString: string): number|null => {
   return null;
 };
 
+/**
+ * For our purposes, an enumeration is a fixed set of CSS-expression-compatible
+ * names. When serialized, a selected subset of the members may be specified as
+ * whitespace-separated strings. An enumeration deserializer is a function that
+ * parses a serialized subset of an enumeration and returns any members that are
+ * found as a Set.
+ *
+ * The following example will produce a deserializer for the days of the
+ * week:
+ *
+ * const deserializeDaysOfTheWeek = enumerationDeserializer([
+ *   'Monday',
+ *   'Tuesday',
+ *   'Wednesday',
+ *   'Thursday',
+ *   'Friday',
+ *   'Saturday',
+ *   'Sunday'
+ * ]);
+ */
 export const enumerationDeserializer = <T extends string>(allowedNames: T[]) =>
     (valueString: string): Set<T> => {
       try {

--- a/src/features/ar.ts
+++ b/src/features/ar.ts
@@ -101,7 +101,7 @@ const $defaultExitFullscreenButton = Symbol('defaultExitFullscreenButton');
 const $enterARWithWebXR = Symbol('enterARWithWebXR');
 const $canActivateAR = Symbol('canActivateAR');
 const $arMode = Symbol('arMode');
-export const $isAllowedQuickLookBrowser = Symbol('isAllowedBrowser');
+const $isAllowedQuickLookBrowser = Symbol('isAllowedBrowser');
 const $quickLookBrowsers = Symbol('quickLookBrowsers');
 
 const $arButtonContainerClickHandler = Symbol('arButtonContainerClickHandler');

--- a/src/features/ar.ts
+++ b/src/features/ar.ts
@@ -101,7 +101,7 @@ const $defaultExitFullscreenButton = Symbol('defaultExitFullscreenButton');
 const $enterARWithWebXR = Symbol('enterARWithWebXR');
 const $canActivateAR = Symbol('canActivateAR');
 const $arMode = Symbol('arMode');
-const $isAllowedQuickLookBrowser = Symbol('isAllowedBrowser');
+const $canLaunchQuickLook = Symbol('canLaunchQuickLook');
 const $quickLookBrowsers = Symbol('quickLookBrowsers');
 
 const $arButtonContainerClickHandler = Symbol('arButtonContainerClickHandler');
@@ -283,7 +283,7 @@ configuration or device capabilities');
               IS_WEBXR_AR_CANDIDATE && await renderer.supportsPresentation();
           const arViewerCandidate = IS_ANDROID && this.ar;
           const iosQuickLookCandidate = IS_IOS && IS_AR_QUICKLOOK_CANDIDATE &&
-              this[$isAllowedQuickLookBrowser] && !!this.iosSrc;
+              this[$canLaunchQuickLook] && !!this.iosSrc;
 
           const showArButton = unstableWebxrCandidate || arViewerCandidate ||
               iosQuickLookCandidate;
@@ -318,7 +318,7 @@ configuration or device capabilities');
           this.activateAR();
         }
 
-        get[$isAllowedQuickLookBrowser](): boolean {
+        get[$canLaunchQuickLook](): boolean {
           if (IS_IOS_CHROME) {
             return this[$quickLookBrowsers].has('chrome');
           } else if (IS_IOS_SAFARI) {

--- a/src/test/conversions-spec.ts
+++ b/src/test/conversions-spec.ts
@@ -15,7 +15,7 @@
 
 import {Math as ThreeMath} from 'three';
 
-import {deserializeAngleToDeg, deserializeSpherical} from '../conversions.js';
+import {deserializeAngleToDeg, deserializeSpherical, enumerationDeserializer} from '../conversions.js';
 
 const expect = chai.expect;
 
@@ -62,6 +62,37 @@ suite('conversions', () => {
 
     test('allows degress to be used instead of radians', () => {
       expect(deserializeAngleToDeg('1.23deg')).to.be.eql(1.23);
+    });
+  });
+
+  suite('enumerationDeserializer', () => {
+    type Animal = 'elephant'|'octopus'|'chinchilla';
+    let animals: Animal[];
+    let deserializeAnimals: (input: string) => Set<Animal>;
+
+    setup(() => {
+      animals = ['elephant', 'octopus', 'chinchilla'];
+      deserializeAnimals = enumerationDeserializer<Animal>(animals);
+    });
+
+    test('yields the members of the enumeration in the input string', () => {
+      const deserialized = deserializeAnimals('elephant chinchilla');
+      expect(deserialized.size).to.be.equal(2);
+      expect(deserialized.has('elephant')).to.be.true;
+      expect(deserialized.has('chinchilla')).to.be.true;
+    });
+
+    test('filters out non-members of the enumeration', () => {
+      const deserialized = deserializeAnimals('octopus paris');
+      expect(deserialized.size).to.be.equal(1);
+      expect(deserialized.has('octopus')).to.be.true;
+    });
+
+    test('yields an empty set from null input', () => {
+      // tsc would normally warn about null not being accepted
+      // but it is worth ensuring the correct behavior all the same:
+      const deserialized = deserializeAnimals(null as any);
+      expect(deserialized.size).to.be.equal(0);
     });
   });
 });

--- a/src/test/features/ar-spec.ts
+++ b/src/test/features/ar-spec.ts
@@ -14,10 +14,10 @@
  */
 
 import {IS_IOS} from '../../constants.js';
-import {$isAllowedQuickLookBrowser, ARInterface, ARMixin} from '../../features/ar.js';
+import {ARInterface, ARMixin} from '../../features/ar.js';
 import ModelViewerElementBase from '../../model-viewer-base.js';
 import {Constructor} from '../../utilities.js';
-import {assetPath, IOS_CHROME_USER_AGENT, IOS_SAFARI_USER_AGENT, spoofUserAgent, timePasses, waitForEvent} from '../helpers.js';
+import {assetPath, timePasses, waitForEvent} from '../helpers.js';
 import {BasicSpecTemplate} from '../templates.js';
 
 const expect = chai.expect;

--- a/src/test/features/ar-spec.ts
+++ b/src/test/features/ar-spec.ts
@@ -14,10 +14,10 @@
  */
 
 import {IS_IOS} from '../../constants.js';
-import {ARMixin} from '../../features/ar.js';
+import {$isAllowedQuickLookBrowser, ARInterface, ARMixin} from '../../features/ar.js';
 import ModelViewerElementBase from '../../model-viewer-base.js';
 import {Constructor} from '../../utilities.js';
-import {assetPath, timePasses, waitForEvent} from '../helpers.js';
+import {assetPath, IOS_CHROME_USER_AGENT, IOS_SAFARI_USER_AGENT, spoofUserAgent, timePasses, waitForEvent} from '../helpers.js';
 import {BasicSpecTemplate} from '../templates.js';
 
 const expect = chai.expect;
@@ -26,7 +26,7 @@ suite('ModelViewerElementBase with ARMixin', () => {
   suite('when registered', () => {
     let nextId = 0;
     let tagName: string;
-    let ModelViewerElement: Constructor<ModelViewerElementBase>;
+    let ModelViewerElement: Constructor<ModelViewerElementBase&ARInterface>;
 
     setup(() => {
       tagName = `model-viewer-ar-${nextId++}`;
@@ -41,14 +41,21 @@ suite('ModelViewerElementBase with ARMixin', () => {
 
     BasicSpecTemplate(() => ModelViewerElement, () => tagName);
 
+    suite('quick-look-browsers', () => {
+      // TODO(#624,#625): We cannot implement these tests without the ability
+      // to mock our constants
+      test('shows the AR button for allowed browsers');
+      test('hides the AR button for non-allowed browsers');
+    });
+
     suite('with unstable-webxr', () => {
-      let element: ModelViewerElementBase;
+      let element: ModelViewerElementBase&ARInterface;
 
       setup(async () => {
         element = new ModelViewerElement();
         document.body.appendChild(element);
 
-        (element as any).unstableWebxr = true;
+        element.unstableWebxr = true;
         element.src = assetPath('Astronaut.glb');
 
         await waitForEvent(element, 'load');
@@ -61,14 +68,14 @@ suite('ModelViewerElementBase with ARMixin', () => {
       });
 
       test('hides the AR button if not on AR platform', () => {
-        expect((element as any).canActivateAR).to.be.equal(false);
+        expect(element.canActivateAR).to.be.equal(false);
       });
 
       test('shows the AR button if on AR platform');
     });
 
     suite('ios-src', () => {
-      let element: ModelViewerElementBase;
+      let element: ModelViewerElementBase&ARInterface;
 
       setup(async () => {
         element = new ModelViewerElement();
@@ -88,34 +95,34 @@ suite('ModelViewerElementBase with ARMixin', () => {
       if (IS_IOS) {
         suite('on iOS Safari', () => {
           test('hides the AR button', () => {
-            expect((element as any).canActivateAR).to.be.equal(false);
+            expect(element.canActivateAR).to.be.equal(false);
           });
 
           suite('with an ios-src', () => {
             setup(async () => {
-              (element as any).iosSrc = assetPath('Astronaut.usdz');
+              element.iosSrc = assetPath('Astronaut.usdz');
               await timePasses();
             });
 
             test('shows the AR button', () => {
-              expect((element as any).canActivateAR).to.be.equal(true);
+              expect(element.canActivateAR).to.be.equal(true);
             });
           });
         });
       } else {
         suite('on browsers that are not iOS Safari', () => {
           test('hides the AR button', () => {
-            expect((element as any).canActivateAR).to.be.equal(false);
+            expect(element.canActivateAR).to.be.equal(false);
           });
 
           suite('with an ios-src', () => {
             setup(async () => {
-              (element as any).iosSrc = assetPath('Astronaut.usdz');
+              element.iosSrc = assetPath('Astronaut.usdz');
               await timePasses();
             });
 
             test('still hides the AR button', () => {
-              expect((element as any).canActivateAR).to.be.equal(false);
+              expect(element.canActivateAR).to.be.equal(false);
             });
           });
         });


### PR DESCRIPTION
 - It is now possible to opt-in or -out of Quick Look integration for a set of known browsers
 - Currently only "chrome" and "safari" are supported values
 - 🚨**BREAKING CHANGE**: iOS Chrome is now opt-in by default (previously it was enabled by default, with no way to opt-out)
 - To achieve the behavior before this change, use the following configuration: `<model-viewer quick-look-browsers="safari chrome"></model-viewer>`
 - Other browsers are not included because we don't test for them and don't currently know if they even integrate with Quick Look (#627)
 - Currently tests targeting specific browsers are prohibitively difficult to write due to how we set constants (#624, #625)

Fixes #534 