### PR TITLE
Remove duplicate environment creation

### DIFF
--- a/src/features/environment.ts
+++ b/src/features/environment.ts
@@ -112,15 +112,6 @@ export const EnvironmentMixin = (ModelViewerElement:
           }
         }
 
-        firstUpdated(changedProperties: Map<string, any>) {
-          super.firstUpdated && super.firstUpdated(changedProperties);
-          // In case no environment-related properties were confiured, we should
-          // make sure that the environment is updated at least once:
-          if (this[$cancelEnvironmentUpdate] == null) {
-            this[$updateEnvironment]();
-          }
-        }
-
         [$onModelLoad](event: any) {
           super[$onModelLoad](event);
 

--- a/src/features/environment.ts
+++ b/src/features/environment.ts
@@ -167,6 +167,7 @@ export const EnvironmentMixin = (ModelViewerElement:
             }
 
             this[$applyEnvironmentMap](environmentMap);
+            this[$scene].model.dispatchEvent({type: 'envmap-update'});
           } catch (errorOrPromise) {
             if (errorOrPromise instanceof Error) {
               this[$applyEnvironmentMap](null);

--- a/src/test/features/environment-spec.ts
+++ b/src/test/features/environment-spec.ts
@@ -32,7 +32,7 @@ const UNLIT_MODEL_URL =
 const MULTI_MATERIAL_MODEL_URL = assetPath('Triangle.gltf');
 
 const backgroundHasMap =
-    (scene: Scene, url: string) => {
+    (scene: Scene, url: string|null) => {
       return textureMatchesMeta((scene.background as any).texture, {url: url});
     }
 
@@ -158,6 +158,31 @@ suite('ModelViewerElementBase with EnvironmentMixin', () => {
         await timePasses();
         expect(backgroundHasColor(scene, 'ffffff')).to.be.equal(true);
       });
+
+  suite('with no background-image property', () => {
+    suite('and a src property', () => {
+      setup(async () => {
+        let onLoad = waitForLoadAndEnvMap(scene, element, {url: null});
+        element.src = MODEL_URL;
+        document.body.appendChild(element);
+        await onLoad;
+      });
+
+      teardown(() => {
+        document.body.removeChild(element);
+      });
+
+      test('displays default background', async function() {
+        expect(backgroundHasColor(scene, 'ffffff')).to.be.equal(true);
+      });
+
+      test('applies a generated environment map on model', async function() {
+        expect(modelUsingEnvMap(scene, {
+          url: null,
+        })).to.be.ok;
+      });
+    });
+  });
 
   suite('with a background-image property', () => {
     suite('and a src property', () => {

--- a/src/test/features/environment-spec.ts
+++ b/src/test/features/environment-spec.ts
@@ -160,11 +160,17 @@ suite('ModelViewerElementBase with EnvironmentMixin', () => {
       });
 
   suite('with no background-image property', () => {
+    let environmentChanges = 0;
     suite('and a src property', () => {
       setup(async () => {
         let onLoad = waitForLoadAndEnvMap(scene, element, {url: null});
         element.src = MODEL_URL;
         document.body.appendChild(element);
+
+        environmentChanges = 0;
+        scene.model.addEventListener('envmap-update', () => {
+          environmentChanges++;
+        });
         await onLoad;
       });
 
@@ -180,6 +186,10 @@ suite('ModelViewerElementBase with EnvironmentMixin', () => {
         expect(modelUsingEnvMap(scene, {
           url: null,
         })).to.be.ok;
+      });
+
+      test('changes the environment exactly once', async function() {
+        expect(environmentChanges).to.be.eq(1);
       });
     });
   });


### PR DESCRIPTION
Fixes #649 

Our environments were getting loaded twice, once in firstUpdate, and again in update. I think generation only happened once because of three's caching, but reading in the HDR file and running PMREM were both definitely happening twice, and are both quite expensive. I can't see anything going wrong from removing the firstUpdate function, but I'm also not sure why it was there, so please let me know if I've missed some side effect. 