### PR TITLE
Stop event bubbling when handling behavior is 'prevent-all'

### DIFF
--- a/src/three-components/SmoothControls.ts
+++ b/src/three-components/SmoothControls.ts
@@ -638,6 +638,7 @@ export class SmoothControls extends EventDispatcher {
     if ((handled || this[$options].eventHandlingBehavior === 'prevent-all') &&
         event.cancelable) {
       event.preventDefault();
+      event.stopPropagation();
     };
   }
 
@@ -699,6 +700,7 @@ export class SmoothControls extends EventDispatcher {
          this[$options].eventHandlingBehavior === 'prevent-all') &&
         event.cancelable) {
       event.preventDefault();
+      event.stopPropagation();
     }
   }
 
@@ -740,6 +742,7 @@ export class SmoothControls extends EventDispatcher {
         (handled || this[$options].eventHandlingBehavior === 'prevent-all') &&
         event.cancelable) {
       event.preventDefault();
+      event.stopPropagation();
     }
   }
 }


### PR DESCRIPTION
Fixes #794

It seems like we are doing `preventDefault()` but we should also be doing `stopPropagation()`. Do you know if this would have any ill-intended events?

I also couldn't quite figure out how to test this.
https://github.com/GoogleWebComponents/model-viewer/blob/master/src/test/three-components/SmoothControls-spec.ts#L304-L308

Maybe we need to register another event on it and make sure it doesn't fire?