### PR TITLE
Camera target control

### DIFF
--- a/examples/staging-and-camera-control.html
+++ b/examples/staging-and-camera-control.html
@@ -128,7 +128,7 @@
         </div>
         <example-snippet stamp-to="demo-container-4" highlight-as="html">
           <template>
-<model-viewer camera-controls src="assets/odd-shape-labeled.glb" background-color="#eee" alt="An abstract 3D model with labeled origin and center"></model-viewer>
+<model-viewer camera-controls src="assets/odd-shape-labeled.glb" background-color="#eee" alt="An abstract 3D model with labeled origin and center" shadow-intensity="1"></model-viewer>
           </template>
         </example-snippet>
       </div>
@@ -145,7 +145,7 @@
         </div>
         <example-snippet stamp-to="demo-container-5" highlight-as="html">
           <template>
-<model-viewer camera-controls camera-target="0m 0m 0m" src="assets/odd-shape-labeled.glb" background-color="#eee" alt="An abstract 3D model with labeled origin and center"></model-viewer>
+<model-viewer camera-controls camera-target="0m 0m 0m" src="assets/odd-shape-labeled.glb" background-color="#eee" alt="An abstract 3D model with labeled origin and center" shadow-intensity="1"></model-viewer>
           </template>
         </example-snippet>
       </div>

--- a/examples/staging-and-camera-control.html
+++ b/examples/staging-and-camera-control.html
@@ -123,7 +123,7 @@
     <div class="content">
       <div class="wrapper">
         <div class="heading">
-          <h2 class="demo-title">By default, models are aligned by the center of their bounding box</h2>
+          <h2 class="demo-title">By default, the camera targets the center of the model's bounding box</h2>
           <h4></h4>
         </div>
         <example-snippet stamp-to="demo-container-4" highlight-as="html">
@@ -140,12 +140,12 @@
     <div class="content">
       <div class="wrapper">
         <div class="heading">
-          <h2 class="demo-title">Use the <span class="attribute">align-model</span> attribute to center the model at its origin</h2>
+          <h2 class="demo-title">Use the <span class="attribute">camera-target</span> attribute to orbit a different coordinate</h2>
           <h4></h4>
         </div>
         <example-snippet stamp-to="demo-container-5" highlight-as="html">
           <template>
-<model-viewer camera-controls align-model="origin" src="assets/odd-shape-labeled.glb" background-color="#eee" alt="An abstract 3D model with labeled origin and center"></model-viewer>
+<model-viewer camera-controls camera-target="0m 0m 0m" src="assets/odd-shape-labeled.glb" background-color="#eee" alt="An abstract 3D model with labeled origin and center"></model-viewer>
           </template>
         </example-snippet>
       </div>

--- a/index.html
+++ b/index.html
@@ -170,7 +170,19 @@
               changes from its initially configured value, the camera will
               interpolate from its current position to the new value. Defaults to
               "0deg 75deg auto".</p>
-            </li><li>
+            </li>
+            <li>
+              <div>camera-target</div>
+              <p>Set the starting and/or subsequent point the camera orbits
+              around. Accepts values of the form "$X $Y $Z", like "0m 1.5m
+              -0.5m". Also supports units in centimeters ("cm") or millimeters
+              ("mm"). A special value "auto" can be used, which sets the target
+              to the center of the model's bounding box in that dimension. Any
+              time this value changes from its initially configured value, the
+              camera will interpolate from its current position to the new
+              value. Defaults to "auto auto auto".</p>
+            </li>
+            <li>
               <div>environment-image</div>
               <p>Controls the environmental reflection of the model. Normally if
               background-image is set, that image will also be used for the

--- a/scripts/ci-run-tests.sh
+++ b/scripts/ci-run-tests.sh
@@ -22,7 +22,7 @@ if [ "${TEST_TYPE}" = "unit" ]; then
 
   xvfb-run npm run test
 
-  if  [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${TRAVIS_BRANCH}" != "master" ]; then
+  if  [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
     ./scripts/run-sauce-tests.sh;
   fi
 fi

--- a/scripts/run-fidelity-check.sh
+++ b/scripts/run-fidelity-check.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-if [ "${TEST_TYPE}" = "fidelity" ] || [ "${TRAVIS_BRANCH}" = "master" ]; then
+if [ "${TEST_TYPE}" = "fidelity" ] || [ "${TRAVIS_PULL_REQUEST_BRANCH}" = "master" ]; then
   npm run build
   npm run check-fidelity
 fi

--- a/src/conversions.ts
+++ b/src/conversions.ts
@@ -14,7 +14,6 @@
  */
 
 import {Math as ThreeMath} from 'three';
-import {Vector3} from 'three';
 
 import {parseValues, ValueNode} from './parsers.js';
 
@@ -111,29 +110,33 @@ export const deserializeSpherical =
 /**
  * Vector String => Vector Values
  *
- * Converts a "vector string" to values suitable for assigning to a Three.js
- * Vector3 object. Position strings are of the form "$x $y $z".
- * Accepted units include meters (m), centimeters (cm) and millimeters (mm).
+ * Converts a "vector string" to 3 values, either numbers in meters or the
+ * string 'auto'. Position strings are of the form "$x $y $z". Accepted units
+ * include meters (m), centimeters (cm) and millimeters (mm).
  *
  * Returns null if the vector string cannot be parsed.
  */
-export const deserializeVector3 = (vectorString: string): Vector3|null => {
-  try {
-    const vectorValueNodes = parseValues(vectorString);
+export const deserializeVector3 =
+    (vectorString: string): (number|string)[]|null => {
+      try {
+        const vectorValueNodes = parseValues(vectorString);
 
-    if (vectorValueNodes.length === 3) {
-      const vector = new Vector3;
-      vector.x = lengthValueNodeToMeters(vectorValueNodes[0]);
-      vector.y = lengthValueNodeToMeters(vectorValueNodes[1]);
-      vector.z = lengthValueNodeToMeters(vectorValueNodes[2]);
+        const xyz = [];
+        if (vectorValueNodes.length === 3) {
+          for (let i = 0; i < 3; i++) {
+            xyz.push(
+                vectorValueNodes[i].value === 'auto' ?
+                    'auto' :
+                    lengthValueNodeToMeters(vectorValueNodes[i]));
+          }
 
-      return vector;
-    }
-  } catch (_error) {
-  }
+          return xyz;
+        }
+      } catch (_error) {
+      }
 
-  return null;
-};
+      return null;
+    };
 
 export const deserializeAngleToDeg = (angleString: string): number|null => {
   try {

--- a/src/conversions.ts
+++ b/src/conversions.ts
@@ -14,6 +14,8 @@
  */
 
 import {Math as ThreeMath} from 'three';
+import {Vector3} from 'three';
+
 import {parseValues, ValueNode} from './parsers.js';
 
 
@@ -105,6 +107,33 @@ export const deserializeSpherical =
 
       return null;
     };
+
+/**
+ * Vector String => Vector Values
+ *
+ * Converts a "vector string" to values suitable for assigning to a Three.js
+ * Vector3 object. Position strings are of the form "$x $y $z".
+ * Accepted units include meters (m), centimeters (cm) and millimeters (mm).
+ *
+ * Returns null if the vector string cannot be parsed.
+ */
+export const deserializeVector3 = (vectorString: string): Vector3|null => {
+  try {
+    const vectorValueNodes = parseValues(vectorString);
+
+    if (vectorValueNodes.length === 3) {
+      const vector = new Vector3;
+      vector.x = lengthValueNodeToMeters(vectorValueNodes[0]);
+      vector.y = lengthValueNodeToMeters(vectorValueNodes[1]);
+      vector.z = lengthValueNodeToMeters(vectorValueNodes[2]);
+
+      return vector;
+    }
+  } catch (_error) {
+  }
+
+  return null;
+};
 
 export const deserializeAngleToDeg = (angleString: string): number|null => {
   try {

--- a/src/features/controls.ts
+++ b/src/features/controls.ts
@@ -280,10 +280,15 @@ export const ControlsMixin = (ModelViewerElement:
         }
 
         [$updateCameraTarget]() {
-          let target = deserializeVector3(this.cameraTarget);
+          const targetValues = deserializeVector3(this.cameraTarget);
+          let target = this[$scene].model.boundingBox.getCenter(new Vector3);
 
-          if (target == null) {  // this happens in the default 'auto' case
-            target = this[$scene].model.boundingBox.getCenter(new Vector3);
+          if (targetValues != null) {
+            for (let i = 0; i < 3; i++) {
+              if (targetValues[i] !== 'auto') {
+                target.setComponent(i, targetValues[i] as number);
+              }
+            }
           }
 
           this[$controls].setTarget(target);

--- a/src/features/controls.ts
+++ b/src/features/controls.ts
@@ -14,9 +14,9 @@
  */
 
 import {property} from 'lit-element';
-import {Event, Spherical} from 'three';
+import {Event, Spherical, Vector3} from 'three';
 
-import {deserializeAngleToDeg, deserializeSpherical} from '../conversions.js';
+import {deserializeAngleToDeg, deserializeSpherical, deserializeVector3} from '../conversions.js';
 import ModelViewerElementBase, {$ariaLabel, $needsRender, $onModelLoad, $onResize, $scene, $tick} from '../model-viewer-base.js';
 import {ChangeEvent, ChangeSource, SmoothControls} from '../three-components/SmoothControls.js';
 import {Constructor} from '../utilities.js';
@@ -276,20 +276,12 @@ export const ControlsMixin = (ModelViewerElement:
         }
 
         [$updateCameraTarget]() {
-          let target = deserializeSpherical(this.cameraOrbit);
+          let target = deserializeVector3(this.cameraTarget);
 
-          if (target == null) {
-            target = deserializeSpherical(DEFAULT_CAMERA_ORBIT)!;
+          if (target == null) {  // this happens in the default 'auto' case
+            target = this[$scene].model.boundingBox.getCenter(new Vector3);
           }
 
-          if (typeof radius === 'string') {
-            switch (radius) {
-              default:
-              case 'auto':
-                radius = this[$idealCameraDistance]!;
-                break;
-            }
-          }
           this[$controls].setTarget(target);
         }
 
@@ -370,7 +362,6 @@ export const ControlsMixin = (ModelViewerElement:
           controls.applyOptions({minimumRadius, maximumRadius});
 
           controls.setRadius(zoom * this[$idealCameraDistance]!);
-          controls.setTarget(scene.target);
           controls.jumpToGoal();
         }
 
@@ -438,6 +429,7 @@ export const ControlsMixin = (ModelViewerElement:
           super[$onModelLoad](event);
           this[$updateCamera]();
           this[$updateCameraOrbit]();
+          this[$updateCameraTarget]();
           this[$controls].jumpToGoal();
         }
 

--- a/src/features/controls.ts
+++ b/src/features/controls.ts
@@ -86,7 +86,6 @@ const $onPromptTransitionend = Symbol('onPromptTransitionend');
 const $shouldPromptUserToInteract = Symbol('shouldPromptUserToInteract');
 const $waitingToPromptUser = Symbol('waitingToPromptUser');
 const $userPromptedOnce = Symbol('userPromptedOnce');
-const $idleTime = Symbol('idleTime');
 
 const $lastSpherical = Symbol('lastSpherical');
 const $jumpCamera = Symbol('jumpCamera');
@@ -137,7 +136,6 @@ export const ControlsMixin = (ModelViewerElement:
 
         protected[$promptElement]: Element;
 
-        protected[$idleTime] = 0;
         protected[$userPromptedOnce] = false;
         protected[$waitingToPromptUser] = false;
         protected[$shouldPromptUserToInteract] = true;
@@ -296,11 +294,8 @@ export const ControlsMixin = (ModelViewerElement:
 
           if (this[$waitingToPromptUser] &&
               this.interactionPrompt !== InteractionPromptStrategy.NONE) {
-            if (this.loaded) {
-              this[$idleTime] += delta;
-            }
-
-            if (this[$idleTime] > this.interactionPromptThreshold) {
+            if (this.loaded &&
+                time > this.loadedTime + this.interactionPromptThreshold) {
               (this as any)[$scene].canvas.setAttribute(
                   'aria-label', INTERACTION_PROMPT);
 
@@ -322,7 +317,7 @@ export const ControlsMixin = (ModelViewerElement:
         [$deferInteractionPrompt]() {
           // Effectively cancel the timer waiting for user interaction:
           this[$waitingToPromptUser] = false;
-          this[$promptElement]!.classList.remove('visible');
+          this[$promptElement].classList.remove('visible');
 
           // Implicitly there was some reason to defer the prompt. If the user
           // has been prompted at least once already, we no longer need to
@@ -459,7 +454,6 @@ export const ControlsMixin = (ModelViewerElement:
           // prompt threshold:
           if (this[$shouldPromptUserToInteract]) {
             this[$waitingToPromptUser] = true;
-            this[$idleTime] = 0;
           }
         }
 

--- a/src/features/controls.ts
+++ b/src/features/controls.ts
@@ -358,8 +358,9 @@ export const ControlsMixin = (ModelViewerElement:
           // and will only end up showing the skysphere if zoomed out enough
           const minimumRadius = near + framedHeight / 2.0;
           const maximumRadius = this[$idealCameraDistance]!;
+          const modelSize = scene.model.size.length();
 
-          controls.applyOptions({minimumRadius, maximumRadius});
+          controls.applyOptions({minimumRadius, maximumRadius, modelSize});
 
           controls.setRadius(zoom * this[$idealCameraDistance]!);
           controls.jumpToGoal();

--- a/src/features/controls.ts
+++ b/src/features/controls.ts
@@ -17,7 +17,7 @@ import {property} from 'lit-element';
 import {Event, Spherical, Vector3} from 'three';
 
 import {deserializeAngleToDeg, deserializeSpherical, deserializeVector3} from '../conversions.js';
-import ModelViewerElementBase, {$ariaLabel, $needsRender, $onModelLoad, $onResize, $scene, $tick} from '../model-viewer-base.js';
+import ModelViewerElementBase, {$ariaLabel, $loadedTime, $needsRender, $onModelLoad, $onResize, $scene, $tick} from '../model-viewer-base.js';
 import {ChangeEvent, ChangeSource, SmoothControls} from '../three-components/SmoothControls.js';
 import {Constructor} from '../utilities.js';
 
@@ -295,7 +295,7 @@ export const ControlsMixin = (ModelViewerElement:
           if (this[$waitingToPromptUser] &&
               this.interactionPrompt !== InteractionPromptStrategy.NONE) {
             if (this.loaded &&
-                time > this.loadedTime + this.interactionPromptThreshold) {
+                time > this[$loadedTime] + this.interactionPromptThreshold) {
               (this as any)[$scene].canvas.setAttribute(
                   'aria-label', INTERACTION_PROMPT);
 
@@ -358,9 +358,8 @@ export const ControlsMixin = (ModelViewerElement:
           // and will only end up showing the skysphere if zoomed out enough
           const minimumRadius = near + framedHeight / 2.0;
           const maximumRadius = this[$idealCameraDistance]!;
-          const modelSize = scene.model.size.length();
 
-          controls.applyOptions({minimumRadius, maximumRadius, modelSize});
+          controls.applyOptions({minimumRadius, maximumRadius});
 
           controls.setRadius(zoom * this[$idealCameraDistance]!);
           controls.jumpToGoal();

--- a/src/features/controls.ts
+++ b/src/features/controls.ts
@@ -464,15 +464,10 @@ export const ControlsMixin = (ModelViewerElement:
         }
 
         [$onChange]({source}: ChangeEvent) {
-          if (this.interactionPrompt ===
-              InteractionPromptStrategy.WHEN_FOCUSED) {
-            this[$deferInteractionPrompt]();
-          }
           this[$updateAria]();
           this[$needsRender]();
 
-          if (source === ChangeSource.USER_INTERACTION &&
-              this.interactionPrompt === InteractionPromptStrategy.AUTO) {
+          if (source === ChangeSource.USER_INTERACTION) {
             this[$deferInteractionPrompt]();
           }
 

--- a/src/features/controls.ts
+++ b/src/features/controls.ts
@@ -47,7 +47,7 @@ const InteractionPolicy: {[index: string]: InteractionPolicy} = {
 };
 
 export const DEFAULT_CAMERA_ORBIT = '0deg 75deg auto';
-const DEFAULT_CAMERA_TARGET = 'auto';
+const DEFAULT_CAMERA_TARGET = 'auto auto auto';
 const DEFAULT_FIELD_OF_VIEW = '45deg';
 
 const HALF_PI = Math.PI / 2.0;

--- a/src/features/controls.ts
+++ b/src/features/controls.ts
@@ -99,6 +99,7 @@ export interface ControlsInterface {
   interactionPolicy: InteractionPolicy;
   interactionPromptThreshold: number;
   getCameraOrbit(): SphericalPosition;
+  getCameraTarget(): Vector3;
   getFieldOfView(): number;
   jumpCameraToGoal(): void;
 }
@@ -170,6 +171,10 @@ export const ControlsMixin = (ModelViewerElement:
         getCameraOrbit(): SphericalPosition {
           const {theta, phi, radius} = this[$lastSpherical];
           return {theta, phi, radius};
+        }
+
+        getCameraTarget(): Vector3 {
+          return this[$controls].getTarget();
         }
 
         getFieldOfView(): number {

--- a/src/model-viewer-base.ts
+++ b/src/model-viewer-base.ts
@@ -33,6 +33,7 @@ const UNSIZED_MEDIA_HEIGHT = 150;
 
 const $updateSize = Symbol('updateSize');
 const $loaded = Symbol('loaded');
+const $loadedTime = Symbol('loadedTime');
 const $template = Symbol('template');
 const $fallbackResizeHandler = Symbol('fallbackResizeHandler');
 const $defaultAriaLabel = Symbol('defaultAriaLabel');
@@ -93,6 +94,7 @@ export default class ModelViewerElementBase extends UpdatingElement {
   src: string|null = null;
 
   protected[$loaded]: boolean = false;
+  protected[$loadedTime]: number = 0;
   protected[$scene]: ModelScene;
   protected[$container]: HTMLDivElement;
   protected[$canvas]: HTMLCanvasElement;
@@ -112,6 +114,10 @@ export default class ModelViewerElementBase extends UpdatingElement {
 
   get loaded() {
     return this[$loaded];
+  }
+
+  get loadedTime() {
+    return this[$loadedTime];
   }
 
   get[$renderer]() {
@@ -269,6 +275,7 @@ export default class ModelViewerElementBase extends UpdatingElement {
     // sure that the value has actually changed before changing the loaded flag.
     if (changedProperties.has('src') && this.src !== this[$scene].model.url) {
       this[$loaded] = false;
+      this[$loadedTime] = 0;
       (async () => {
         const updateSourceProgress = this[$progressTracker].beginActivity();
         await this[$updateSource](
@@ -330,6 +337,7 @@ export default class ModelViewerElementBase extends UpdatingElement {
     }
 
     this[$loaded] = true;
+    this[$loadedTime] = performance.now();
     // Asynchronously invoke `update`:
     this.requestUpdate();
   }

--- a/src/model-viewer-base.ts
+++ b/src/model-viewer-base.ts
@@ -33,7 +33,6 @@ const UNSIZED_MEDIA_HEIGHT = 150;
 
 const $updateSize = Symbol('updateSize');
 const $loaded = Symbol('loaded');
-const $loadedTime = Symbol('loadedTime');
 const $template = Symbol('template');
 const $fallbackResizeHandler = Symbol('fallbackResizeHandler');
 const $defaultAriaLabel = Symbol('defaultAriaLabel');
@@ -44,6 +43,7 @@ const $clearModelTimeout = Symbol('clearModelTimeout');
 
 export const $resetRenderer = Symbol('resetRenderer');
 export const $ariaLabel = Symbol('ariaLabel');
+export const $loadedTime = Symbol('loadedTime');
 export const $updateSource = Symbol('updateSource');
 export const $markLoaded = Symbol('markLoaded');
 export const $container = Symbol('container');
@@ -114,10 +114,6 @@ export default class ModelViewerElementBase extends UpdatingElement {
 
   get loaded() {
     return this[$loaded];
-  }
-
-  get loadedTime() {
-    return this[$loadedTime];
   }
 
   get[$renderer]() {

--- a/src/test/features/controls-spec.ts
+++ b/src/test/features/controls-spec.ts
@@ -148,6 +148,19 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
             element.getCameraOrbit(), {...orbit, radius: nextRadius});
       });
 
+      test('can independently adjust target', async () => {
+        const target = element.getCameraTarget();
+        target.addScalar(1);
+
+        element.cameraTarget = `${target.x}m ${target.y}m ${target.z}m`;
+
+        await timePasses();
+
+        settleControls(controls);
+
+        expect(element.getCameraTarget()).to.be.eql(target);
+      });
+
       test('defaults FOV correctly', async () => {
         expect(element.getFieldOfView()).to.be.equal(DEFAULT_FOV);
       });

--- a/src/test/features/controls-spec.ts
+++ b/src/test/features/controls-spec.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import {$controls, $idealCameraDistance, $promptElement, CameraChangeDetails, ControlsInterface, ControlsMixin, DEFAULT_INTERACTION_PROMPT_THRESHOLD, INTERACTION_PROMPT, SphericalPosition} from '../../features/controls.js';
+import {$controls, $idealCameraDistance, $promptElement, CameraChangeDetails, ControlsInterface, ControlsMixin, INTERACTION_PROMPT, SphericalPosition} from '../../features/controls.js';
 import ModelViewerElementBase, {$canvas, $scene} from '../../model-viewer-base.js';
 import {ChangeSource, SmoothControls} from '../../three-components/SmoothControls.js';
 import {Constructor} from '../../utilities.js';
@@ -411,8 +411,7 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
                     .to.be.equal(true);
               });
 
-          // TODO(#584)
-          test.skip('does not prompt if user already interacted', async () => {
+          test('does not prompt if user already interacted', async () => {
             const canvas: HTMLCanvasElement = (element[$scene] as any).canvas;
             const promptElement = (element as any)[$promptElement];
             const originalLabel = canvas.getAttribute('aria-label');
@@ -421,11 +420,11 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
 
             canvas.focus();
 
-            await timePasses(DEFAULT_INTERACTION_PROMPT_THRESHOLD / 2.0);
+            await timePasses(element.interactionPromptThreshold / 2.0);
 
             interactWith(canvas);
 
-            await timePasses(DEFAULT_INTERACTION_PROMPT_THRESHOLD + 100);
+            await timePasses(element.interactionPromptThreshold + 100);
 
             expect(canvas.getAttribute('aria-label'))
                 .to.not.be.equal(INTERACTION_PROMPT);

--- a/src/test/features/controls-spec.ts
+++ b/src/test/features/controls-spec.ts
@@ -382,10 +382,10 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
           test(
               'does not prompt users to interact before a model is loaded',
               async () => {
+                element.src = null;
+
                 Object.defineProperty(
                     element, 'loaded', {value: false, configurable: true});
-
-                element.interactionPromptThreshold = 500;
 
                 const canvas: HTMLCanvasElement =
                     (element[$scene] as any).canvas;

--- a/src/test/features/controls-spec.ts
+++ b/src/test/features/controls-spec.ts
@@ -420,8 +420,6 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
 
             canvas.focus();
 
-            await timePasses(element.interactionPromptThreshold / 2.0);
-
             interactWith(canvas);
 
             await timePasses(element.interactionPromptThreshold + 100);

--- a/src/test/features/controls-spec.ts
+++ b/src/test/features/controls-spec.ts
@@ -254,17 +254,23 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
         expect(controls).to.be.ok;
       });
 
-      test('requires focus to interact if policy is set to allow-when-focused', async  () => {
-        element.interactionPolicy = 'allow-when-focused';
-        await timePasses();
-        expect(controls.options.interactionPolicy).to.be.equal('allow-when-focused');
-      });
+      test(
+          'requires focus to interact if policy is set to allow-when-focused',
+          async () => {
+            element.interactionPolicy = 'allow-when-focused';
+            await timePasses();
+            expect(controls.options.interactionPolicy)
+                .to.be.equal('allow-when-focused');
+          });
 
-      test('does not require focus to interact if policy is set to always-allow', async () => {
-        element.interactionPolicy = 'always-allow';
-        await timePasses();
-        expect(controls.options.interactionPolicy).to.be.equal('always-allow');
-      });
+      test(
+          'does not require focus to interact if policy is set to always-allow',
+          async () => {
+            element.interactionPolicy = 'always-allow';
+            await timePasses();
+            expect(controls.options.interactionPolicy)
+                .to.be.equal('always-allow');
+          });
 
       test('sets max radius to the camera framed distance', () => {
         const cameraDistance = element[$scene].camera.position.distanceTo(
@@ -280,14 +286,15 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
 
       suite('when user is interacting', () => {
         test('sets an appropriate camera-change event source', async () => {
-          const cameraChangeDispatches =
-              waitForEvent<CustomEvent<CameraChangeDetails>>(
-                  element, 'camera-change');
-
           await rafPasses();
           element[$canvas].focus();
           interactWith(element[$canvas]);
+
+          const cameraChangeDispatches =
+              waitForEvent<CustomEvent<CameraChangeDetails>>(
+                  element, 'camera-change');
           const event = await cameraChangeDispatches;
+
           expect(event.detail.source)
               .to.be.equal(ChangeSource.USER_INTERACTION);
         });

--- a/src/test/features/controls-spec.ts
+++ b/src/test/features/controls-spec.ts
@@ -412,7 +412,8 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
                     .to.be.equal(true);
               });
 
-          test('does not prompt if user already interacted', async () => {
+          // TODO(#584)
+          test.skip('does not prompt if user already interacted', async () => {
             const canvas: HTMLCanvasElement = (element[$scene] as any).canvas;
             const promptElement = (element as any)[$promptElement];
             const originalLabel = canvas.getAttribute('aria-label');

--- a/src/test/features/controls-spec.ts
+++ b/src/test/features/controls-spec.ts
@@ -150,9 +150,10 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
 
       test('can independently adjust target', async () => {
         const target = element.getCameraTarget();
-        target.addScalar(1);
+        target.x += 1;
+        target.z += 1;
 
-        element.cameraTarget = `${target.x}m ${target.y}m ${target.z}m`;
+        element.cameraTarget = `${target.x}m auto ${target.z}m`;
 
         await timePasses();
 

--- a/src/test/features/environment-spec.ts
+++ b/src/test/features/environment-spec.ts
@@ -227,12 +227,6 @@ suite('ModelViewerElementBase with EnvironmentMixin', () => {
           element.backgroundColor = '#ff0077';
           await timePasses();
         });
-
-        test('the directional light is white', () => {
-          const lightColor =
-              scene.shadowLight.color.getHexString().toLowerCase();
-          expect(lightColor).to.be.equal('ffffff');
-        });
       });
 
       suite('on an unlit model', () => {

--- a/src/test/features/staging-spec.ts
+++ b/src/test/features/staging-spec.ts
@@ -13,19 +13,14 @@
  * limitations under the License.
  */
 
-import {Vector3} from 'three';
-
 import {AUTO_ROTATE_DELAY_AFTER_USER_INTERACTION, StagingMixin} from '../../features/staging.js';
-import ModelViewerElementBase, {$onUserModelOrbit, $scene} from '../../model-viewer-base.js';
+import ModelViewerElementBase, {$onUserModelOrbit} from '../../model-viewer-base.js';
 import {assetPath, timePasses, waitForEvent} from '../helpers.js';
 import {BasicSpecTemplate} from '../templates.js';
 
 const expect = chai.expect;
 
 const ODD_SHAPE_GLB_PATH = assetPath('odd-shape.glb');
-const CENTER_OFFSET = new Vector3(0.5, 1.0, 0.5);
-const ORIGIN_OFFSET = new Vector3();
-const FRAMED_SIZE = new Vector3(5, 4.5, 5);
 
 suite('ModelViewerElementBase with StagingMixin', () => {
   let nextId = 0;
@@ -57,57 +52,6 @@ suite('ModelViewerElementBase with StagingMixin', () => {
 
     teardown(() => {
       document.body.removeChild(element);
-    });
-
-    suite('align-model', () => {
-      test('centers the model in the frame by default', () => {
-        const offset = (element as any)[$scene].model.position;
-        expect(offset).to.be.deep.equal(CENTER_OFFSET);
-      });
-
-      suite('origin alignment', () => {
-        setup(async () => {
-          element.alignModel = 'origin';
-          await timePasses();
-        });
-
-        test('aligns model origin with the scene origin', () => {
-          // NOTE(cdata): We clone the offset as a cheap way of normalizing
-          // -0 values as 0
-          const offset = (element as any)[$scene].model.position.clone();
-          expect(offset).to.be.deep.equal(ORIGIN_OFFSET);
-        });
-
-        test('places shadow under a non-centered model', () => {
-          const shadowSize = (element as any)[$scene].shadow.scale;
-          expect(shadowSize.x).to.be.equal(FRAMED_SIZE.x);
-          expect(shadowSize.z).to.be.equal(FRAMED_SIZE.z);
-        });
-      });
-
-      suite('mixed values', () => {
-        suite('two values', () => {
-          test('aligns x and y axes accordingly', async () => {
-            element.alignModel = 'center origin';
-            await timePasses();
-
-            const offset = (element as any)[$scene].model.position.clone();
-            expect(offset).to.be.deep.equal(
-                new Vector3(CENTER_OFFSET.x, ORIGIN_OFFSET.y, CENTER_OFFSET.z));
-          });
-        });
-
-        suite('three values', () => {
-          test('aligns x, y and z axes accordingly', async () => {
-            element.alignModel = 'origin center origin';
-            await timePasses();
-
-            const offset = (element as any)[$scene].model.position.clone();
-            expect(offset).to.be.deep.equal(
-                new Vector3(ORIGIN_OFFSET.x, CENTER_OFFSET.y, ORIGIN_OFFSET.z));
-          });
-        });
-      });
     });
 
     suite('auto-rotate', () => {

--- a/src/test/three-components/ModelScene-spec.ts
+++ b/src/test/three-components/ModelScene-spec.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import {Matrix4, Mesh, Object3D, SphereBufferGeometry, Vector3} from 'three';
+import {Matrix4, Mesh, SphereBufferGeometry, Vector3} from 'three';
 
 import ModelViewerElementBase, {$canvas, $renderer} from '../../model-viewer-base.js';
 import ModelScene from '../../three-components/ModelScene.js';
@@ -116,30 +116,6 @@ suite('ModelScene', () => {
       scene.setSize(0, 0);
       expect(scene.width).to.be.equal(1);
       expect(scene.height).to.be.equal(1);
-    });
-  });
-
-  suite('alignModel', () => {
-    test('does not throw if model has no volume', () => {
-      scene.model.setObject(new Object3D());
-      scene.alignModel();
-    });
-
-    test('does not throw if model not loaded', () => {
-      scene.model.modelContainer.add(dummyMesh);
-      scene.model.updateBoundingBox();
-      scene.alignModel();
-    });
-
-    test('updates object position to center it on the floor', () => {
-      scene.setSize(1000, 500);
-      dummyMesh.geometry.applyMatrix(new Matrix4().makeTranslation(5, 10, 20));
-      scene.model.setObject(dummyMesh);
-
-      scene.alignModel();
-
-      expect(scene.model.position)
-          .to.be.eql(new Vector3(-5, dummyRadius - 10, -20));
     });
   });
 });

--- a/src/three-components/ARRenderer.ts
+++ b/src/three-components/ARRenderer.ts
@@ -220,7 +220,6 @@ export class ARRenderer extends EventDispatcher {
     if (this[$presentedScene] != null) {
       this.dolly.remove(this[$presentedScene]!);
       this[$presentedScene]!.updateFraming();
-      this[$presentedScene]!.alignModel();
     }
 
     this[$refSpace] = null;

--- a/src/three-components/ModelScene.ts
+++ b/src/three-components/ModelScene.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import {BackSide, BoxBufferGeometry, Camera, Color, DirectionalLight, Object3D, PerspectiveCamera, Scene, Shader, ShaderLib, ShaderMaterial} from 'three';
+import {BackSide, BoxBufferGeometry, Camera, Color, Object3D, PerspectiveCamera, Scene, Shader, ShaderLib, ShaderMaterial} from 'three';
 import {Mesh} from 'three';
 
 import ModelViewerElementBase from '../model-viewer-base.js';
@@ -52,7 +52,6 @@ export default class ModelScene extends Scene {
 
   public canvas: HTMLCanvasElement;
   public renderer: Renderer;
-  public shadowLight: DirectionalLight;
   public shadow: StaticShadow;
   public pivot: Object3D;
   public width: number;
@@ -82,10 +81,6 @@ export default class ModelScene extends Scene {
 
     this.model = new Model();
     this.shadow = new StaticShadow();
-
-    this.shadowLight = new DirectionalLight(0xffffff, 1.0);
-    this.shadowLight.position.set(0, 10, 0);
-    this.shadowLight.name = 'ShadowLight';
 
     this.width = width;
     this.height = height;
@@ -239,12 +234,7 @@ export default class ModelScene extends Scene {
     const currentRotation = this.pivot.rotation.y;
     this.pivot.rotation.y = 0;
 
-    this.model.boundingBox.getCenter(this.shadow.position);
-    this.shadow.position.y -= this.model.size.y / 2;
-    this.shadow.scale.x = this.model.size.x;
-    this.shadow.scale.z = this.model.size.z;
-
-    this.shadow.render(this.renderer.renderer, this, this.shadowLight);
+    this.shadow.render(this.renderer.renderer, this);
 
     // Lazily add the shadow so we're only displaying it once it has
     // a generated texture.

--- a/src/three-components/ModelScene.ts
+++ b/src/three-components/ModelScene.ts
@@ -148,10 +148,9 @@ export default class ModelScene extends Scene {
   /**
    * To frame the scene, a box is fit around the model such that the X and Z
    * dimensions (modelDepth) are the same (for Y-rotation) and the X/Y ratio is
-   * the aspect ratio of the canvas (framedHeight is the Y dimension). For
-   * non-centered models, the box is fit symmetrically about the XZ origin to
-   * keep them in frame as they are rotated. At the ideal distance, the camera's
-   * fov exactly covers the front face of this box when looking down the Z-axis.
+   * the aspect ratio of the canvas (framedHeight is the Y dimension). At the
+   * ideal distance, the camera's fov exactly covers the front face of this box
+   * when looking down the Z-axis.
    */
   updateFraming() {
     const dpr = resolveDpr();
@@ -204,7 +203,6 @@ export default class ModelScene extends Scene {
 
   /**
    * Sets the passed in camera to be used for rendering.
-   * @param {THREE.Camera}
    */
   setCamera(camera: Camera) {
     this.activeCamera = camera;
@@ -220,7 +218,7 @@ export default class ModelScene extends Scene {
   }
 
   /**
-   * Called to update the shadow rendering when the room or model changes.
+   * Called to update the shadow rendering when the model changes.
    */
   updateStaticShadow() {
     if (!this.model.hasModel() || this.model.size.length() === 0) {

--- a/src/three-components/SmoothControls.ts
+++ b/src/three-components/SmoothControls.ts
@@ -530,7 +530,7 @@ export class SmoothControls extends EventDispatcher {
         this[$goalSpherical].phi === this[$spherical].phi &&
         this[$goalSpherical].radius === this[$spherical].radius &&
         this[$goalLogFov] === this[$logFov] &&
-        this[$goalTarget] === this[$target];
+        this[$goalTarget].equals(this[$target]);
   }
 
   private[$moveCamera]() {

--- a/src/three-components/SmoothControls.ts
+++ b/src/three-components/SmoothControls.ts
@@ -42,8 +42,6 @@ export interface SmoothControlsOptions {
   eventHandlingBehavior?: EventHandlingBehavior;
   // Controls when interaction is allowed (always, or only when focused)
   interactionPolicy?: InteractionPolicy;
-  // The approximate size of the model (m)
-  modelSize?: number;
 }
 
 export const DEFAULT_OPTIONS = Object.freeze<SmoothControlsOptions>({
@@ -56,8 +54,7 @@ export const DEFAULT_OPTIONS = Object.freeze<SmoothControlsOptions>({
   minimumFieldOfView: 10,
   maximumFieldOfView: 45,
   eventHandlingBehavior: 'prevent-all',
-  interactionPolicy: 'always-allow',
-  modelSize: 1
+  interactionPolicy: 'always-allow'
 });
 
 const $velocity = Symbol('v');
@@ -494,7 +491,7 @@ export class SmoothControls extends EventDispatcher {
     if (this[$isStationary]()) {
       return;
     }
-    const {maximumPolarAngle, maximumRadius, maximumFieldOfView, modelSize} =
+    const {maximumPolarAngle, maximumRadius, maximumFieldOfView} =
         this[$options];
 
     this[$spherical].theta = this[$thetaDamper].update(
@@ -516,11 +513,11 @@ export class SmoothControls extends EventDispatcher {
         this[$logFov], this[$goalLogFov], delta, maximumFieldOfView!);
 
     this[$target].x = this[$targetDamperX].update(
-        this[$target].x, this[$goalTarget].x, delta, modelSize!);
+        this[$target].x, this[$goalTarget].x, delta, maximumRadius!);
     this[$target].y = this[$targetDamperY].update(
-        this[$target].y, this[$goalTarget].y, delta, modelSize!);
+        this[$target].y, this[$goalTarget].y, delta, maximumRadius!);
     this[$target].z = this[$targetDamperZ].update(
-        this[$target].z, this[$goalTarget].z, delta, modelSize!);
+        this[$target].z, this[$goalTarget].z, delta, maximumRadius!);
 
     this[$moveCamera]();
   }

--- a/src/three-components/StaticShadow.ts
+++ b/src/three-components/StaticShadow.ts
@@ -18,8 +18,6 @@ import {WebGLRenderer} from 'three';
 import ModelScene from './ModelScene';
 
 export interface ShadowGenerationConfig {
-  near?: number;
-  far?: number;
   textureWidth?: number;
   textureHeight?: number;
 }
@@ -30,8 +28,6 @@ const $renderTarget = Symbol('renderTarget');
 const BASE_SHADOW_OPACITY = 0.1;
 
 const DEFAULT_CONFIG: ShadowGenerationConfig = {
-  near: 0.01,
-  far: 100,
   textureWidth: 512,
   textureHeight: 512,
 };
@@ -134,8 +130,8 @@ export default class StaticShadow extends Mesh {
     this[$camera].bottom = size.z / -2;
     this[$camera].left = size.x / -2;
     this[$camera].right = size.x / 2;
-    this[$camera].near = config.near!;
-    this[$camera].far = config.far!;
+    this[$camera].near = 0;
+    this[$camera].far = size.y * 2;
     this[$camera].updateProjectionMatrix();
 
     // There's a chance the shadow will be in the scene that's being rerendered;

--- a/src/three-components/StaticShadow.ts
+++ b/src/three-components/StaticShadow.ts
@@ -13,8 +13,9 @@
  * limitations under the License.
  */
 
-import {DirectionalLight, Mesh, MeshBasicMaterial, OrthographicCamera, PlaneGeometry, RGBAFormat, Scene, Vector3, WebGLRenderTarget} from 'three';
+import {Mesh, MeshBasicMaterial, OrthographicCamera, PlaneGeometry, RGBAFormat, Vector3, WebGLRenderTarget} from 'three';
 import {WebGLRenderer} from 'three';
+import ModelScene from './ModelScene';
 
 export interface ShadowGenerationConfig {
   near?: number;
@@ -25,8 +26,6 @@ export interface ShadowGenerationConfig {
 
 const $camera = Symbol('camera');
 const $renderTarget = Symbol('renderTarget');
-
-const scale = new Vector3();
 
 const BASE_SHADOW_OPACITY = 0.1;
 
@@ -94,18 +93,9 @@ export default class StaticShadow extends Mesh {
    * Updates the generated static shadow. The size of the camera is dependent
    * on the current scale of the StaticShadow that will host the texture.
    * It's expected for the StaticShadow to be facing the light source.
-   *
-   * @param {THREE.WebGLRenderer} renderer
-   * @param {THREE.Scene} scene
-   * @param {THREE.DirectionalLight} light
-   * @param {Object} config
-   * @param {number} config.near
-   * @param {number} config.far
-   * @param {number} config.textureWidth
-   * @param {number} config.textureHeight
    */
   render(
-      renderer: WebGLRenderer, scene: Scene, light: DirectionalLight,
+      renderer: WebGLRenderer, scene: ModelScene,
       config: ShadowGenerationConfig = {}) {
     const userSceneOverrideMaterial = scene.overrideMaterial;
     const userSceneBackground = scene.background;
@@ -125,24 +115,25 @@ export default class StaticShadow extends Mesh {
       this[$renderTarget].setSize(config.textureWidth!, config.textureHeight!);
     }
 
-    // Set the camera to where the light source is,
-    // and facing its target.
-    light.updateMatrixWorld(true);
-    light.target.updateMatrixWorld(true);
+    const {boundingBox, size} = scene.model;
+    const modelCenter = boundingBox.getCenter(new Vector3);
+    this[$camera].position.x = modelCenter.x;
+    this[$camera].position.z = modelCenter.z;
+    this[$camera].position.y = modelCenter.y + size.y;
 
-    this[$camera].position.setFromMatrixPosition(light.matrixWorld);
+    this[$camera].lookAt(modelCenter);
     this[$camera].updateMatrixWorld(true);
-    this[$camera].lookAt(light.target.position);
 
-    // Update the camera's frustum to fully engulf the StaticShadow
-    // mesh that will be rendering the generated texture.
-    this.updateMatrixWorld(true);
-    scale.setFromMatrixScale(this.matrixWorld);
+    this.scale.x = size.x;
+    this.scale.z = size.z;
+    this.position.x = modelCenter.x;
+    this.position.z = modelCenter.z;
+    this.position.y = boundingBox.min.y;
 
-    this[$camera].top = scale.z / 2;
-    this[$camera].bottom = scale.z / -2;
-    this[$camera].left = scale.x / -2;
-    this[$camera].right = scale.x / 2;
+    this[$camera].top = size.z / 2;
+    this[$camera].bottom = size.z / -2;
+    this[$camera].left = size.x / -2;
+    this[$camera].right = size.x / 2;
     this[$camera].near = config.near!;
     this[$camera].far = config.far!;
     this[$camera].updateProjectionMatrix();


### PR DESCRIPTION
Fixes #453 
Fixes #603 
Fixes #679 

In the process of removing align-model I was able to simplify our logic considerably, including cleaning up how the static shadow is placed, since I was having trouble following its logic as I was debugging. The target is interpolated along with the other camera parameters, so this should allow us to do a smooth transition that includes zooming, position and rotation, and once combined with #729, without going through the model. 

I only removed a function from staging.ts, but it seems it wasn't formatted before? Because everything got reflowed. I'm assuming it's correct now...

#679 turned out to be mostly not a <model-viewer> bug, but we noticed that it did show an incorrect shadow for large models. The refactor of StaticShadow here should fix this.
