### PR TITLE
Selectively hide focus ring via :focus-visible polyfill support

### DIFF
--- a/POLYFILLS.md
+++ b/POLYFILLS.md
@@ -28,6 +28,7 @@ Feature                    | Chrome | Canary | Safari 12 | Firefox 65 | Edge | I
 Resize Observer[¹](1)      |     ✅ |     ✅ |        ✋ |         ✋ |   ✋ |   ✋ |               ✅
 Intersection Observer[²](2)|     ✅ |     ✅ |        ✋ |         ✅ |   ✅ |   ✋ |               ✅
 Fullscreen API[³](3)       |     ✅ |     ✅ |        ✋ |         ✅ |   ✋ |   ✋ |               ✋
+`:focus-visible`[⁴](4)     |     ✋ |     ✋ |        ✋ |         ✋ |   ✋ |   ✋ |               ✋
 
 These browser features are **optional** and are only needed if you wish to use
 the `unstable-webxr` feature:
@@ -41,6 +42,7 @@ WebXR HitTest API          |     🚫 |     🚧 |        🚫 |         🚫 | 
 [1]: https://github.com/PolymerLabs/model-viewer/blob/master/POLYFILLS.md#regarding-resize-observer
 [2]: https://github.com/PolymerLabs/model-viewer/blob/master/POLYFILLS.md#regarding-intersection-observer
 [3]: https://github.com/PolymerLabs/model-viewer/blob/master/POLYFILLS.md#regarding-fullscreen-api
+[4]: https://github.com/PolymerLabs/model-viewer/blob/master/POLYFILLS.md#regarding-focus-visible
 
 ### Regarding IE 11
 
@@ -65,6 +67,7 @@ The following emerging web platform APIs are *optional*, and will be used by
  - [Resize Observer](https://wicg.github.io/ResizeObserver/) ([CanIUse](https://caniuse.com/#feat=resizeobserver), [Chrome Platform Status](https://www.chromestatus.com/features/5705346022637568))
  - [Intersection Observer](https://w3c.github.io/IntersectionObserver/) ([CanIUse](https://caniuse.com/#feat=intersectionobserver), [Chrome Platform Status](https://www.chromestatus.com/features/5695342691483648))
  - [Fullscreen API](https://fullscreen.spec.whatwg.org/) ([CanIUse](https://caniuse.com/#feat=fullscreen), [Chrome Platform Status](https://www.chromestatus.com/features/6596356319739904))
+ - [`:focus-visible`]() ([CanIUse](https://caniuse.com/#feat=css-focus-visible), [Chrome Platform Status](https://chromestatus.com/features/5823526732824576))
 
 Additionally, the following _highly experimental and volatile_ APIs are needed
 to enable in-browser AR (currently available in Chrome Canary only):
@@ -82,6 +85,7 @@ fine. The following is a selection of recommended polyfill implementations:
  - [Resize Observer Polyfill](https://github.com/que-etc/resize-observer-polyfill)
  - [Intersection Observer Polyfill](https://github.com/w3c/IntersectionObserver/tree/master/polyfill)
  - [Fullscreen Polyfill](https://github.com/nguyenj/fullscreen-polyfill)
+ - [`:focus-visible` Polyfill](https://github.com/WICG/focus-visible)
 
 Please keep in mind that your mileage may vary depending on the browsers you
 need to support and the fidelity of the polyfills used.
@@ -129,6 +133,21 @@ general performance characteristics of `<model-viewer>` will be worse overall.
 Unlike Resize Observer, there is not fallback for Intersection Observer unles
 you use a polyfill.
 
+### Regarding `:focus-visible`
+
+`:focus-visible` is an as-yet unimplemented web platform feature that enables
+content authors to style a component on the condition that it received focus in
+such a way that suggests the focus state should be visibly evident.
+
+The `:focus-visible` capability has not been implemented in any stable browsers
+yet. If [the polyfill][6] is available on the page, `<model-viewer>` will use it
+and only display focus rings when `:focus-visible` should apply.
+
+Check out [this related MDN][5] article for more details on `:focus-visible`.
+
+[5]: https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible
+[6]: https://github.com/WICG/focus-visible
+
 ## Usage Example
 
 If you are using the polyfills recommended above, you can install them with
@@ -163,6 +182,9 @@ the rest of your application code:
 
     <!-- 💁 OPTIONAL: Fullscreen polyfill is required for experimental AR features in Canary -->
     <script src="./node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>
+
+    <!-- 💁 OPTIONAL: The :focus-visible polyfill removes the focus ring for some input types -->
+    <script src="./node_modules/focus-visible/dist/focus-visible.js" defer></script>
 
     <!-- 💁 OPTIONAL: Include prismatic.js for Magic Leap support -->
     <!--<script src="./node_modules/@magicleap/prismatic/prismatic.min.js"></script>-->
@@ -208,6 +230,9 @@ recommended polyfills and `<model-viewer>`:
 
     <!-- 💁 OPTIONAL: Fullscreen polyfill is required for experimental AR features in Canary -->
     <script src="https://unpkg.com/fullscreen-polyfill@1.0.2/dist/fullscreen.polyfill.js"></script>
+
+    <!-- 💁 OPTIONAL: The :focus-visible polyfill removes the focus ring for some input types -->
+    <script src="https://unpkg.com/focus-visible@5.0.1/dist/focus-visible.js" defer></script>
 
     <!-- 💁 OPTIONAL: Include prismatic.js for Magic Leap support -->
     <!--<script src="https://unpkg.com/@magicleap/prismatic@0.18.2/prismatic.min.js"></script>-->

--- a/examples/animation.html
+++ b/examples/animation.html
@@ -39,6 +39,9 @@
   <!-- 💁 OPTIONAL: Fullscreen polyfill is needed to fully support AR features -->
   <script src="../node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>
 
+  <!-- 💁 OPTIONAL: The :focus-visible polyfill removes the focus ring for some input types -->
+  <script src="../node_modules/focus-visible/dist/focus-visible.js" defer></script>
+
   <!-- 💁 OPTIONAL: Include prismatic.js for Magic Leap support -->
   <!--<script src="../node_modules/@magicleap/prismatic/prismatic.min.js"></script>-->
 

--- a/examples/augmented-reality.html
+++ b/examples/augmented-reality.html
@@ -38,6 +38,9 @@
   <!-- 💁 OPTIONAL: Fullscreen polyfill is needed to fully support AR features -->
   <script src="../node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>
 
+  <!-- 💁 OPTIONAL: The :focus-visible polyfill removes the focus ring for some input types -->
+  <script src="../node_modules/focus-visible/dist/focus-visible.js" defer></script>
+
   <!-- 💁 OPTIONAL: Include prismatic.js for Magic Leap support -->
   <!--<script src="../node_modules/@magicleap/prismatic/prismatic.min.js"></script>-->
 

--- a/examples/fuzzer.html
+++ b/examples/fuzzer.html
@@ -39,6 +39,9 @@
   <!-- 💁 OPTIONAL: Fullscreen polyfill is needed to fully support AR features -->
   <script src="../node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>
 
+  <!-- 💁 OPTIONAL: The :focus-visible polyfill removes the focus ring for some input types -->
+  <script src="../node_modules/focus-visible/dist/focus-visible.js" defer></script>
+
   <!-- 💁 OPTIONAL: Include prismatic.js for Magic Leap support -->
   <!--<script src="../node_modules/@magicleap/prismatic/prismatic.min.js"></script>-->
 

--- a/examples/lazy-loading.html
+++ b/examples/lazy-loading.html
@@ -37,7 +37,10 @@
   <script src="../node_modules/resize-observer-polyfill/dist/ResizeObserver.js"></script>
 
   <!-- 💁 OPTIONAL: Fullscreen polyfill is needed to fully support AR features -->
-  <!--<script src="../node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>-->
+  <script src="../node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>
+
+  <!-- 💁 OPTIONAL: The :focus-visible polyfill removes the focus ring for some input types -->
+  <script src="../node_modules/focus-visible/dist/focus-visible.js" defer></script>
 
   <!-- 💁 OPTIONAL: Include prismatic.js for Magic Leap support -->
   <!--<script src="../node_modules/@magicleap/prismatic/prismatic.min.js"></script>-->

--- a/examples/lighting-and-environment.html
+++ b/examples/lighting-and-environment.html
@@ -39,6 +39,9 @@
   <!-- 💁 OPTIONAL: Fullscreen polyfill is needed to fully support AR features -->
   <script src="../node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>
 
+  <!-- 💁 OPTIONAL: The :focus-visible polyfill removes the focus ring for some input types -->
+  <script src="../node_modules/focus-visible/dist/focus-visible.js" defer></script>
+
   <!-- 💁 OPTIONAL: Include prismatic.js for Magic Leap support -->
   <!--<script src="../node_modules/@magicleap/prismatic/prismatic.min.js"></script>-->
 

--- a/examples/list.html
+++ b/examples/list.html
@@ -38,6 +38,9 @@
   <!-- 💁 OPTIONAL: Fullscreen polyfill is needed to fully support AR features -->
   <script src="../node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>
 
+  <!-- 💁 OPTIONAL: The :focus-visible polyfill removes the focus ring for some input types -->
+  <script src="../node_modules/focus-visible/dist/focus-visible.js" defer></script>
+
   <!-- 💁 OPTIONAL: Include prismatic.js for Magic Leap support -->
   <!--<script src="../node_modules/@magicleap/prismatic/prismatic.min.js"></script>-->
 

--- a/examples/model-formats.html
+++ b/examples/model-formats.html
@@ -38,6 +38,9 @@
   <!-- 💁 OPTIONAL: Fullscreen polyfill is needed to fully support AR features -->
   <script src="../node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>
 
+  <!-- 💁 OPTIONAL: The :focus-visible polyfill removes the focus ring for some input types -->
+  <script src="../node_modules/focus-visible/dist/focus-visible.js" defer></script>
+
   <!-- 💁 OPTIONAL: Include prismatic.js for Magic Leap support -->
   <!--<script src="../node_modules/@magicleap/prismatic/prismatic.min.js"></script>-->
 

--- a/examples/multiple-elements.html
+++ b/examples/multiple-elements.html
@@ -38,6 +38,9 @@
   <!-- 💁 OPTIONAL: Fullscreen polyfill is needed to fully support AR features -->
   <script src="../node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>
 
+  <!-- 💁 OPTIONAL: The :focus-visible polyfill removes the focus ring for some input types -->
+  <script src="../node_modules/focus-visible/dist/focus-visible.js" defer></script>
+
   <!-- 💁 OPTIONAL: Include prismatic.js for Magic Leap support -->
   <!--<script src="../node_modules/@magicleap/prismatic/prismatic.min.js"></script>-->
 

--- a/examples/pbr.html
+++ b/examples/pbr.html
@@ -38,6 +38,9 @@
   <!-- 💁 OPTIONAL: Fullscreen polyfill is needed to fully support AR features -->
   <script src="../node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>
 
+  <!-- 💁 OPTIONAL: The :focus-visible polyfill removes the focus ring for some input types -->
+  <script src="../node_modules/focus-visible/dist/focus-visible.js" defer></script>
+
   <!-- 💁 OPTIONAL: Include prismatic.js for Magic Leap support -->
   <!--<script src="../node_modules/@magicleap/prismatic/prismatic.min.js"></script>-->
 

--- a/examples/rendering-showcase.html
+++ b/examples/rendering-showcase.html
@@ -38,6 +38,9 @@
   <!-- 💁 OPTIONAL: Fullscreen polyfill is needed to fully support AR features -->
   <script src="../node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>
 
+  <!-- 💁 OPTIONAL: The :focus-visible polyfill removes the focus ring for some input types -->
+  <script src="../node_modules/focus-visible/dist/focus-visible.js" defer></script>
+
   <!-- 💁 OPTIONAL: Include prismatic.js for Magic Leap support -->
   <!--<script src="../node_modules/@magicleap/prismatic/prismatic.min.js"></script>-->
 

--- a/examples/staging-and-camera-control.html
+++ b/examples/staging-and-camera-control.html
@@ -39,6 +39,9 @@
   <!-- 💁 OPTIONAL: Fullscreen polyfill is needed to fully support AR features -->
   <script src="node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>
 
+  <!-- 💁 OPTIONAL: The :focus-visible polyfill removes the focus ring for some input types -->
+  <script src="../node_modules/focus-visible/dist/focus-visible.js" defer></script>
+
   <!-- 💁 OPTIONAL: Include prismatic.js for Magic Leap support -->
   <!--<script src="../node_modules/@magicleap/prismatic/prismatic.min.js"></script>-->
 

--- a/index.html
+++ b/index.html
@@ -38,6 +38,9 @@
   <!-- 💁 OPTIONAL: Fullscreen polyfill is needed to fully support AR features -->
   <script src="node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>
 
+  <!-- 💁 OPTIONAL: The :focus-visible polyfill removes the focus ring for some input types -->
+  <script src="node_modules/focus-visible/dist/focus-visible.js" defer></script>
+
   <!-- 💁 OPTIONAL: Include prismatic.js for Magic Leap support -->
   <!--<script src="node_modules/@magicleap/prismatic/prismatic.min.js"></script>-->
 </head>
@@ -439,7 +442,7 @@
             </tr>
           </table>
 
-          <p class="browser-support-desc">These browser features are <b>optional</b> and are only used if available for performance optimization:</p>
+          <p class="browser-support-desc">These browser features are <b>optional</b> and are only used if available for performance optimization or specific features:</p>
           <table class="browser-support">
             <tr>
               <th>Feature</th>
@@ -477,6 +480,16 @@
               <td><img class="icon-check"></td>
               <td><img class="icon-warning"></td>
               <td><img class="icon-check"></td>
+              <td><img class="icon-warning"></td>
+              <td><img class="icon-warning"></td>
+              <td><img class="icon-warning"></td>
+            </tr>
+            <tr>
+              <td>:focus-visible</td>
+              <td><img class="icon-warning"></td>
+              <td><img class="icon-warning"></td>
+              <td><img class="icon-warning"></td>
+              <td><img class="icon-warning"></td>
               <td><img class="icon-warning"></td>
               <td><img class="icon-warning"></td>
               <td><img class="icon-warning"></td>

--- a/package-lock.json
+++ b/package-lock.json
@@ -4271,6 +4271,12 @@
       "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
       "dev": true
     },
+    "focus-visible": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/focus-visible/-/focus-visible-5.0.1.tgz",
+      "integrity": "sha512-xmuzsbC+LsF8iHlbBUvLsM6sfqyeUCAJTq3GK9JboFAdCqdDt/d4XoeE9jWT3cct2NFs/BKZ8IM8Yjkk1wgO3Q==",
+      "dev": true
+    },
     "follow-redirects": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "concurrently": "^4.0.1",
     "cross-os": "^1.3.0",
     "esm": "^3.0.84",
+    "focus-visible": "^5.0.1",
     "fullscreen-polyfill": "^1.0.2",
     "intersection-observer": "^0.5.1",
     "local-web-server": "^2.6.0",

--- a/src/model-viewer.ts
+++ b/src/model-viewer.ts
@@ -22,12 +22,14 @@ import {MagicLeapMixin} from './features/magic-leap.js';
 import {StagingMixin} from './features/staging.js';
 import ModelViewerElementBase from './model-viewer-base.js';
 import {Constructor} from './utilities.js';
+import {FocusVisiblePolyfillMixin} from './utilities/focus-visible.js';
 
 type ModelViewerMixin =
     (ModelViewerElement: Constructor<ModelViewerElementBase>) =>
         Constructor<ModelViewerElementBase>;
 
-const mixins: Array<ModelViewerMixin> = ([
+const mixins = [
+  FocusVisiblePolyfillMixin,
   AnimationMixin,
   LoadingMixin,
   ARMixin,
@@ -35,8 +37,7 @@ const mixins: Array<ModelViewerMixin> = ([
   EnvironmentMixin,
   StagingMixin,
   MagicLeapMixin
-] as Array<ModelViewerMixin>);  // NOTE(cdata): Remove cast when all mixins are
-                                // converted to TypeScript
+];
 
 const ModelViewerElement: Constructor<ModelViewerElementBase> = mixins.reduce(
     (Base: Constructor<ModelViewerElementBase>, Mixin: ModelViewerMixin) =>

--- a/src/template.ts
+++ b/src/template.ts
@@ -28,6 +28,15 @@ template.innerHTML = `
       height: 150px;
     }
 
+    /* NOTE: This ruleset is our integration surface area with the
+     * :focus-visible polyfill.
+     *
+     * @see https://github.com/WICG/focus-visible/pull/196 */
+    :host([data-js-focus-visible]:focus:not(.focus-visible)),
+    :host([data-js-focus-visible]) :focus:not(.focus-visible) {
+      outline: none;
+    }
+
     .container {
       position: relative;
     }

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -25,6 +25,8 @@ import './three-components/TextureUtils-spec.js';
 import './three-components/CachingGLTFLoader-spec.js';
 import './three-components/ModelUtils-spec.js';
 import './utilities/progress-tracker-spec.js';
+import './utilities/timer-spec.js';
+import './utilities/focus-visible-spec.js';
 import './features/animation-spec.js';
 import './features/staging-spec.js';
 import './features/controls-spec.js';

--- a/src/test/utilities/focus-visible.ts
+++ b/src/test/utilities/focus-visible.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import ModelViewerElementBase from '../../model-viewer-base.js';
+import {FocusVisiblePolyfillMixin} from '../../utilities/focus-visible.js';
+import {BasicSpecTemplate} from '../templates.js';
+
+const expect = chai.expect;
+
+suite('ModelViewerElementBase with FocusVisiblePolyfillMixin', () => {
+  let nextId = 0;
+  let tagName: string;
+  let ModelViewerElement: Constructor<ModelViewerElementBase>;
+  let element: ModelViewerElementBase;
+
+  setup(() => {
+    tagName = `model-viewer-focus-visible-${nextId++}`;
+    ModelViewerElement = class extends
+    FocusVisiblePolyfillMixin<Constructor<ModelViewerElementBase>>(
+        ModelViewerElementBase) {
+      static get is() {
+        return tagName;
+      }
+    };
+    customElements.define(tagName, ModelViewerElement);
+  });
+
+  BasicSpecTemplate(() => ModelViewerElement, () => tagName);
+
+  test('typically does not show the focus ring when focused', () => {
+    element = new ModelViewerElement();
+    element.tabIndex = 0;
+    document.body.appendChild(element);
+
+    element.focus();
+
+    expect(element.matches(':focus')).to.be.equal(true);
+    expect(window.getComputedStyle(element).outlineStyle).to.be.equal('none');
+  });
+});

--- a/src/utilities/focus-visible.ts
+++ b/src/utilities/focus-visible.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {Constructor} from '../utilities.js';
+
+export interface OptionalConnnectedCallback {
+  connectedCallback?(): void;
+}
+
+export type MixableBaseClass = HTMLElement&OptionalConnnectedCallback;
+
+/**
+ * This mixin function is designed to be applied to a class that inherits
+ * from HTMLElement. It makes it easy for a custom element to coordinate with
+ * the :focus-visible polyfill.
+ *
+ * NOTE(cdata): The code here was adapted from an example proposed with the
+ * introduction of ShadowDOM support in the :focus-visible polyfill.
+ *
+ * @see https://github.com/WICG/focus-visible/pull/196
+ * @param {Function} SuperClass The base class implementation to decorate with
+ * implementation that coordinates with the :focus-visible polyfill
+ */
+export const FocusVisiblePolyfillMixin =
+    <T extends Constructor<MixableBaseClass>>(SuperClass: T): T => {
+      var coordinateWithPolyfill = function(instance: MixableBaseClass) {
+        // If there is no shadow root, there is no need to coordinate with
+        // the polyfill. If we already coordinated with the polyfill, we can
+        // skip subsequent invokcations:
+        if (instance.shadowRoot == null ||
+            instance.hasAttribute('data-js-focus-visible')) {
+          return;
+        }
+
+        // The polyfill might already be loaded. If so, we can apply it to
+        // the shadow root immediately:
+        if ((self as any).applyFocusVisiblePolyfill) {
+          (self as any).applyFocusVisiblePolyfill(instance.shadowRoot);
+        } else {
+          // Otherwise, wait for the polyfill to be loaded lazily. It might
+          // never be loaded, but if it is then we can apply it to the
+          // shadow root at the appropriate time by waiting for the ready
+          // event:
+          self.addEventListener('focus-visible-polyfill-ready', function() {
+            (self as any).applyFocusVisiblePolyfill(instance.shadowRoot);
+          }, {once: true});
+        }
+      };
+
+      // IE11 doesn't natively support custom elements or JavaScript class
+      // syntax The mixin implementation assumes that the user will take the
+      // appropriate steps to support both:
+      class FocusVisibleCoordinator extends SuperClass {
+        // Attempt to coordinate with the polyfill when connected to the
+        // document:
+        connectedCallback() {
+          super.connectedCallback && super.connectedCallback();
+          coordinateWithPolyfill(this);
+        }
+      };
+
+      return FocusVisibleCoordinator;
+    };

--- a/test/index.html
+++ b/test/index.html
@@ -35,6 +35,9 @@
   <!-- Fullscreen polyfill is required to support WebXR-based AR in stable browsers that support it: -->
   <!--<script src="../node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>-->
 
+  <!-- The :focus-visible polyfill removes the focus ring for some input types -->
+  <script src="node_modules/focus-visible/dist/focus-visible.js" defer></script>
+
   <!-- EventTarget polyfill is *only* needed for running the tests -->
   <script src="../node_modules/@jsantell/event-target/dist/event-target.js"></script>
 


### PR DESCRIPTION
# `:focus-visible` support

This change proposes that we integrate with the `:focus-visible` polyfill (finally possible now that WICG/focus-visible#196 has landed in a release), and rely on its signaling to selectively disable the default focus ring for non-keyboard interactions.

Additional highlights of this change include:
 - The [custom element mixin](https://github.com/cdata/focus-visible/blob/fc33395294dd69ad8af70e822e6176a8893816e2/src/custom-element-mixin.js#L1-L49) originally created as an example for WICG/focus-visible#196 has been adapted and added in our project
 - Docs have been updated to include information on the polyfill and the use case it supports
 - If the polyfill is not included on the page, the focus ring will behave as it did before this change

## Examples

This change, **polyfill not present** on the page |
------------------------------------------------ |
![focusvisible-without-polyfill](https://user-images.githubusercontent.com/240083/60139584-482d5e00-9763-11e9-8148-ccd5e275e09c.gif) |

This change, with `:focus-visible` polyfill |
----------------------------------------- |
![focusvisible-with-polyfill](https://user-images.githubusercontent.com/240083/60139587-4b284e80-9763-11e9-8a17-32f8dd8eae89.gif) |

Fixes #463 