### PR TITLE
Force canvas onto its own render layer

### DIFF
--- a/src/template.ts
+++ b/src/template.ts
@@ -45,6 +45,12 @@ template.innerHTML = `
       width: 100%;
       height: 100%;
       display: none;
+      /* NOTE(cdata): Chrome 76 and below apparently have a bug
+       * that causes our canvas not to display pixels unless it is
+       * on its own render layer
+       * @see https://github.com/GoogleWebComponents/model-viewer/pull/755#issuecomment-536597893
+       */
+      transform: translateZ(0);
     }
 
     canvas.show {


### PR DESCRIPTION
Although we fixed computation-based visibility errors in #755 , Chrome 76 apparently has a rendering disparity that causes render layers to be messed up without any interventions by us. This is what the render layers look like without / with the intervention:

Without intervention | With forced `transform`
---------------------|-------------------------
![image](https://user-images.githubusercontent.com/240083/65898718-0bc35c80-e367-11e9-8e8a-6a60a9964e4e.png)|![image](https://user-images.githubusercontent.com/240083/65898864-50e78e80-e367-11e9-974f-0505cb8c29de.png)


