### PR TITLE
Update WebXR mode to match current immersive-ar

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,21 +17,16 @@
 // the appropriate flags. However, just because we have the API does not
 // guarantee that AR will work.
 export const HAS_WEBXR_DEVICE_API = navigator.xr != null &&
-    self.XRSession != null && self.XRDevice != null &&
-    self.XRDevice.prototype.supportsSession != null;
+    self.XRSession != null && navigator.xr.supportsSession != null;
 
 export const HAS_WEBXR_HIT_TEST_API =
     HAS_WEBXR_DEVICE_API && self.XRSession!.prototype.requestHitTest;
-
-export const HAS_FULLSCREEN_API = document.documentElement != null &&
-    document.documentElement.requestFullscreen != null;
 
 export const HAS_RESIZE_OBSERVER = self.ResizeObserver != null;
 
 export const HAS_INTERSECTION_OBSERVER = self.IntersectionObserver != null;
 
-export const IS_WEBXR_AR_CANDIDATE =
-    HAS_WEBXR_HIT_TEST_API && HAS_FULLSCREEN_API;
+export const IS_WEBXR_AR_CANDIDATE = HAS_WEBXR_HIT_TEST_API;
 
 export const IS_MOBILE = (() => {
   const userAgent =

--- a/src/features/ar.ts
+++ b/src/features/ar.ts
@@ -17,7 +17,7 @@ import {property} from 'lit-element';
 
 import {IS_ANDROID, IS_AR_QUICKLOOK_CANDIDATE, IS_IOS, IS_IOS_CHROME, IS_IOS_SAFARI, IS_WEBXR_AR_CANDIDATE} from '../constants.js';
 import {enumerationDeserializer} from '../conversions.js';
-import ModelViewerElementBase, {$renderer, $scene} from '../model-viewer-base.js';
+import ModelViewerElementBase, {$container, $renderer, $scene} from '../model-viewer-base.js';
 import {Constructor, deserializeUrl} from '../utilities.js';
 
 /**
@@ -95,15 +95,28 @@ const ARMode: {[index: string]: ARMode} = {
   NONE: 'none'
 };
 
+const $exitFullscreenButtonContainer = Symbol('exitFullscreenButtonContainer');
 const $arButtonContainer = Symbol('arButtonContainer');
+const $defaultExitFullscreenButton = Symbol('defaultExitFullscreenButton');
 const $enterARWithWebXR = Symbol('enterARWithWebXR');
 const $canActivateAR = Symbol('canActivateAR');
 const $arMode = Symbol('arMode');
 const $canLaunchQuickLook = Symbol('canLaunchQuickLook');
 const $quickLookBrowsers = Symbol('quickLookBrowsers');
 
+const $arButtonContainerFallbackClickHandler =
+    Symbol('arButtonContainerFallbackClickHandler');
+const $onARButtonContainerFallbackClick =
+    Symbol('onARButtonContainerFallbackClick');
 const $arButtonContainerClickHandler = Symbol('arButtonContainerClickHandler');
 const $onARButtonContainerClick = Symbol('onARButtonContainerClick');
+
+const $exitFullscreenButtonContainerClickHandler =
+    Symbol('exitFullscreenButtonContainerClickHandler');
+const $onExitFullscreenButtonClick = Symbol('onExitFullscreenButtonClick');
+
+const $fullscreenchangeHandler = Symbol('fullscreenHandler');
+const $onFullscreenchange = Symbol('onFullscreen');
 
 export interface ARInterface {
   ar: boolean;
@@ -140,8 +153,31 @@ export const ARMixin = <T extends Constructor<ModelViewerElementBase>>(
     protected[$arButtonContainer]: HTMLElement =
         this.shadowRoot!.querySelector('.ar-button') as HTMLElement;
 
+    protected[$exitFullscreenButtonContainer]: HTMLElement =
+        this.shadowRoot!.querySelector('.slot.exit-fullscreen-button') as
+        HTMLElement;
+    protected[$defaultExitFullscreenButton]: HTMLElement =
+        this.shadowRoot!.querySelector('#default-exit-fullscreen-button') as
+        HTMLElement;
+
+    // NOTE(cdata): We use a second, separate "fallback" click handler in
+    // order to work around a regression in how Chrome on Android behaves
+    // when requesting fullscreen at the same time as triggering an intent.
+    // As of m76, intents could no longer be triggered successfully if they
+    // were dispatched in the same handler as the fullscreen request. The
+    // workaround is to split both effects into their own event handlers.
+    // @see https://github.com/GoogleWebComponents/model-viewer/issues/693
+    protected[$arButtonContainerFallbackClickHandler] = (event: Event) =>
+        this[$onARButtonContainerFallbackClick](event);
+
     protected[$arButtonContainerClickHandler]: (event: Event) => void =
         (event) => this[$onARButtonContainerClick](event);
+
+    protected[$exitFullscreenButtonContainerClickHandler]:
+        () => void = () => this[$onExitFullscreenButtonClick]();
+
+    protected[$fullscreenchangeHandler]:
+        () => void = () => this[$onFullscreenchange]();
 
     protected[$arMode]: ARMode = ARMode.NONE;
 
@@ -169,6 +205,46 @@ export const ARMixin = <T extends Constructor<ModelViewerElementBase>>(
               'No AR Mode can be activated. This is probably due to missing \
 configuration or device capabilities');
           break;
+      }
+    }
+
+    connectedCallback() {
+      super.connectedCallback();
+      document.addEventListener(
+          'fullscreenchange', this[$fullscreenchangeHandler]);
+    }
+
+    disconnectedCallback() {
+      super.disconnectedCallback();
+      document.removeEventListener(
+          'fullscreenchange', this[$fullscreenchangeHandler]);
+    }
+
+    [$onExitFullscreenButtonClick]() {
+      if (document.fullscreenElement === this) {
+        document.exitFullscreen();
+      }
+    }
+
+    [$onFullscreenchange]() {
+      const renderer = this[$renderer];
+      const scene = this[$scene];
+      const isFullscreen = document.fullscreenElement === this;
+
+      if (isFullscreen) {
+        this[$container].classList.add('fullscreen');
+      } else {
+        this[$container].classList.remove('fullscreen');
+      }
+
+      if (document.fullscreenElement !== this &&
+          renderer.presentedScene === scene) {
+        try {
+          renderer.stopPresenting();
+        } catch (error) {
+          console.warn('Unexpected error while stopping AR presentation');
+          console.error(error);
+        }
       }
     }
 
@@ -220,12 +296,31 @@ configuration or device capabilities');
 
       if (showArButton) {
         this[$arButtonContainer].classList.add('enabled');
+        // NOTE(cdata): The order of the two click handlers on the "ar
+        // button container" is important, vital to the workaround described
+        // earlier in this file. Reversing their order will cause our Scene
+        // Viewer integration to break.
+        // @see https://github.com/GoogleWebComponents/model-viewer/issues/693
         this[$arButtonContainer].addEventListener(
             'click', this[$arButtonContainerClickHandler]);
+        this[$arButtonContainer].addEventListener(
+            'click', this[$arButtonContainerFallbackClickHandler]);
+        this[$exitFullscreenButtonContainer].addEventListener(
+            'click', this[$exitFullscreenButtonContainerClickHandler]);
       } else {
         this[$arButtonContainer].removeEventListener(
             'click', this[$arButtonContainerClickHandler]);
+        this[$arButtonContainer].removeEventListener(
+            'click', this[$arButtonContainerFallbackClickHandler]);
+        this[$exitFullscreenButtonContainer].removeEventListener(
+            'click', this[$exitFullscreenButtonContainerClickHandler]);
         this[$arButtonContainer].classList.remove('enabled');
+      }
+    }
+
+    [$onARButtonContainerFallbackClick](_event: Event) {
+      if (this[$arMode] === ARMode.AR_VIEWER) {
+        this.requestFullscreen();
       }
     }
 

--- a/src/test/three-components/ARRenderer-spec.ts
+++ b/src/test/three-components/ARRenderer-spec.ts
@@ -39,10 +39,9 @@ class MockXRFrame implements XRFrame {
   constructor(public session: XRSession) {
   }
 
-  // We don't use nor test the returned XRInputPose
-  // other than its existence.
-  getInputPose(_xrInputSource: XRInputSource, _frameOfRef?: XRReferenceSpace) {
-    return {} as XRInputPose;
+  // We don't use nor test the returned XRPose other than its existence.
+  getPose(_xrSpace: XRSpace, _frameOfRef: XRReferenceSpace) {
+    return {} as XRPose;
   }
 
   getViewerPose(_referenceSpace?: XRReferenceSpace): XRViewerPose {
@@ -71,13 +70,17 @@ suite('ARRenderer', () => {
 
     arRenderer.resolveARSession = async () => {
       class FakeSession extends EventTarget implements XRSession {
-        public baseLayer: XRLayer = {} as XRLayer;
+        public renderState: XRRenderState = {baseLayer: {} as XRLayer} as
+            XRRenderState;
+
+        updateRenderState(_object: any) {
+        }
 
         requestFrameOfReference() {
           return {};
         }
 
-        async requestReferenceSpace(_options: XRReferenceSpaceOptions):
+        async requestReferenceSpace(_type: XRReferenceSpaceType):
             Promise<XRReferenceSpace> {
           return {
             originOffset: {
@@ -88,18 +91,20 @@ suite('ARRenderer', () => {
           } as XRReferenceSpace;
         }
 
-        getInputSources() {
+        get inputSources(): Array<XRInputSource> {
           return inputSources;
         }
 
         /**
          * Returns a hit if ray collides with the XZ plane
          */
-        async requestHitTest(
-            origin: Float32Array, dir: Float32Array,
-            _frameOfRef: XRFrameOfReference): Promise<Array<XRHitResult>> {
+        async requestHitTest(rayIn: XRRay, _frameOfRef: XRFrameOfReference):
+            Promise<Array<XRHitResult>> {
           const hits = [];
-          const ray = new Ray(new Vector3(...origin), new Vector3(...dir));
+          const ray = new Ray(
+              new Vector3(rayIn.origin.x, rayIn.origin.y, rayIn.origin.z),
+              new Vector3(
+                  rayIn.direction.x, rayIn.direction.y, rayIn.direction.z));
           const success = ray.intersectPlane(xzPlane, vec3);
 
           if (success) {
@@ -227,7 +232,12 @@ suite('ARRenderer', () => {
         arRenderer.camera.matrix.setPosition(new Vector3(10, 2, 0));
         arRenderer.camera.updateMatrixWorld(true);
 
-        setInputSources([{targetRayMode: 'screen', handedness: ''}]);
+        setInputSources([{
+          targetRayMode: 'screen' as XRTargetRayMode,
+          handedness: '' as XRHandedness,
+          targetRaySpace: {} as XRSpace,
+          profiles: []
+        }]);
         arRenderer.processXRInput(new MockXRFrame(xrSession));
         await waitForEvent(arRenderer, 'modelmove');
 
@@ -253,7 +263,12 @@ suite('ARRenderer', () => {
         arRenderer.camera.updateMatrixWorld(true);
         await arRenderer.present(modelScene);
 
-        setInputSources([{targetRayMode: 'gaze', handedness: ''}]);
+        setInputSources([{
+          targetRayMode: 'gaze' as XRTargetRayMode,
+          handedness: '' as XRHandedness,
+          targetRaySpace: {} as XRSpace,
+          profiles: []
+        }]);
         arRenderer.processXRInput(new MockXRFrame(xrSession));
         await timePasses();
 

--- a/src/test/three-components/ARRenderer-spec.ts
+++ b/src/test/three-components/ARRenderer-spec.ts
@@ -136,7 +136,7 @@ suite('ARRenderer', () => {
   setup(() => {
     element = new ModelViewerElementBase();
     renderer = element[$renderer];
-    arRenderer = ARRenderer.fromInlineRenderer(renderer);
+    arRenderer = new ARRenderer(renderer);
   });
 
   teardown(async () => {

--- a/src/three-components/ARRenderer.ts
+++ b/src/three-components/ARRenderer.ts
@@ -106,6 +106,10 @@ export class ARRenderer extends EventDispatcher {
     // TODO: this method should be added to three.js's exported interface.
     (this.renderer as any)
         .setFramebuffer(session.renderState.baseLayer!.framebuffer);
+    this.renderer.setSize(session.renderState.baseLayer!.framebufferWidth,
+                          session.renderState.baseLayer!.framebufferHeight,
+                          false);
+
     return session;
   }
 
@@ -321,8 +325,7 @@ export class ARRenderer extends EventDispatcher {
 
     for (const view of (frame as any).getViewerPose(this[$refSpace]).views) {
       const viewport = session.renderState.baseLayer!.getViewport(view);
-      this.renderer.setViewport(0, 0, viewport.width, viewport.height);
-      this.renderer.setSize(viewport.width, viewport.height, false);
+      this.renderer.setViewport(viewport.x, viewport.y, viewport.width, viewport.height);
       this.camera.projectionMatrix.fromArray(view.projectionMatrix);
       const viewMatrix = matrix4.fromArray(view.transform.inverse.matrix);
 

--- a/src/three-components/ARRenderer.ts
+++ b/src/three-components/ARRenderer.ts
@@ -22,15 +22,12 @@ import {assertContext} from './WebGLUtils.js';
 
 const $presentedScene = Symbol('presentedScene');
 
-const $device = Symbol('device');
-const $devicePromise = Symbol('devicePromise');
 const $rafId = Symbol('rafId');
 const $currentSession = Symbol('currentSession');
 const $tick = Symbol('tick');
 const $refSpace = Symbol('refSpace');
 const $resolveCleanup = Symbol('resolveCleanup');
 
-const $outputCanvas = Symbol('outputCanvas');
 const $outputContext = Symbol('outputContext');
 
 const $onWebXRFrame = Symbol('onWebXRFrame');
@@ -38,12 +35,10 @@ const $postSessionCleanup = Symbol('postSessionCleanup');
 
 const matrix4 = new Matrix4();
 const vector3 = new Vector3();
-const originArray = new Float32Array(3);
-const directionArray = new Float32Array(3);
 
 export class ARRenderer extends EventDispatcher {
-  public renderer: WebGLRenderer|null;
-  public inputCanvas: HTMLCanvasElement;
+  public renderer: WebGLRenderer;
+  public parentRenderer: Renderer;
   public inputContext: WebGLRenderingContext;
 
   public camera: PerspectiveCamera = new PerspectiveCamera();
@@ -52,93 +47,66 @@ export class ARRenderer extends EventDispatcher {
   public reticle: Reticle = new Reticle(this.camera);
   public raycaster: Raycaster|null = null;
 
-  private[$outputCanvas]: HTMLCanvasElement|null = null;
   private[$outputContext]: WebGLRenderingContext|null = null;
   private[$rafId]: number|null = null;
   private[$currentSession]: XRSession|null = null;
   private[$refSpace]: XRCoordinateSystem|null = null;
   private[$presentedScene]: ModelScene|null = null;
   private[$resolveCleanup]: ((...args: any[]) => void)|null = null;
-  private[$device]: XRDevice|null = null;
-  private[$devicePromise]: Promise<void|XRDevice>;
 
   /**
    * Given an inline Renderer, construct an ARRenderer and return it
    */
   static fromInlineRenderer(renderer: Renderer) {
-    return new ARRenderer(renderer.canvas, renderer.context!);
+    return new ARRenderer(renderer);
   }
 
-  constructor(
-      inputCanvas: HTMLCanvasElement, inputContext: WebGLRenderingContext) {
+  constructor(parentRenderer: Renderer) {
     super();
+    const inputContext: WebGLRenderingContext = parentRenderer.context!;
+    this.parentRenderer = parentRenderer;
 
-    this.renderer = null;
+    this.renderer = parentRenderer.renderer;
 
-    this.inputCanvas = inputCanvas;
     this.inputContext = inputContext;
 
     this.camera.matrixAutoUpdate = false;
 
     this.scene.add(this.reticle);
     this.scene.add(this.dolly);
-
-    // NOTE: XRDevice is being removed
-    // @see https://github.com/immersive-web/webxr/pull/405
-    this[$devicePromise] = this.resolveDevice()
-                               .then((device) => {
-                                 return this[$device] = device;
-                               })
-                               .catch((error) => {
-                                 console.warn(error);
-                                 console.warn('Browser AR will be disabled');
-                               });
   }
 
   initializeRenderer() {
-    if (this.renderer != null) {
-      return;
-    }
-
-    this.renderer = new WebGLRenderer(
-        {canvas: this.inputCanvas, context: this.inputContext});
-    this.renderer.setSize(window.innerWidth, window.innerHeight);
     this.renderer.setPixelRatio(1);
-    this.renderer.autoClear = false;
-    this.renderer.gammaOutput = true;
-    this.renderer.gammaFactor = 2.2;
-  }
-
-  async resolveDevice(): Promise<XRDevice> {
-    assertIsArCandidate();
-
-    return await navigator.xr!.requestDevice();
   }
 
   async resolveARSession(): Promise<XRSession> {
     assertIsArCandidate();
 
-    const device = this[$device];
+    const session: XRSession =
+        await navigator.xr!.requestSession!('immersive-ar');
 
-    const session: XRSession = await device!.requestSession(
-        {environmentIntegration: true, outputContext: this.outputContext!} as
-        any);
+    const gl: WebGLRenderingContext = assertContext(this.renderer.getContext());
 
-    const gl: WebGLRenderingContext =
-        assertContext(this.renderer!.getContext());
+    // `makeXRCompatible` replaced `setCompatibleXRDevice` in Chrome M73 @TODO
+    // #293, handle WebXR API changes. WARNING: this can cause a GL context
+    // loss according to the spec, though current implementations don't do so.
+    await gl.makeXRCompatible();
+    this[$outputContext] = gl;
 
-    // `makeXRCompatible` replaced `setCompatibleXRDevice` in Chrome M73
-    // @TODO #293, handle WebXR API changes
-    if ('setCompatibleXRDevice' in gl) {
-      await gl.setCompatibleXRDevice(device!);
-    } else {
-      await (gl as any).makeXRCompatible();
-    }
+    session.updateRenderState(
+        {baseLayer: new XRWebGLLayer(session, gl, {alpha: true})});
 
-    session.baseLayer = new XRWebGLLayer(session, gl, {alpha: true});
+    // The render state update takes effect on the next animation frame. Wait
+    // for it so that we get a framebuffer.
+    let waitForAnimationFrame = new Promise((resolve, _reject) => {
+      session.requestAnimationFrame(() => resolve());
+    });
+    await waitForAnimationFrame;
+
     (this.renderer as any)
-        .setFramebuffer((session.baseLayer as XRWebGLLayer).framebuffer);
-
+        .setFramebuffer(
+            (session.renderState.baseLayer as XRWebGLLayer).framebuffer);
     return session;
   }
 
@@ -156,12 +124,7 @@ export class ARRenderer extends EventDispatcher {
   async supportsPresentation() {
     try {
       assertIsArCandidate();
-
-      const device: XRDevice = await this[$devicePromise] as XRDevice;
-      await device.supportsSession(
-          {environmentIntegration: true, outputContext: this.outputContext!} as
-          any);
-
+      await navigator.xr!.supportsSession!('immersive-ar');
       return true;
     } catch (error) {
       return false;
@@ -171,10 +134,9 @@ export class ARRenderer extends EventDispatcher {
   /**
    * Present a scene in AR
    */
-  async present(scene: ModelScene): Promise<HTMLCanvasElement> {
+  async present(scene: ModelScene): Promise<void> {
     if (this.isPresenting) {
       console.warn('Cannot present while a model is already presenting');
-      return this.outputCanvas;
     }
 
     scene.model.scale.set(1, 1, 1);
@@ -190,18 +152,10 @@ export class ARRenderer extends EventDispatcher {
 
     // `requestReferenceSpace` replaced `requestFrameOfReference` in Chrome M73
     // @TODO #293, handle WebXR API changes
-    this[$refSpace] = await (
-        'requestFrameOfReference' in this[$currentSession]!?
-            (this[$currentSession] as any)
-                .requestFrameOfReference('eye-level') :
-            this[$currentSession]!.requestReferenceSpace({
-              type: 'stationary',
-              subtype: 'eye-level',
-            } as any));
+    this[$refSpace] =
+        await (this[$currentSession]!.requestReferenceSpace('local') as any);
 
     this[$tick]();
-
-    return this.outputCanvas;
   }
 
   /**
@@ -232,16 +186,18 @@ export class ARRenderer extends EventDispatcher {
   }
 
   [$postSessionCleanup]() {
+    (this.renderer as any).setFramebuffer(null);
+    this.parentRenderer.setRendererSize(1, 1);
+
+    // Trigger a parent renderer update. TODO(klausw): are these all
+    // necessary and sufficient?
     if (this[$presentedScene] != null) {
       this.dolly.remove(this[$presentedScene]!);
+      this[$presentedScene]!.isDirty = true;
     }
 
     this[$refSpace] = null;
     this[$presentedScene] = null;
-
-    if (this.outputCanvas.parentNode != null) {
-      this.outputCanvas.parentNode.removeChild(this.outputCanvas);
-    }
 
     if (this[$resolveCleanup] != null) {
       this[$resolveCleanup]!();
@@ -255,27 +211,7 @@ export class ARRenderer extends EventDispatcher {
     return this[$presentedScene] != null;
   }
 
-  get outputCanvas(): HTMLCanvasElement {
-    if (this[$outputCanvas] == null) {
-      this[$outputCanvas] = document.createElement('canvas');
-      this[$outputCanvas]!.setAttribute('style', `
-display: block;
-position: absolute;
-top: 0px;
-left: 0px;
-width: 100%;
-height: 100%;`);
-    }
-
-    return this[$outputCanvas]!;
-  }
-
   get outputContext() {
-    if (this[$outputContext] == null) {
-      this[$outputContext] =
-          this.outputCanvas.getContext('xrpresent') as WebGLRenderingContext;
-    }
-
     return this[$outputContext];
   }
 
@@ -292,13 +228,13 @@ height: 100%;`);
     // Eventually we might use input coordinates for this.
     this.raycaster.setFromCamera({x: 0, y: 0}, this.camera);
     const ray = this.raycaster.ray;
-    originArray.set(ray.origin.toArray());
-    directionArray.set(ray.direction.toArray());
+    let xrray: XRRay =
+        new XRRay(ray.origin as DOMPointInit, ray.direction as DOMPointInit);
 
     let hits;
     try {
       hits = await (this[$currentSession] as any)
-                 .requestHitTest(originArray, directionArray, this[$refSpace]);
+                 .requestHitTest(xrray, this[$refSpace]);
     } catch (e) {
       // Spec says this should no longer throw on invalid requests:
       // https://github.com/immersive-web/hit-test/issues/24
@@ -340,14 +276,15 @@ height: 100%;`);
     // which is only added to the session's active input sources immediately
     // before `selectstart` and removed immediately after `selectend` event.
     // If we have a 'screen' source here, it means the output canvas was tapped.
-    const sources = session.getInputSources().filter(
-        input => input.targetRayMode === 'screen');
+    const sources = Array.from(session.inputSources)
+                        .filter(input => input.targetRayMode === 'screen');
 
     if (sources.length === 0) {
       return;
     }
 
-    const pose = (frame as any).getInputPose(sources[0], this[$refSpace])
+    const pose =
+        (frame as any).getPose(sources[0].targetRaySpace, this[$refSpace])
     if (pose) {
       this.placeModel();
     }
@@ -376,12 +313,13 @@ height: 100%;`);
       return;
     }
 
-    for (const view of (frame as any).views) {
-      const viewport = (session.baseLayer as XRWebGLLayer).getViewport(view);
-      this.renderer!.setViewport(0, 0, viewport.width, viewport.height);
-      this.renderer!.setSize(viewport.width, viewport.height, false);
+    for (const view of (frame as any).getViewerPose(this[$refSpace]).views) {
+      const viewport =
+          (session.renderState.baseLayer as XRWebGLLayer).getViewport(view);
+      this.renderer.setViewport(0, 0, viewport.width, viewport.height);
+      this.renderer.setSize(viewport.width, viewport.height, false);
       this.camera.projectionMatrix.fromArray(view.projectionMatrix);
-      const viewMatrix = matrix4.fromArray(pose.getViewMatrix(view));
+      const viewMatrix = matrix4.fromArray(view.transform.inverse.matrix);
 
       this.camera.matrix.getInverse(viewMatrix);
       this.camera.updateMatrixWorld(true);
@@ -395,7 +333,7 @@ height: 100%;`);
       // NOTE: Clearing depth caused issues on Samsung devices
       // @see https://github.com/googlecodelabs/ar-with-webxr/issues/8
       // this.renderer.clearDepth();
-      this.renderer!.render(this.scene, this.camera);
+      this.renderer.render(this.scene, this.camera);
     }
   }
 }

--- a/src/three-components/Renderer.ts
+++ b/src/three-components/Renderer.ts
@@ -90,7 +90,7 @@ export default class Renderer extends EventDispatcher {
       console.warn(error);
     }
 
-    this[$arRenderer] = ARRenderer.fromInlineRenderer(this);
+    this[$arRenderer] = new ARRenderer(this);
     this.textureUtils = this.canRender ? new TextureUtils(this.renderer) : null;
 
     this.setRendererSize(1, 1);

--- a/src/three-components/Renderer.ts
+++ b/src/three-components/Renderer.ts
@@ -128,7 +128,7 @@ export default class Renderer extends EventDispatcher {
     return this[$arRenderer].presentedScene;
   }
 
-  async present(scene: ModelScene): Promise<HTMLCanvasElement> {
+  async present(scene: ModelScene): Promise<void> {
     try {
       return await this[$arRenderer].present(scene);
     } catch (error) {

--- a/src/three-components/Reticle.ts
+++ b/src/three-components/Reticle.ts
@@ -15,9 +15,6 @@
 
 import {Camera, Math as ThreeMath, Matrix4, Mesh, MeshBasicMaterial, Object3D, Raycaster, RingGeometry, Vector3,} from 'three';
 
-const originArray = new Float32Array(3);
-const directionArray = new Float32Array(3);
-
 /**
  * The Reticle class creates an object that repeatedly calls
  * `xrSession.requestHitTest()` to render a ring along a found
@@ -61,15 +58,12 @@ export default class Reticle extends Object3D {
     this.raycaster = this.raycaster || new Raycaster();
     this.raycaster.setFromCamera({x: 0, y: 0}, this.camera);
     const ray = this.raycaster.ray;
-
-    originArray.set(ray.origin.toArray());
-    directionArray.set(ray.direction.toArray());
+    let xrray: XRRay = new XRRay(ray.origin, ray.direction);
 
     let hits: Array<XRHitResult>;
 
     try {
-      hits =
-          await session.requestHitTest(originArray, directionArray, frameOfRef);
+      hits = await session.requestHitTest(xrray, frameOfRef);
     } catch (error) {
       hits = [];
     }

--- a/src/types/webxr.d.ts
+++ b/src/types/webxr.d.ts
@@ -120,12 +120,22 @@ interface XRFrame {
 type XRFrameRequestCallback = (time: number, frame: XRFrame) => void;
 
 interface XRRenderState {
-  baseLayer: XRLayer;
+  readonly depthNear: number;
+  readonly depthFar: number;
+  readonly inlineVerticalFieldOfView?: number;
+  readonly baseLayer?: XRWebGLLayer;
+}
+
+interface XRRenderStateInit {
+  depthNear?: number;
+  depthFar?: number;
+  inlineVerticalFieldOfView?: number;
+  baseLayer?: XRWebGLLayer;
 }
 
 interface XRSession extends EventTarget {
   renderState: XRRenderState;
-  updateRenderState(obj: any): any;
+  updateRenderState(state?: XRRenderStateInit): any;
   requestReferenceSpace(type: XRReferenceSpaceType): Promise<XRReferenceSpace>;
   requestHitTest(ray: XRRay, frameOfReference: XRFrameOfReference):
       Promise<XRHitResult[]>;

--- a/src/types/webxr.d.ts
+++ b/src/types/webxr.d.ts
@@ -161,6 +161,8 @@ interface XRLayer {}
 
 declare class XRWebGLLayer implements XRLayer {
   public framebuffer: WebGLFramebuffer;
+  public framebufferWidth: number; 
+  public framebufferHeight: number; 
 
   constructor(
       session: XRSession, gl: WebGLRenderingContext,

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import {HAS_FULLSCREEN_API, HAS_WEBXR_DEVICE_API, HAS_WEBXR_HIT_TEST_API, IS_WEBXR_AR_CANDIDATE} from './constants.js';
+import {HAS_WEBXR_DEVICE_API, HAS_WEBXR_HIT_TEST_API, IS_WEBXR_AR_CANDIDATE} from './constants.js';
 
 export type Constructor<T = object> = {
   new (...args: any[]): T,
@@ -30,10 +30,6 @@ export const assertIsArCandidate = () => {
   }
 
   const missingApis = [];
-
-  if (!HAS_FULLSCREEN_API) {
-    missingApis.push('Fullscreen API');
-  }
 
   if (!HAS_WEBXR_DEVICE_API) {
     missingApis.push('WebXR Device API');


### PR DESCRIPTION
Get WebXR mode working again using the current API as implemented in Chrome Canary using immersive-ar mode. 

This commit is a snapshot of an airplane hacking session, it's in rough shape due to having a barely-functioning dev environment. Please ignore superficial issues such as indentation, those should obviously be fixed before merging. There's also extra logging, and I was taking shortcuts to get it working such as overriding feature checks. I'm turning it into a PR at @elalish 's suggestion, at least it should be useful as a roadmap of areas that need changing.

FYI, the hit test API is likely to undergo more changes in the near future again, so that will need further tweaks at that time.

Fixes #495