### PR TITLE
Change interaction prompt default, allow disabling it

### DIFF
--- a/src/features/controls.ts
+++ b/src/features/controls.ts
@@ -31,20 +31,20 @@ export interface SphericalPosition {
   radius: number;
 }
 
-export type InteractionPromptStrategy = 'auto'|'when-focused';
+export type InteractionPromptStrategy = 'auto'|'when-focused'|'none';
 export type InteractionPolicy = 'always-allow'|'allow-when-focused';
 
 const InteractionPromptStrategy:
     {[index: string]: InteractionPromptStrategy} = {
       AUTO: 'auto',
-      WHEN_FOCUSED: 'when-focused'
+      WHEN_FOCUSED: 'when-focused',
+      NONE: 'none'
     };
 
-const InteractionPolicy:
-    {[index: string]: InteractionPolicy} = {
-      ALWAYS_ALLOW: 'always-allow',
-      WHEN_FOCUSED: 'allow-when-focused'
-    };
+const InteractionPolicy: {[index: string]: InteractionPolicy} = {
+  ALWAYS_ALLOW: 'always-allow',
+  WHEN_FOCUSED: 'allow-when-focused'
+};
 
 export const DEFAULT_CAMERA_ORBIT = '0deg 75deg auto';
 const DEFAULT_FIELD_OF_VIEW = '45deg';
@@ -122,11 +122,10 @@ export const ControlsMixin = (ModelViewerElement:
 
         @property({type: String, attribute: 'interaction-prompt'})
         interactionPrompt: InteractionPromptStrategy =
-            InteractionPromptStrategy.WHEN_FOCUSED;
+            InteractionPromptStrategy.AUTO;
 
         @property({type: String, attribute: 'interaction-policy'})
-        interactionPolicy: InteractionPolicy =
-            InteractionPolicy.ALWAYS_ALLOW;
+        interactionPolicy: InteractionPolicy = InteractionPolicy.ALWAYS_ALLOW;
 
         protected[$promptElement]: Element;
 
@@ -269,7 +268,8 @@ export const ControlsMixin = (ModelViewerElement:
         [$tick](time: number, delta: number) {
           super[$tick](time, delta);
 
-          if (this[$waitingToPromptUser]) {
+          if (this[$waitingToPromptUser] &&
+              this.interactionPrompt !== InteractionPromptStrategy.NONE) {
             if (this.loaded) {
               this[$idleTime] += delta;
             }

--- a/src/test/features/controls-spec.ts
+++ b/src/test/features/controls-spec.ts
@@ -254,17 +254,23 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
         expect(controls).to.be.ok;
       });
 
-      test('requires focus to interact if policy is set to allow-when-focused', async  () => {
-        element.interactionPolicy = 'allow-when-focused';
-        await timePasses();
-        expect(controls.options.interactionPolicy).to.be.equal('allow-when-focused');
-      });
+      test(
+          'requires focus to interact if policy is set to allow-when-focused',
+          async () => {
+            element.interactionPolicy = 'allow-when-focused';
+            await timePasses();
+            expect(controls.options.interactionPolicy)
+                .to.be.equal('allow-when-focused');
+          });
 
-      test('does not require focus to interact if policy is set to always-allow', async () => {
-        element.interactionPolicy = 'always-allow';
-        await timePasses();
-        expect(controls.options.interactionPolicy).to.be.equal('always-allow');
-      });
+      test(
+          'does not require focus to interact if policy is set to always-allow',
+          async () => {
+            element.interactionPolicy = 'always-allow';
+            await timePasses();
+            expect(controls.options.interactionPolicy)
+                .to.be.equal('always-allow');
+          });
 
       test('sets max radius to the camera framed distance', () => {
         const cameraDistance = element[$scene].camera.position.distanceTo(
@@ -294,6 +300,15 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
       });
 
       suite('interaction-prompt', () => {
+        test('can be configured to never appear', async () => {
+          element.interactionPrompt = 'none';
+          await timePasses(element.interactionPromptThreshold + 100);
+
+          const promptElement: HTMLElement = (element as any)[$promptElement];
+          expect(promptElement.classList.contains('visible'))
+              .to.be.equal(false);
+        });
+
         test('can be configured to raise automatically', async () => {
           element.interactionPrompt = 'auto';
           await timePasses(element.interactionPromptThreshold + 100);
@@ -319,79 +334,87 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
                   .to.be.equal(element.alt);
             });
 
-        test('prompts user to interact when focused', async () => {
-          const canvas: HTMLCanvasElement = (element[$scene] as any).canvas;
-          const promptElement: HTMLElement = (element as any)[$promptElement];
+        suite('when configured for focus-based interaction prompting', () => {
+          setup(() => {
+            element.interactionPrompt = 'when-focused';
+          });
 
-          settleControls(controls);
+          test('prompts user to interact when focused', async () => {
+            const canvas: HTMLCanvasElement = (element[$scene] as any).canvas;
+            const promptElement: HTMLElement = (element as any)[$promptElement];
 
-          // NOTE(cdata): This wait time was added in order to deflake tests on
-          // iOS Simulator and Android Emulator on Sauce Labs. These same test
-          // targets were tested manually locally and manually on Sauce, and do
-          // not fail. Only automated Sauce tests seem to fail consistently
-          // without this additional wait time:
-          await rafPasses();
+            settleControls(controls);
 
-          canvas.focus();
+            // NOTE(cdata): This wait time was added in order to deflake tests
+            // on iOS Simulator and Android Emulator on Sauce Labs. These same
+            // test targets were tested manually locally and manually on Sauce,
+            // and do not fail. Only automated Sauce tests seem to fail
+            // consistently without this additional wait time:
+            await rafPasses();
 
-          await until(
-              () => canvas.getAttribute('aria-label') === INTERACTION_PROMPT);
+            canvas.focus();
 
-          expect(promptElement.classList.contains('visible')).to.be.equal(true);
-        });
+            await until(
+                () => canvas.getAttribute('aria-label') === INTERACTION_PROMPT);
 
-        test(
-            'does not prompt users to interact before a model is loaded',
-            async () => {
-              Object.defineProperty(
-                  element, 'loaded', {value: false, configurable: true});
+            expect(promptElement.classList.contains('visible'))
+                .to.be.equal(true);
+          });
 
-              element.interactionPromptThreshold = 500;
+          test(
+              'does not prompt users to interact before a model is loaded',
+              async () => {
+                Object.defineProperty(
+                    element, 'loaded', {value: false, configurable: true});
 
-              const canvas: HTMLCanvasElement = (element[$scene] as any).canvas;
-              const promptElement: HTMLElement =
-                  (element as any)[$promptElement];
+                element.interactionPromptThreshold = 500;
 
-              settleControls(controls);
+                const canvas: HTMLCanvasElement =
+                    (element[$scene] as any).canvas;
+                const promptElement: HTMLElement =
+                    (element as any)[$promptElement];
 
-              await rafPasses();
+                settleControls(controls);
 
-              canvas.focus();
+                await rafPasses();
 
-              await timePasses(element.interactionPromptThreshold + 100);
+                canvas.focus();
 
-              expect(promptElement.classList.contains('visible'))
-                  .to.be.equal(false);
+                await timePasses(element.interactionPromptThreshold + 100);
 
-              Object.defineProperty(
-                  element, 'loaded', {value: true, configurable: true});
+                expect(promptElement.classList.contains('visible'))
+                    .to.be.equal(false);
 
-              await timePasses(element.interactionPromptThreshold + 100);
+                Object.defineProperty(
+                    element, 'loaded', {value: true, configurable: true});
 
-              expect(promptElement.classList.contains('visible'))
-                  .to.be.equal(true);
-            });
+                await timePasses(element.interactionPromptThreshold + 100);
 
-        // TODO(#584)
-        test.skip('does not prompt if user already interacted', async () => {
-          const canvas: HTMLCanvasElement = (element[$scene] as any).canvas;
-          const promptElement = (element as any)[$promptElement];
-          const originalLabel = canvas.getAttribute('aria-label');
+                expect(promptElement.classList.contains('visible'))
+                    .to.be.equal(true);
+              });
 
-          expect(originalLabel).to.not.be.equal(INTERACTION_PROMPT);
+          // TODO(#584)
+          test.skip('does not prompt if user already interacted', async () => {
+            const canvas: HTMLCanvasElement = (element[$scene] as any).canvas;
+            const promptElement = (element as any)[$promptElement];
+            const originalLabel = canvas.getAttribute('aria-label');
 
-          canvas.focus();
+            expect(originalLabel).to.not.be.equal(INTERACTION_PROMPT);
 
-          await timePasses(DEFAULT_INTERACTION_PROMPT_THRESHOLD / 2.0);
+            canvas.focus();
 
-          interactWith(canvas);
+            await timePasses(DEFAULT_INTERACTION_PROMPT_THRESHOLD / 2.0);
 
-          await timePasses(DEFAULT_INTERACTION_PROMPT_THRESHOLD + 100);
+            interactWith(canvas);
 
-          expect(canvas.getAttribute('aria-label'))
-              .to.not.be.equal(INTERACTION_PROMPT);
-          expect(promptElement.classList.contains('visible'))
-              .to.be.equal(false);
+            await timePasses(DEFAULT_INTERACTION_PROMPT_THRESHOLD + 100);
+
+            expect(canvas.getAttribute('aria-label'))
+                .to.not.be.equal(INTERACTION_PROMPT);
+            expect(promptElement.classList.contains('visible'))
+                .to.be.equal(false);
+          });
         });
 
         test(

--- a/src/test/features/controls-spec.ts
+++ b/src/test/features/controls-spec.ts
@@ -79,6 +79,9 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
         document.body.appendChild(element);
         element.src = assetPath('cube.gltf');
 
+        element.interactionPromptThreshold =
+            100;  // Fairly low, to keep the test time down
+
         await waitForEvent(element, 'load');
         // NOTE(cdata): Sometimes the load event dispatches quickly enough to
         // cause a race condition where property change occurs _after_ load.


### PR DESCRIPTION
This change proposes that the default for `interaction-prompt` should become `auto`, causing the visible interaction prompt to always appear after the configured `interaction-prompt-threshold` time has elapsed. The changed default here makes this PR a _breaking change_.

Additionally, this change adds `none` to the set of allowed values for `interaction-prompt`. Setting `interaction-prompt="none"` prevents the interaction prompt from ever being displayed or presented to screen readers. This additional feature was added since we received user feedback in #623 that this was a desirable mode for some use cases.

Fixes #623 