### PR TITLE
Ensure model visibility works when element not renderable

### DIFF
--- a/src/test/features/loading-spec.ts
+++ b/src/test/features/loading-spec.ts
@@ -178,6 +178,34 @@ suite('ModelViewerElementBase with LoadingMixin', () => {
         });
       });
 
+      suite('when element starts in non-rendered state', () => {
+        setup(() => {
+          element.style.display = 'none';
+        });
+
+        suite('model-visibility event', () => {
+          test('is dispatched', async () => {
+            const modelBecomesVisible =
+                waitForEvent(element, 'model-visibility');
+            element.src = ASTRONAUT_GLB_PATH;
+            await modelBecomesVisible;
+          });
+        });
+
+        suite('modelIsVisible', () => {
+          test(
+              'is true when the element eventually becomes renderable',
+              async () => {
+                const modelBecomesVisible =
+                    waitForEvent(element, 'model-visibility');
+                element.src = ASTRONAUT_GLB_PATH;
+                await modelBecomesVisible;
+                element.style.display = 'block';
+                expect(element.modelIsVisible).to.be.equal(true);
+              });
+        });
+      });
+
       suite('with loaded model src', () => {
         setup(() => {
           element.src = ASTRONAUT_GLB_PATH;


### PR DESCRIPTION
Previously, we keyed off of CSS transition events to know when to switch model visibility state internally. However, when an element is in a non-renderable state (such as when its layout is collapsed or when its computed CSS `display` property is `none`), transitions don't occur and so the associated events do not fire.

This change adds a check for "renderable" element state. The element is considered renderable if its layout dimensions are greater than 0. If it is renderable, we proceed as before. If it isn't, we perform the necessary side-effects immediately instead of waiting for a transition to complete.

Fixes https://github.com/GoogleWebComponents/model-viewer/issues/524