### PR TITLE
Default stage light to zero

### DIFF
--- a/src/features/environment.ts
+++ b/src/features/environment.ts
@@ -16,7 +16,6 @@
 import {property} from 'lit-element';
 import {Color, Texture} from 'three';
 import ModelViewerElementBase, {$container, $needsRender, $onModelLoad, $progressTracker, $renderer, $scene} from '../model-viewer-base.js';
-import {IlluminationRole} from '../three-components/ModelScene.js';
 import {Constructor, deserializeUrl} from '../utilities.js';
 
 export interface EnvironmentInterface {
@@ -32,7 +31,7 @@ export interface EnvironmentInterface {
 const DEFAULT_BACKGROUND_COLOR = '#ffffff';
 const DEFAULT_SHADOW_INTENSITY = 0.0;
 const DEFAULT_EXPOSURE = 1.0;
-const DEFAULT_STAGE_LIGHT_INTENSITY = 1.0;
+const DEFAULT_STAGE_LIGHT_INTENSITY = 0.0;
 const DEFAULT_ENVIRONMENT_INTENSITY = 1.0;
 
 const $currentEnvironmentMap = Symbol('currentEnvironmentMap');
@@ -206,11 +205,8 @@ export const EnvironmentMixin = (ModelViewerElement:
 
         private[$updateLighting]() {
           const scene = this[$scene];
-          const illuminationRole = IlluminationRole.Secondary;
-          scene.configureStageLighting(
-              this.stageLightIntensity, illuminationRole);
-          scene.model.setEnvironmentMapIntensity(
-              this.environmentIntensity * 0.65);
+          scene.configureStageLighting(this.stageLightIntensity);
+          scene.model.setEnvironmentMapIntensity(this.environmentIntensity);
         }
 
         private[$deallocateTextures]() {

--- a/src/test/features/environment-spec.ts
+++ b/src/test/features/environment-spec.ts
@@ -361,7 +361,7 @@ suite('ModelViewerElementBase with EnvironmentMixin', () => {
       element.stageLightIntensity = 0.5;
       await timePasses();
       const newLightIntensity = scene.shadowLight.intensity;
-      expect(newLightIntensity).to.be.lessThan(originalLightIntensity);
+      expect(newLightIntensity).to.be.greaterThan(originalLightIntensity);
     });
   });
 

--- a/src/three-components/EnvironmentMapGenerator.ts
+++ b/src/three-components/EnvironmentMapGenerator.ts
@@ -93,35 +93,41 @@ export default class EnvironmentMapGenerator extends EventDispatcher {
     scene.add(box6);
 
 
-    // -z right
+    // -x right
     const light1 = new Mesh(geometry, this.createAreaLightMaterial(50));
     light1.position.set(-16.116, 14.37, 8.208);
     light1.scale.set(0.1, 2.428, 2.739);
     scene.add(light1);
 
-    // -z left
+    // -x left
     const light2 = new Mesh(geometry, this.createAreaLightMaterial(50));
     light2.position.set(-16.109, 18.021, -8.207);
     light2.scale.set(0.1, 2.425, 2.751);
     scene.add(light2);
 
-    // +z
+    // +x
     const light3 = new Mesh(geometry, this.createAreaLightMaterial(17));
     light3.position.set(14.904, 12.198, -1.832);
     light3.scale.set(0.15, 4.265, 6.331);
     scene.add(light3);
 
-    // +x
+    // +z
     const light4 = new Mesh(geometry, this.createAreaLightMaterial(43));
     light4.position.set(-0.462, 8.89, 14.520);
     light4.scale.set(4.38, 5.441, 0.088);
     scene.add(light4);
 
-    // -x
+    // -z
     const light5 = new Mesh(geometry, this.createAreaLightMaterial(20));
     light5.position.set(3.235, 11.486, -12.541);
     light5.scale.set(2.5, 2.0, 0.1);
     scene.add(light5);
+
+    // +y
+    const light6 = new Mesh(geometry, this.createAreaLightMaterial(100));
+    light6.position.set(0.0, 20.0, 0.0);
+    light6.scale.set(1.0, 0.1, 1.0);
+    scene.add(light6);
 
     this.camera = new CubeCamera(0.1, 100, 256);
     this.camera.renderTarget.texture.type = HalfFloatType;

--- a/src/three-components/ModelScene.ts
+++ b/src/three-components/ModelScene.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import {Camera, Color, DirectionalLight, HemisphereLight, Object3D, PerspectiveCamera, Scene, Vector3} from 'three';
+import {Camera, Color, DirectionalLight, Object3D, PerspectiveCamera, Scene, Vector3} from 'three';
 
 import ModelViewerElementBase from '../model-viewer-base.js';
 import {resolveDpr} from '../utilities.js';
@@ -37,12 +37,6 @@ export const IlluminationRole: {[index: string]: IlluminationRole} = {
   Secondary: 'secondary'
 };
 
-const AMBIENT_LIGHT_LOW_INTENSITY = 0.0;
-const DIRECTIONAL_LIGHT_LOW_INTENSITY = 2.0;
-
-const AMBIENT_LIGHT_HIGH_INTENSITY = 3.0;
-const DIRECTIONAL_LIGHT_HIGH_INTENSITY = 4.0;
-
 const $paused = Symbol('paused');
 const $modelAlignmentMask = Symbol('modelAlignmentMask');
 
@@ -58,7 +52,6 @@ export default class ModelScene extends Scene {
   private aspect: number;
 
   public canvas: HTMLCanvasElement;
-  public light: HemisphereLight;
   public renderer: Renderer;
   public shadowLight: DirectionalLight;
   public shadow: StaticShadow;
@@ -97,16 +90,8 @@ export default class ModelScene extends Scene {
 
     this.model = new Model();
     this.shadow = new StaticShadow();
-    this.light =
-        new HemisphereLight(0xBBBBBB, 0x444444, AMBIENT_LIGHT_HIGH_INTENSITY);
-    this.light.name = 'HemisphereLight';
-    this.light.position.set(2, 4, 2);
 
-    // This light is only for generating (fake) shadows
-    // and does not needed to be added to the scene.
-    // @see StaticShadow.js
-    this.shadowLight =
-        new DirectionalLight(0xffffff, DIRECTIONAL_LIGHT_HIGH_INTENSITY);
+    this.shadowLight = new DirectionalLight(0xffffff, 1.0);
     this.shadowLight.position.set(0, 10, 0);
     this.shadowLight.name = 'ShadowLight';
 
@@ -123,7 +108,6 @@ export default class ModelScene extends Scene {
     this.pivot.name = 'Pivot';
 
     this.add(this.pivot);
-    this.add(this.light);
     this.add(this.shadowLight);
     this.pivot.add(this.model);
 
@@ -237,16 +221,8 @@ export default class ModelScene extends Scene {
     }
   }
 
-  configureStageLighting(
-      intensityScale: number, illuminationRole: IlluminationRole) {
-    this.light.intensity = intensityScale *
-        (illuminationRole === IlluminationRole.Primary ?
-             AMBIENT_LIGHT_HIGH_INTENSITY :
-             AMBIENT_LIGHT_LOW_INTENSITY);
-    this.shadowLight.intensity = intensityScale *
-        (illuminationRole === IlluminationRole.Primary ?
-             DIRECTIONAL_LIGHT_HIGH_INTENSITY :
-             DIRECTIONAL_LIGHT_LOW_INTENSITY);
+  configureStageLighting(intensityScale: number) {
+    this.shadowLight.intensity = intensityScale;
     this.isDirty = true;
   }
 


### PR DESCRIPTION
### Reference Issue
Fixes #396 

In addition to changing the default, I removed the hemisphere light as I believe its only purpose was to hide an old LDR environment lighting bug that has since been fixed. I also removed all the arbitrary constants I could find relating to lighting. 

I also added a top-light to our environment generation to take the place of our default stage light, but we'll need to update our fidelity tests to properly compare.