### PR TITLE
Fix over-spin reversal

### DIFF
--- a/src/test/features/controls-spec.ts
+++ b/src/test/features/controls-spec.ts
@@ -236,7 +236,9 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
           await timePasses();
 
           expect(element.getFieldOfView()).to.be.closeTo(fieldOfView, 0.00001);
-          const orbit = element.getCameraOrbit();
+          let orbit = element.getCameraOrbit();
+          // round to nearest 0.0001
+          orbit.theta = Math.round(orbit.theta * 10000) / 10000;
           expect(`${orbit.theta}rad ${orbit.phi}rad ${orbit.radius}m`)
               .to.equal(cameraOrbit);
         });

--- a/src/test/three-components/SmoothControls-spec.ts
+++ b/src/test/three-components/SmoothControls-spec.ts
@@ -158,6 +158,22 @@ suite('SmoothControls', () => {
           expect(controls.getCameraSpherical().theta)
               .to.be.closeTo(-QUARTER_PI, 0.0001);
         });
+
+        test(
+            'adjustOrbit does not move the goal theta more than pi past the current theta',
+            () => {
+              controls.adjustOrbit(-Math.PI * 3 / 2, 0, 0, 0);
+
+              controls.update(performance.now(), ONE_FRAME_DELTA);
+              const startingTheta = controls.getCameraSpherical().theta;
+              expect(startingTheta).to.be.greaterThan(0);
+
+              controls.adjustOrbit(-Math.PI * 3 / 2, 0, 0, 0);
+              settleControls(controls);
+              const goalTheta = controls.getCameraSpherical().theta;
+              expect(goalTheta).to.be.greaterThan(-Math.PI);
+              expect(goalTheta).to.be.lessThan(startingTheta - Math.PI);
+            });
       });
     });
 

--- a/src/three-components/SmoothControls.ts
+++ b/src/three-components/SmoothControls.ts
@@ -22,8 +22,7 @@ export type InteractionPolicy = 'always-allow'|'allow-when-focused';
 export type TouchMode = 'rotate'|'zoom';
 
 interface Pointer {
-  clientX: number,
-  clientY: number,
+  clientX: number, clientY: number,
 }
 
 export interface SmoothControlsOptions {
@@ -468,7 +467,10 @@ export class SmoothControls extends EventDispatcher {
       deltaFov: number): boolean {
     const {theta, phi, radius} = this[$goalSpherical];
 
-    const goalTheta = theta - deltaTheta;
+    const dTheta = this[$spherical].theta - theta;
+    const dThetaLimit = Math.PI - 0.001;
+    const goalTheta =
+        theta - clamp(deltaTheta, -dThetaLimit - dTheta, dThetaLimit - dTheta);
     const goalPhi = phi - deltaPhi;
     const goalRadius = radius + deltaRadius;
     let handled = this.setOrbit(goalTheta, goalPhi, goalRadius);
@@ -586,7 +588,9 @@ export class SmoothControls extends EventDispatcher {
 
   // Wraps to bewteen -pi and pi
   private[$wrapAngle](radians: number): number {
-    return (radians + Math.PI) % (2 * Math.PI) - Math.PI;
+    const normalized = (radians + Math.PI) / (2 * Math.PI);
+    const wrapped = normalized - Math.floor(normalized);
+    return wrapped * 2 * Math.PI - Math.PI;
   }
 
   private[$pixelLengthToSphericalAngle](pixelLength: number): number {
@@ -652,10 +656,10 @@ export class SmoothControls extends EventDispatcher {
 
   private[$handleSinglePointerMove](pointer: Pointer): boolean {
     const {clientX, clientY} = pointer;
-    const deltaTheta =
-        this[$pixelLengthToSphericalAngle](clientX - this[$lastPointerPosition].clientX);
-    const deltaPhi =
-        this[$pixelLengthToSphericalAngle](clientY - this[$lastPointerPosition].clientY);
+    const deltaTheta = this[$pixelLengthToSphericalAngle](
+        clientX - this[$lastPointerPosition].clientX);
+    const deltaPhi = this[$pixelLengthToSphericalAngle](
+        clientY - this[$lastPointerPosition].clientY);
 
     this[$lastPointerPosition].clientX = clientX;
     this[$lastPointerPosition].clientY = clientY;

--- a/src/three-components/SmoothControls.ts
+++ b/src/three-components/SmoothControls.ts
@@ -460,7 +460,8 @@ export class SmoothControls extends EventDispatcher {
 
   /**
    * Adjust the orbital position of the camera relative to its current orbital
-   * position.
+   * position. Does not let the theta goal get more than pi ahead of the current
+   * theta, which ensures interpolation continues in the direction of the delta.
    */
   adjustOrbit(
       deltaTheta: number, deltaPhi: number, deltaRadius: number,


### PR DESCRIPTION
Fixes #778 

This change means adjustOrbit should not be used to attain an absolute theta (since it will clamp), but that seems fine since we already have a setOrbit method for that purpose. 
