### PR TITLE
Change logic for detecting iOS 13 Safari on iPad

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -54,19 +54,6 @@ export const OFFSCREEN_CANVAS_SUPPORT_BITMAP =
 
 export const IS_ANDROID = /android/i.test(navigator.userAgent);
 
-export const IS_IOS =
-    /iPad|iPhone|iPod/.test(navigator.userAgent) && !(self as any).MSStream;
-
-export const IS_AR_QUICKLOOK_CANDIDATE = (() => {
-  const tempAnchor = document.createElement('a');
-
-  return Boolean(
-      tempAnchor.relList && tempAnchor.relList.supports &&
-      tempAnchor.relList.supports('ar'));
-})();
-
-// @see https://developer.chrome.com/multidevice/user-agent
-export const IS_IOS_CHROME = IS_IOS && /CriOS\//.test(navigator.userAgent);
 // Prior to iOS 13, detecting iOS Safari was relatively straight-forward.
 // As of iOS 13, Safari on iPad (in its default configuration) reports the same
 // user-agent string as Safari on desktop MacOS. Strictly speaking, we only care
@@ -78,8 +65,20 @@ export const IS_IOS_CHROME = IS_IOS && /CriOS\//.test(navigator.userAgent);
 // @see https://stackoverflow.com/questions/57765958/how-to-detect-ipad-and-ipad-os-version-in-ios-13-and-up
 // @see https://forums.developer.apple.com/thread/119186
 // @see https://github.com/GoogleWebComponents/model-viewer/issues/758
-export const IS_IOS_SAFARI = /Safari\//.test(navigator.userAgent) &&
-    (IS_IOS ||
-     (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1));
+export const IS_IOS =
+    (/iPad|iPhone|iPod/.test(navigator.userAgent) && !(self as any).MSStream) ||
+    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+
+export const IS_AR_QUICKLOOK_CANDIDATE = (() => {
+  const tempAnchor = document.createElement('a');
+
+  return Boolean(
+      tempAnchor.relList && tempAnchor.relList.supports &&
+      tempAnchor.relList.supports('ar'));
+})();
+
+// @see https://developer.chrome.com/multidevice/user-agent
+export const IS_IOS_CHROME = IS_IOS && /CriOS\//.test(navigator.userAgent);
+export const IS_IOS_SAFARI = IS_IOS && /Safari\//.test(navigator.userAgent);
 export const IS_IE11 =
     !((window as any).ActiveXObject) && 'ActiveXObject' in window;


### PR DESCRIPTION
Fixes #758 

In #775 we addressed incorrect detection of iOS 13 Safari on iPad. Unfortunately, the logic was subtly flawed, and we discovered the flaw when testing the fix on an iPad Pro this morning. This change addresses the flaw. It has been tested on an iOS 13 iPad Pro, iOS 12 iPad Air and MacOS Safari to ensure that the AR button display cases are what we expect.

Once this goes out, we will also back-port this as v0.6.2.