### PR TITLE
Configuration to raise prompt automatically

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,6 +174,16 @@
               for in-depth details related to this lighting mode.</p>
             </li>
             <li>
+              <div>interaction-prompt</div>
+              <p>Allows you to change the conditions under which the visual and
+              audible interaction prompt will display. Allowed values are "auto"
+              and "when-focused". If set to "auto", the interaction prompt will
+              be displayed as soon as the interaction-prompt-threshold (see below)
+              time has elapsed (after the model is revealed). If set to "when-focused",
+              the interaction prompt will only be activated if the element has
+              first received focus. Defaults to "when-focused".</p>
+            </li>
+            <li>
               <div>interaction-prompt-threshold</div>
               <p>When camera-controls are enabled, &lt;model-viewer&gt; will
               prompt the user visually (and audibly, for screen readers) to

--- a/src/test/features/controls-spec.ts
+++ b/src/test/features/controls-spec.ts
@@ -243,6 +243,16 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
         expect(controls.interactionEnabled).to.be.false;
       });
 
+      suite('interaction-prompt', () => {
+        test('can be configured to raise automatically', async () => {
+          element.interactionPrompt = 'auto';
+          await timePasses(element.interactionPromptThreshold + 100);
+
+          const promptElement: HTMLElement = (element as any)[$promptElement];
+          expect(promptElement.classList.contains('visible')).to.be.equal(true);
+        });
+      });
+
       suite('a11y', () => {
         setup(async () => {
           element.alt = 'A 3D model of a cube';


### PR DESCRIPTION
 - A new `interaction-prompt` attribute is introduced, with two supported values:
   1. **`when-focused`** (default): this is the current behavior, where the threshold is not measured until the element is first focused
   2. **`auto`**:  This enables the behavior described in #529 , and causes the threshold time to be measured as soon as the model is revealed
 - In both cases, the prompt is dismissed by user interaction the same way
 - This change precedes #622 , but in that change `auto` will become the default behavior (and we will possibly also remove `when-focused`)

Fixes #529 