### PR TITLE
Revert "Upgrade to Three.js r105.2"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10361,9 +10361,9 @@
       }
     },
     "three": {
-      "version": "0.105.2",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.105.2.tgz",
-      "integrity": "sha512-L3Al37k4g3hVbgFFS251UVtIc25chhyN0/RvXzR0C+uIBToV6EKDG+MZzEXm9L2miGUVMK27W46/VkP6WUZXMg=="
+      "version": "0.104.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.104.0.tgz",
+      "integrity": "sha512-q617IMBC5k40U2E9UC4/LtmhzTOOLB1jGMIooUL+QrhZ7abiGCSDrKrpCDt9V8RTl6xw+0FYfA1PYsIPKbQOgg=="
     },
     "through": {
       "version": "2.3.8",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
   },
   "dependencies": {
     "lit-element": "^2.0.0",
-    "three": "^0.105.2"
+    "three": "^0.104.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Reverts GoogleWebComponents/model-viewer#641

We need to ship a v0.4.x point release to fix `field-of-view` attribute before shipping v0.5.0.