### PR TITLE
Zoom using FoV

### DIFF
--- a/src/features/controls.ts
+++ b/src/features/controls.ts
@@ -315,8 +315,6 @@ export const ControlsMixin = (ModelViewerElement:
           const controls = this[$controls];
           const framedHeight = scene.framedHeight;
 
-          // Make zoom sensitivity scale with model size:
-          const zoomSensitivity = framedHeight;
           const framedDistance = (framedHeight / 2) /
               Math.tan((controls.getFieldOfView() / 2) * Math.PI / 180);
           const near = framedHeight / 10.0;
@@ -331,7 +329,7 @@ export const ControlsMixin = (ModelViewerElement:
               1;
           this[$idealCameraDistance] = framedDistance + scene.modelDepth / 2;
 
-          controls.updateIntrinsics(near, far, scene.aspect, zoomSensitivity);
+          controls.updateIntrinsics(near, far, scene.aspect);
 
           // Zooming out beyond the 'frame' doesn't serve much purpose
           // and will only end up showing the skysphere if zoomed out enough

--- a/src/features/controls.ts
+++ b/src/features/controls.ts
@@ -40,11 +40,10 @@ const InteractionPromptStrategy:
       WHEN_FOCUSED: 'when-focused'
     };
 
-const InteractionPolicy:
-    {[index: string]: InteractionPolicy} = {
-      ALWAYS_ALLOW: 'always-allow',
-      WHEN_FOCUSED: 'allow-when-focused'
-    };
+const InteractionPolicy: {[index: string]: InteractionPolicy} = {
+  ALWAYS_ALLOW: 'always-allow',
+  WHEN_FOCUSED: 'allow-when-focused'
+};
 
 export const DEFAULT_CAMERA_ORBIT = '0deg 75deg auto';
 const DEFAULT_FIELD_OF_VIEW = '45deg';
@@ -125,8 +124,7 @@ export const ControlsMixin = (ModelViewerElement:
             InteractionPromptStrategy.WHEN_FOCUSED;
 
         @property({type: String, attribute: 'interaction-policy'})
-        interactionPolicy: InteractionPolicy =
-            InteractionPolicy.ALWAYS_ALLOW;
+        interactionPolicy: InteractionPolicy = InteractionPolicy.ALWAYS_ALLOW;
 
         protected[$promptElement]: Element;
 
@@ -318,7 +316,7 @@ export const ControlsMixin = (ModelViewerElement:
           const framedHeight = scene.framedHeight;
 
           // Make zoom sensitivity scale with model size:
-          const zoomSensitivity = framedHeight / 10;
+          const zoomSensitivity = framedHeight;
           const framedDistance = (framedHeight / 2) /
               Math.tan((controls.getFieldOfView() / 2) * Math.PI / 180);
           const near = framedHeight / 10.0;

--- a/src/test/features/controls-spec.ts
+++ b/src/test/features/controls-spec.ts
@@ -204,7 +204,7 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
         });
 
         test('updates with current orbit after interaction', async () => {
-          controls.adjustOrbit(0, 0.5, 0);
+          controls.adjustOrbit(0, 0.5, 0, 0);
           settleControls(controls);
 
           const orbit = element.getCameraOrbit();
@@ -254,17 +254,23 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
         expect(controls).to.be.ok;
       });
 
-      test('requires focus to interact if policy is set to allow-when-focused', async  () => {
-        element.interactionPolicy = 'allow-when-focused';
-        await timePasses();
-        expect(controls.options.interactionPolicy).to.be.equal('allow-when-focused');
-      });
+      test(
+          'requires focus to interact if policy is set to allow-when-focused',
+          async () => {
+            element.interactionPolicy = 'allow-when-focused';
+            await timePasses();
+            expect(controls.options.interactionPolicy)
+                .to.be.equal('allow-when-focused');
+          });
 
-      test('does not require focus to interact if policy is set to always-allow', async () => {
-        element.interactionPolicy = 'always-allow';
-        await timePasses();
-        expect(controls.options.interactionPolicy).to.be.equal('always-allow');
-      });
+      test(
+          'does not require focus to interact if policy is set to always-allow',
+          async () => {
+            element.interactionPolicy = 'always-allow';
+            await timePasses();
+            expect(controls.options.interactionPolicy)
+                .to.be.equal('always-allow');
+          });
 
       test('sets max radius to the camera framed distance', () => {
         const cameraDistance = element[$scene].camera.position.distanceTo(
@@ -414,13 +420,13 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
               expect(canvas.getAttribute('aria-label'))
                   .to.be.equal('View from stage right');
 
-              controls.adjustOrbit(-Math.PI / 2.0, 0, 0);
+              controls.adjustOrbit(-Math.PI / 2.0, 0, 0, 0);
               settleControls(controls);
 
               expect(canvas.getAttribute('aria-label'))
                   .to.be.equal('View from stage back');
 
-              controls.adjustOrbit(Math.PI, 0, 0);
+              controls.adjustOrbit(Math.PI, 0, 0, 0);
               settleControls(controls);
 
               expect(canvas.getAttribute('aria-label'))
@@ -443,13 +449,13 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
               expect(canvas.getAttribute('aria-label'))
                   .to.be.equal('View from stage upper-front');
 
-              controls.adjustOrbit(0, -Math.PI / 2.0, 0);
+              controls.adjustOrbit(0, -Math.PI / 2.0, 0, 0);
               settleControls(controls);
 
               expect(canvas.getAttribute('aria-label'))
                   .to.be.equal('View from stage front');
 
-              controls.adjustOrbit(0, -Math.PI / 2.0, 0);
+              controls.adjustOrbit(0, -Math.PI / 2.0, 0, 0);
               settleControls(controls);
 
               expect(canvas.getAttribute('aria-label'))

--- a/src/test/features/controls-spec.ts
+++ b/src/test/features/controls-spec.ts
@@ -149,7 +149,7 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
       });
 
       test('defaults FOV correctly', async () => {
-        expect(element.getFieldOfView()).to.be.equal(DEFAULT_FOV);
+        expect(element.getFieldOfView()).to.be.closeTo(DEFAULT_FOV, 0.00001);
       });
 
       test('can independently adjust FOV', async () => {
@@ -162,7 +162,7 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
 
         settleControls(controls);
 
-        expect(element.getFieldOfView()).to.be.equal(nextFov);
+        expect(element.getFieldOfView()).to.be.closeTo(nextFov, 0.00001);
       });
 
       test('causes camera-change event to fire', async () => {
@@ -221,7 +221,7 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
 
           await timePasses();
 
-          expect(element.getFieldOfView()).to.be.equal(fieldOfView);
+          expect(element.getFieldOfView()).to.be.closeTo(fieldOfView, 0.00001);
           const orbit = element.getCameraOrbit();
           expect(`${orbit.theta}rad ${orbit.phi}rad ${orbit.radius}m`)
               .to.equal(cameraOrbit);

--- a/src/test/three-components/SmoothControls-spec.ts
+++ b/src/test/three-components/SmoothControls-spec.ts
@@ -237,6 +237,25 @@ suite('SmoothControls', () => {
         });
       });
 
+      suite('field of view', () => {
+        setup(() => {
+          controls.applyOptions(
+              {minimumFieldOfView: 15, maximumFieldOfView: 20});
+        });
+
+        test('prevents field of view from exceeding options', () => {
+          controls.setFov(5);
+          settleControls(controls);
+
+          expect(controls.getFieldOfView()).to.be.closeTo(15, 0.00001);
+
+          controls.setFov(30);
+          settleControls(controls);
+
+          expect(controls.getFieldOfView()).to.be.closeTo(20, 0.00001);
+        });
+      });
+
       suite('event handling', () => {
         suite('prevent-all', () => {
           setup(() => {
@@ -281,7 +300,7 @@ suite('SmoothControls', () => {
             expect(controls.getCameraSpherical().radius)
                 .to.be.equal(DEFAULT_OPTIONS.minimumRadius);
             expect(controls.getFieldOfView())
-                .to.be.equal(Math.exp(DEFAULT_OPTIONS.maximumLogFov!));
+                .to.be.closeTo(DEFAULT_OPTIONS.maximumFieldOfView!, 0.00001);
 
             dispatchSyntheticEvent(element, 'wheel', {deltaY: -1});
 
@@ -290,7 +309,7 @@ suite('SmoothControls', () => {
             expect(controls.getCameraSpherical().radius)
                 .to.be.equal(DEFAULT_OPTIONS.minimumRadius);
             expect(controls.getFieldOfView())
-                .to.be.equal(Math.exp(DEFAULT_OPTIONS.maximumLogFov!));
+                .to.be.closeTo(DEFAULT_OPTIONS.maximumFieldOfView!, 0.00001);
           });
 
           test('does not orbit when pointing while blurred', () => {
@@ -306,7 +325,7 @@ suite('SmoothControls', () => {
 
           test('does zoom when scrolling while focused', () => {
             expect(controls.getFieldOfView())
-                .to.be.equal(Math.exp(DEFAULT_OPTIONS.maximumLogFov!));
+                .to.be.closeTo(DEFAULT_OPTIONS.maximumFieldOfView!, 0.00001);
 
             element.focus();
 
@@ -315,7 +334,7 @@ suite('SmoothControls', () => {
             settleControls(controls);
 
             expect(controls.getFieldOfView())
-                .to.be.lessThan(Math.exp(DEFAULT_OPTIONS.maximumLogFov!));
+                .to.be.lessThan(DEFAULT_OPTIONS.maximumFieldOfView!);
           });
         });
 
@@ -341,14 +360,14 @@ suite('SmoothControls', () => {
 
           test('zooms when scrolling, even while blurred', () => {
             expect(controls.getFieldOfView())
-                .to.be.equal(Math.exp(DEFAULT_OPTIONS.maximumLogFov!));
+                .to.be.closeTo(DEFAULT_OPTIONS.maximumFieldOfView!, 0.00001);
 
             dispatchSyntheticEvent(element, 'wheel', {deltaY: -1});
 
             settleControls(controls);
 
             expect(controls.getFieldOfView())
-                .to.be.lessThan(Math.exp(DEFAULT_OPTIONS.maximumLogFov!));
+                .to.be.lessThan(DEFAULT_OPTIONS.maximumFieldOfView!);
           });
         });
 

--- a/src/test/three-components/SmoothControls-spec.ts
+++ b/src/test/three-components/SmoothControls-spec.ts
@@ -280,13 +280,17 @@ suite('SmoothControls', () => {
           test('does not zoom when scrolling while blurred', () => {
             expect(controls.getCameraSpherical().radius)
                 .to.be.equal(DEFAULT_OPTIONS.minimumRadius);
+            expect(controls.getFieldOfView())
+                .to.be.equal(Math.exp(DEFAULT_OPTIONS.maximumLogFov!));
 
-            dispatchSyntheticEvent(element, 'wheel');
+            dispatchSyntheticEvent(element, 'wheel', {deltaY: -1});
 
             settleControls(controls);
 
             expect(controls.getCameraSpherical().radius)
                 .to.be.equal(DEFAULT_OPTIONS.minimumRadius);
+            expect(controls.getFieldOfView())
+                .to.be.equal(Math.exp(DEFAULT_OPTIONS.maximumLogFov!));
           });
 
           test('does not orbit when pointing while blurred', () => {
@@ -301,17 +305,17 @@ suite('SmoothControls', () => {
           });
 
           test('does zoom when scrolling while focused', () => {
-            expect(controls.getCameraSpherical().radius)
-                .to.be.equal(DEFAULT_OPTIONS.minimumRadius);
+            expect(controls.getFieldOfView())
+                .to.be.equal(Math.exp(DEFAULT_OPTIONS.maximumLogFov!));
 
             element.focus();
 
-            dispatchSyntheticEvent(element, 'wheel');
+            dispatchSyntheticEvent(element, 'wheel', {deltaY: -1});
 
             settleControls(controls);
 
-            expect(controls.getCameraSpherical().radius)
-                .to.be.greaterThan(DEFAULT_OPTIONS.minimumRadius as number);
+            expect(controls.getFieldOfView())
+                .to.be.lessThan(Math.exp(DEFAULT_OPTIONS.maximumLogFov!));
           });
         });
 
@@ -336,15 +340,15 @@ suite('SmoothControls', () => {
           });
 
           test('zooms when scrolling, even while blurred', () => {
-            expect(controls.getCameraSpherical().radius)
-                .to.be.equal(DEFAULT_OPTIONS.minimumRadius);
+            expect(controls.getFieldOfView())
+                .to.be.equal(Math.exp(DEFAULT_OPTIONS.maximumLogFov!));
 
-            dispatchSyntheticEvent(element, 'wheel');
+            dispatchSyntheticEvent(element, 'wheel', {deltaY: -1});
 
             settleControls(controls);
 
-            expect(controls.getCameraSpherical().radius)
-                .to.be.greaterThan(DEFAULT_OPTIONS.minimumRadius as number);
+            expect(controls.getFieldOfView())
+                .to.be.lessThan(Math.exp(DEFAULT_OPTIONS.maximumLogFov!));
           });
         });
 

--- a/src/three-components/SmoothControls.ts
+++ b/src/three-components/SmoothControls.ts
@@ -426,7 +426,7 @@ export class SmoothControls extends EventDispatcher {
    */
   setFov(fov: number) {
     const {minimumLogFov, maximumLogFov} = this[$options];
-    this[$goalLogFov] = clamp(fov, minimumLogFov!, maximumLogFov!);
+    this[$goalLogFov] = clamp(Math.log(fov), minimumLogFov!, maximumLogFov!);
   }
 
   /**


### PR DESCRIPTION
Fixes #542 

In addition to zooming using FoV instead of radius, I also interpolate using log(FoV) in order to make it perpetually linear (same movement is the same fractional change from any starting point). I also narrowed the minimum so you can get closer to the object, since you can never enter it now.