### PR TITLE
Reuse renderer in tests

### DIFF
--- a/src/model-viewer-base.ts
+++ b/src/model-viewer-base.ts
@@ -50,7 +50,6 @@ export const $onModelLoad = Symbol('onModelLoad');
 export const $onResize = Symbol('onResize');
 export const $onUserModelOrbit = Symbol('onUserModelOrbit');
 export const $renderer = Symbol('renderer');
-export const $resetRenderer = Symbol('resetRenderer');
 export const $progressTracker = Symbol('progressTracker');
 
 /**
@@ -69,11 +68,6 @@ export default class ModelViewerElementBase extends UpdatingElement {
     }
 
     return this[$template];
-  }
-
-  static[$resetRenderer]() {
-    renderer.dispose();
-    renderer = new Renderer();
   }
 
   @property({type: String}) alt: string|null = null;

--- a/src/test/templates.ts
+++ b/src/test/templates.ts
@@ -15,7 +15,7 @@
 
 import {Cache} from 'three';
 
-import ModelViewerElementBase, {$resetRenderer} from '../model-viewer-base.js';
+import ModelViewerElementBase from '../model-viewer-base.js';
 import {CachingGLTFLoader} from '../three-components/CachingGLTFLoader.js';
 
 import {timePasses} from './helpers.js';
@@ -30,8 +30,6 @@ export const BasicSpecTemplate =
     (ModelViewerElementAccessor: () => Constructor<ModelViewerElementBase>,
      tagNameAccessor: () => string) => {
       teardown(() => {
-        // Ensure that the renderer is disposed across every test run:
-        ModelViewerElementBase[$resetRenderer]();
         CachingGLTFLoader.clearCache();
         Cache.clear();
       });

--- a/src/test/three-components/ARRenderer-spec.ts
+++ b/src/test/three-components/ARRenderer-spec.ts
@@ -135,7 +135,6 @@ suite('ARRenderer', () => {
   });
 
   teardown(async () => {
-    renderer.dispose();
     await arRenderer.stopPresenting().catch(() => {});
   });
 

--- a/src/test/three-components/ModelScene-spec.ts
+++ b/src/test/three-components/ModelScene-spec.ts
@@ -15,7 +15,7 @@
 
 import {Matrix4, Mesh, Object3D, SphereBufferGeometry, Vector3} from 'three';
 
-import ModelViewerElementBase, {$canvas} from '../../model-viewer-base.js';
+import ModelViewerElementBase, {$canvas, $renderer} from '../../model-viewer-base.js';
 import ModelScene from '../../three-components/ModelScene.js';
 import Renderer from '../../three-components/Renderer.js';
 import {assetPath} from '../helpers.js';
@@ -33,20 +33,13 @@ suite('ModelScene', () => {
 
   customElements.define('model-viewer-modelscene', ModelViewerElement);
 
-  suiteSetup(() => {
-    renderer = new Renderer();
-  });
-
-  suiteTeardown(() => {
-    renderer.dispose();
-  });
-
   setup(() => {
     // Set the radius of the sphere to 0.5 so that it's size is 1
     // for testing scaling.
     dummyRadius = 0.5;
     dummyMesh = new Mesh(new SphereBufferGeometry(dummyRadius, 32, 32));
     element = new ModelViewerElement();
+    renderer = element[$renderer];
     scene = new ModelScene({
       element: element,
       canvas: element[$canvas],

--- a/src/test/three-components/Renderer-spec.ts
+++ b/src/test/three-components/Renderer-spec.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import ModelViewerElementBase, {$canvas, $onResize, $renderer, $resetRenderer} from '../../model-viewer-base.js';
+import ModelViewerElementBase, {$canvas, $onResize, $renderer} from '../../model-viewer-base.js';
 import ModelScene from '../../three-components/ModelScene.js';
 import Renderer from '../../three-components/Renderer.js';
 
@@ -62,10 +62,6 @@ suite('Renderer', () => {
   setup(() => {
     scene = createScene();
     renderer = scene.renderer;
-  });
-
-  teardown(() => {
-    ModelViewerElementBase[$resetRenderer]();
   });
 
   suite('render', () => {


### PR DESCRIPTION
Still working on getting our tests to pass. All those Safari warnings about too many WebGL contexts made me dig in a little. I found this thread https://github.com/pixijs/pixi.js/issues/2233#issuecomment-271924403 which says that Three's renderer.dispose() method only simulates a context being destroyed and there's no guarantee the browsers actually clean up at that point. Everyone seems to think the best answer to create a renderer (and therefore a context) once, and always reuse it. We were doing that everywhere except our tests, so I've updated them, and even on Chrome they run markedly faster. We still create and (try to) destroy a few in tests that don't involve an element. I'm not sure if it's worth it to try and make those share a renderer too.

