### PR TITLE
Fixed camera reversal

### DIFF
--- a/src/test/three-components/SmoothControls-spec.ts
+++ b/src/test/three-components/SmoothControls-spec.ts
@@ -147,14 +147,29 @@ suite('SmoothControls', () => {
           settleControls(controls);
           expect(controls.getCameraSpherical().theta).to.be.equal(QUARTER_PI);
 
-          controls.setOrbit(4 * Math.PI - QUARTER_PI);
+          controls.setOrbit(4 * Math.PI - HALF_PI);
+          expect(controls.getCameraSpherical().theta)
+              .to.be.closeTo(4 * Math.PI + QUARTER_PI, 0.0001);
+
           controls.update(performance.now(), ONE_FRAME_DELTA);
           expect(Math.abs(controls.getCameraSpherical().theta))
-              .to.be.lessThan(QUARTER_PI);
+              .to.be.lessThan(4 * Math.PI + QUARTER_PI);
 
           settleControls(controls);
           expect(controls.getCameraSpherical().theta)
-              .to.be.closeTo(-QUARTER_PI, 0.0001);
+              .to.be.closeTo(4 * Math.PI - HALF_PI, 0.0001);
+
+          controls.setOrbit(THREE_QUARTERS_PI);
+          expect(controls.getCameraSpherical().theta)
+              .to.be.closeTo(Math.PI + HALF_PI, 0.0001);
+
+          controls.update(performance.now(), ONE_FRAME_DELTA);
+          expect(Math.abs(controls.getCameraSpherical().theta))
+              .to.be.lessThan(Math.PI + HALF_PI);
+
+          settleControls(controls);
+          expect(controls.getCameraSpherical().theta)
+              .to.be.closeTo(THREE_QUARTERS_PI, 0.0001);
         });
 
         test(
@@ -169,8 +184,8 @@ suite('SmoothControls', () => {
               controls.adjustOrbit(-Math.PI * 3 / 2, 0, 0, 0);
               settleControls(controls);
               const goalTheta = controls.getCameraSpherical().theta;
-              expect(goalTheta).to.be.greaterThan(-Math.PI);
-              expect(goalTheta).to.be.lessThan(startingTheta - Math.PI);
+              expect(goalTheta).to.be.greaterThan(Math.PI);
+              expect(goalTheta).to.be.lessThan(startingTheta + Math.PI);
             });
       });
     });

--- a/src/three-components/SmoothControls.ts
+++ b/src/three-components/SmoothControls.ts
@@ -405,8 +405,6 @@ export class SmoothControls extends EventDispatcher {
       this[$spherical].theta =
           this[$wrapAngle](this[$spherical].theta - nextTheta) + nextTheta;
     }
-    // const nextTheta = this[$wrapAngle](goalTheta);
-    // this[$spherical].theta += nextTheta - goalTheta;
 
     const nextPhi = clamp(goalPhi, minimumPolarAngle!, maximumPolarAngle!);
     const nextRadius = clamp(goalRadius, minimumRadius!, maximumRadius!);
@@ -470,17 +468,6 @@ export class SmoothControls extends EventDispatcher {
     const dThetaLimit = Math.PI - 0.001;
     const goalTheta =
         theta - clamp(deltaTheta, -dThetaLimit - dTheta, dThetaLimit - dTheta);
-
-    // console.log(
-    //     'last theta = ',
-    //     this[$spherical].theta * 180 / Math.PI,
-    //     ', last goal = ',
-    //     theta * 180 / Math.PI,
-    //     ', dTheta = ',
-    //     dTheta * 180 / Math.PI,
-    //     ', next goal = ',
-    //     goalTheta * 180 / Math.PI);
-
     const goalPhi = phi - deltaPhi;
     const goalRadius = radius + deltaRadius;
     let handled = this.setOrbit(goalTheta, goalPhi, goalRadius);

--- a/src/three-components/SmoothControls.ts
+++ b/src/three-components/SmoothControls.ts
@@ -398,8 +398,16 @@ export class SmoothControls extends EventDispatcher {
 
     const {theta, phi, radius} = this[$goalSpherical];
 
-    const nextTheta = this[$wrapAngle](
-        clamp(goalTheta, minimumAzimuthalAngle!, maximumAzimuthalAngle!));
+    const nextTheta =
+        clamp(goalTheta, minimumAzimuthalAngle!, maximumAzimuthalAngle!);
+    if (!isFinite(minimumAzimuthalAngle!) &&
+        !isFinite(maximumAzimuthalAngle!)) {
+      this[$spherical].theta =
+          this[$wrapAngle](this[$spherical].theta - nextTheta) + nextTheta;
+    }
+    // const nextTheta = this[$wrapAngle](goalTheta);
+    // this[$spherical].theta += nextTheta - goalTheta;
+
     const nextPhi = clamp(goalPhi, minimumPolarAngle!, maximumPolarAngle!);
     const nextRadius = clamp(goalRadius, minimumRadius!, maximumRadius!);
 
@@ -462,6 +470,17 @@ export class SmoothControls extends EventDispatcher {
     const dThetaLimit = Math.PI - 0.001;
     const goalTheta =
         theta - clamp(deltaTheta, -dThetaLimit - dTheta, dThetaLimit - dTheta);
+
+    // console.log(
+    //     'last theta = ',
+    //     this[$spherical].theta * 180 / Math.PI,
+    //     ', last goal = ',
+    //     theta * 180 / Math.PI,
+    //     ', dTheta = ',
+    //     dTheta * 180 / Math.PI,
+    //     ', next goal = ',
+    //     goalTheta * 180 / Math.PI);
+
     const goalPhi = phi - deltaPhi;
     const goalRadius = radius + deltaRadius;
     let handled = this.setOrbit(goalTheta, goalPhi, goalRadius);


### PR DESCRIPTION
Fixes #800 

Now when you set orbit to theta = 3.5*pi rad, it will immediately jump theta to 4*pi (no camera motion), then interpolate in the proper direction (-0.5*pi) to the set goal. Before we were clamping the goal between -pi and pi, which was part of how this bug formed.