### PR TITLE
Hotfix: address fullscreen fallback in Chrome m76

### DIFF
--- a/src/features/ar.ts
+++ b/src/features/ar.ts
@@ -313,6 +313,11 @@ configuration or device capabilities');
 
           if (showArButton) {
             this[$arButtonContainer].classList.add('enabled');
+            // NOTE(cdata): The order of the two click handlers on the "ar
+            // button container" is important, vital to the workaround described
+            // earlier in this file. Reversing their order will cause our Scene
+            // Viewer integration to break.
+            // @see https://github.com/GoogleWebComponents/model-viewer/issues/693
             this[$arButtonContainer].addEventListener(
                 'click', this[$arButtonContainerClickHandler]);
             this[$arButtonContainer].addEventListener(

--- a/src/features/ar.ts
+++ b/src/features/ar.ts
@@ -161,6 +161,13 @@ export const ARMixin = (ModelViewerElement:
             this.shadowRoot!.querySelector('#default-exit-fullscreen-button') as
             HTMLElement;
 
+        // NOTE(cdata): We use a second, separate "fallback" click handler in
+        // order to work around a regression in how Chrome on Android behaves
+        // when requesting fullscreen at the same time as triggering an intent.
+        // As of m76, intents could no longer be triggered successfully if they
+        // were dispatched in the same handler as the fullscreen request. The
+        // workaround is to split both effects into their own event handlers.
+        // @see https://github.com/GoogleWebComponents/model-viewer/issues/693
         protected[$arButtonContainerFallbackClickHandler] = (event: Event) =>
             this[$onARButtonContainerFallbackClick](event);
 

--- a/src/features/ar.ts
+++ b/src/features/ar.ts
@@ -104,6 +104,10 @@ const $arMode = Symbol('arMode');
 const $canLaunchQuickLook = Symbol('canLaunchQuickLook');
 const $quickLookBrowsers = Symbol('quickLookBrowsers');
 
+const $arButtonContainerFallbackClickHandler =
+    Symbol('arButtonContainerFallbackClickHandler');
+const $onARButtonContainerFallbackClick =
+    Symbol('onARButtonContainerFallbackClick');
 const $arButtonContainerClickHandler = Symbol('arButtonContainerClickHandler');
 const $onARButtonContainerClick = Symbol('onARButtonContainerClick');
 
@@ -157,6 +161,9 @@ export const ARMixin = (ModelViewerElement:
             this.shadowRoot!.querySelector('#default-exit-fullscreen-button') as
             HTMLElement;
 
+        protected[$arButtonContainerFallbackClickHandler] = (event: Event) =>
+            this[$onARButtonContainerFallbackClick](event);
+
         protected[$arButtonContainerClickHandler]: (event: Event) => void =
             (event) => this[$onARButtonContainerClick](event);
 
@@ -185,7 +192,6 @@ export const ARMixin = (ModelViewerElement:
               await this[$enterARWithWebXR]();
               break;
             case ARMode.AR_VIEWER:
-              this.requestFullscreen();
               openARViewer(this.src!, this.alt || '');
               break;
             default:
@@ -302,14 +308,24 @@ configuration or device capabilities');
             this[$arButtonContainer].classList.add('enabled');
             this[$arButtonContainer].addEventListener(
                 'click', this[$arButtonContainerClickHandler]);
+            this[$arButtonContainer].addEventListener(
+                'click', this[$arButtonContainerFallbackClickHandler]);
             this[$exitFullscreenButtonContainer].addEventListener(
                 'click', this[$exitFullscreenButtonContainerClickHandler]);
           } else {
             this[$arButtonContainer].removeEventListener(
                 'click', this[$arButtonContainerClickHandler]);
+            this[$arButtonContainer].removeEventListener(
+                'click', this[$arButtonContainerFallbackClickHandler]);
             this[$exitFullscreenButtonContainer].removeEventListener(
                 'click', this[$exitFullscreenButtonContainerClickHandler]);
             this[$arButtonContainer].classList.remove('enabled');
+          }
+        }
+
+        [$onARButtonContainerFallbackClick](_event: Event) {
+          if (this[$arMode] === ARMode.AR_VIEWER) {
+            this.requestFullscreen();
           }
         }
 

--- a/src/template.ts
+++ b/src/template.ts
@@ -243,7 +243,7 @@ template.innerHTML = `
 
     <div class="slot ar-button">
       <slot name="ar-button">
-        <a id="default-ar-button" class="fab" href="#"
+        <a id="default-ar-button" class="fab"
             tabindex="2"
             aria-label="View this 3D model up close">
           ${ARGlyph}


### PR DESCRIPTION
This hotfix addresses a regression in Chrome m76, that causes our "fullscreen fallback" for Scene Viewer to not work as intended. The symptoms of this problem have been documented by several users in #693 . 

The nature of the fix is to split our click handling out into multiple event listeners. We now use two events to attempt fullscreen and trigger the intent respectively.

This "fix" is actually just a workaround for the problem. It preserves our behavior through Chrome m76, but **this workaround doesn't save us from potential future regressions**. The kernel of the problem is that we expect a handled `intent://` URL on Android to cancel a `requestFullscreen()` invocation. There is no spec or other explicit guarantee that this will always be true.

Special thanks go to @azakus for suggesting the workaround.

A related crbug is forthcoming.

Fixes #693 