### PR TITLE
Camera change event

### DIFF
--- a/index.html
+++ b/index.html
@@ -359,6 +359,13 @@
 
           <ul class="list-attribute">
             <li>
+              <div>camera-change</div>
+              <p>Fired when the camera position and/or field of view have
+              changed. If the change occurred due to user interaction, the
+              "event.detail.source" property will be set to
+              "user-interaction".</p>
+            </li>
+            <li>
               <div>environment-change</div>
               <p>Fired when the environment has changed. If the environment is
               derived from background-image or environment-image, the image will

--- a/src/features/controls.ts
+++ b/src/features/controls.ts
@@ -17,9 +17,13 @@ import {property} from 'lit-element';
 import {Event, Spherical} from 'three';
 
 import {deserializeAngleToDeg, deserializeSpherical} from '../conversions.js';
-import ModelViewerElementBase, {$ariaLabel, $needsRender, $onModelLoad, $onResize, $onUserModelOrbit, $scene, $tick} from '../model-viewer-base.js';
-import {ChangeEvent, SmoothControls} from '../three-components/SmoothControls.js';
+import ModelViewerElementBase, {$ariaLabel, $needsRender, $onModelLoad, $onResize, $scene, $tick} from '../model-viewer-base.js';
+import {ChangeEvent, ChangeSource, SmoothControls} from '../three-components/SmoothControls.js';
 import {Constructor} from '../utilities.js';
+
+export interface CameraChangeDetails {
+  source: ChangeSource;
+}
 
 export interface SphericalPosition {
   theta: number;  // equator angle around the y (up) axis.
@@ -430,12 +434,13 @@ export const ControlsMixin = (ModelViewerElement:
           this[$updateAria]();
           this[$needsRender]();
 
-          if (source === 'user-interaction') {
-            if (this.interactionPrompt === InteractionPromptStrategy.AUTO) {
-              this[$deferInteractionPrompt]();
-            }
-            this[$onUserModelOrbit]();
+          if (source === ChangeSource.USER_INTERACTION &&
+              this.interactionPrompt === InteractionPromptStrategy.AUTO) {
+            this[$deferInteractionPrompt]();
           }
+
+          this.dispatchEvent(new CustomEvent<CameraChangeDetails>(
+              'camera-change', {detail: {source}}));
         }
       }
 

--- a/src/model-viewer-base.ts
+++ b/src/model-viewer-base.ts
@@ -323,9 +323,6 @@ export default class ModelViewerElementBase extends UpdatingElement {
     this[$needsRender]();
   }
 
-  [$onUserModelOrbit]() {
-  }
-
   /**
    * Parses the element for an appropriate source URL and
    * sets the views to use the new model based off of the `preload`

--- a/src/test/features/controls-spec.ts
+++ b/src/test/features/controls-spec.ts
@@ -271,7 +271,9 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
           const cameraChangeDispatches =
               waitForEvent<CustomEvent<CameraChangeDetails>>(
                   element, 'camera-change');
-          element.focus();
+
+          await rafPasses();
+          element[$canvas].focus();
           interactWith(element[$canvas]);
           const event = await cameraChangeDispatches;
           expect(event.detail.source)

--- a/src/three-components/SmoothControls.ts
+++ b/src/three-components/SmoothControls.ts
@@ -108,8 +108,6 @@ const $handleWheel = Symbol('handleWheel');
 const $handleKey = Symbol('handleKey');
 
 // Constants
-const USER_INTERACTION_CHANGE_SOURCE = 'user-interaction';
-const DEFAULT_INTERACTION_CHANGE_SOURCE = 'none';
 const TOUCH_EVENT_RE = /^touch(start|end|move)$/;
 const KEYBOARD_ORBIT_INCREMENT = Math.PI / 8;
 const DECAY_MILLISECONDS = 50;
@@ -127,6 +125,13 @@ export const KeyCode = {
   DOWN: 40
 };
 
+export type ChangeSource = 'user-interaction'|'none';
+
+export const ChangeSource: {[index: string]: ChangeSource} = {
+  USER_INTERACTION: 'user-interaction',
+  NONE: 'none'
+};
+
 /**
  * ChangEvents are dispatched whenever the camera position or orientation has
  * changed
@@ -136,7 +141,7 @@ export interface ChangeEvent extends Event {
    * determines what was the originating reason for the change event eg user or
    * none
    */
-  source: string,
+  source: ChangeSource,
 }
 
 /**
@@ -515,8 +520,8 @@ export class SmoothControls extends EventDispatcher {
       this.camera.updateProjectionMatrix();
     }
 
-    const source = this[$isUserChange] ? USER_INTERACTION_CHANGE_SOURCE :
-                                         DEFAULT_INTERACTION_CHANGE_SOURCE;
+    const source =
+        this[$isUserChange] ? ChangeSource.USER_INTERACTION : ChangeSource.NONE;
 
     this.dispatchEvent({type: 'change', source});
   }


### PR DESCRIPTION
This change proposes a new, public event `camera-change`, that can be used to observe and respond to changes in the `camera-orbit` and `field-of-view`.

The new event also replaces our internal, ad-hoc coordination with a moving/changing camera.

Fixes #506 