### PR TITLE
Magic Leap / Prismatic example updates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -16,7 +16,7 @@ https://glitch.com/edit/#!/model-viewer
 - [ ] Chrome
 - [ ] Edge
 - [ ] Firefox
-- [ ] Helios
+- [ ] Helio
 - [ ] IE
 - [ ] Safari
 

--- a/examples/augmented-reality.html
+++ b/examples/augmented-reality.html
@@ -42,7 +42,7 @@
   <script src="../node_modules/focus-visible/dist/focus-visible.js" defer></script>
 
   <!-- 💁 OPTIONAL: Include prismatic.js for Magic Leap support -->
-  <!--<script src="../node_modules/@magicleap/prismatic/prismatic.min.js"></script>-->
+  <script src="../node_modules/@magicleap/prismatic/prismatic.min.js"></script>
 
 </head>
 <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -650,9 +650,9 @@
       }
     },
     "@magicleap/prismatic": {
-      "version": "0.17.5",
-      "resolved": "https://registry.npmjs.org/@magicleap/prismatic/-/prismatic-0.17.5.tgz",
-      "integrity": "sha512-tnSru/ua7hzQSjI4nj0198BPNQBdj8Sn9yESFOFuNN3cbM6JfvPMOeTNXle7kJ7in9wE6j0WYoaJjratzm94Eg==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@magicleap/prismatic/-/prismatic-0.20.2.tgz",
+      "integrity": "sha512-vmV/3RlVFwR/upnPj8UMrrcdSaDYRXMUW6GB0g47IOq+BEFhdr9D0HddnqcBgrJ0GJPLCo2geE2NsdDH35y9pg==",
       "dev": true
     },
     "@polymer/esm-amd-loader": {
@@ -4404,7 +4404,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4425,12 +4426,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4445,17 +4448,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4572,7 +4578,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4584,6 +4591,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4598,6 +4606,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4605,12 +4614,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4629,6 +4640,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4709,7 +4721,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4721,6 +4734,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4806,7 +4820,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4842,6 +4857,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4861,6 +4877,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4904,12 +4921,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   ],
   "devDependencies": {
     "@jsantell/event-target": "^1.0.0",
-    "@magicleap/prismatic": "^0.17.5",
+    "@magicleap/prismatic": "^0.20.2",
     "@polymer/iron-demo-helpers": "^3.0.2",
     "@polymer/paper-button": "^3.0.1",
     "@polymer/paper-radio-group": "^3.0.1",

--- a/src/features/magic-leap.ts
+++ b/src/features/magic-leap.ts
@@ -111,7 +111,7 @@ export const MagicLeapMixin = (ModelViewerElement:
             this[$mlModel]!.setAttribute('extractable', 'true');
             this[$mlModel]!.setAttribute('extracted-scale', '1');
             this[$mlModel]!.setAttribute(
-                'environment-lighting', 'color-intensity: 2;');
+                'environment-lighting', 'color-intensity: 8;');
 
             if (this.src != null) {
               this[$mlModel]!.setAttribute('src', this.src);

--- a/src/features/magic-leap.ts
+++ b/src/features/magic-leap.ts
@@ -24,7 +24,7 @@ export interface MagicLeapInterface {
 
 const $showMlModel = Symbol('showMlModel');
 const $hideMlModel = Symbol('hideMlModel');
-const $isHeliosBrowser = Symbol('isHeliosBrowser');
+const $isHelioBrowser = Symbol('isHelioBrowser');
 const $mlModel = Symbol('mlModel');
 
 
@@ -53,14 +53,14 @@ export const MagicLeapMixin = (ModelViewerElement:
 
         // NOTE(cdata): Check at construction time because the check is cheap
         // and it makes testing easier
-        private[$isHeliosBrowser]: boolean = self.mlWorld != null;
+        private[$isHelioBrowser]: boolean = self.mlWorld != null;
 
         private[$mlModel]: HTMLElement|null = null;
 
         updated(changedProperties: Map<string, any>) {
           super.updated(changedProperties);
 
-          if (!this[$isHeliosBrowser]) {
+          if (!this[$isHelioBrowser]) {
             return;
           }
 

--- a/src/features/magic-leap.ts
+++ b/src/features/magic-leap.ts
@@ -36,7 +36,7 @@ const DEFAULT_HOLOGRAM_INLINE_SCALE = 0.65;
 // NOTE(cdata): This probably needs to scale proportionally with the dimensions
 // of the inline model, but we need more experimentation to decide how that
 // should work:
-const DEFAULT_HOLOGRAM_Z_OFFSET = '500px';
+const DEFAULT_HOLOGRAM_Z_OFFSET = '300px';
 
 /**
  * In order to use Magic Leap support, please include prismatic.js in your

--- a/src/test/features/magic-leap-spec.ts
+++ b/src/test/features/magic-leap-spec.ts
@@ -68,7 +68,7 @@ suite('ModelViewerElementBase with MagicLeapMixin', () => {
         });
       });
 
-      suite('in the Helios browser environment', () => {
+      suite('in the Helio browser environment', () => {
         let element: ModelViewerElementBase&MagicLeapInterface;
 
         setup(async () => {


### PR DESCRIPTION
General fixes for Prismatic compatibility with model viewer.

I noticed that the Prismatic library was commented out of all of the examples, so I re-added it back to augmented-reality.html example and made some updates to improve the display of the model when viewed on Magic Leap.
