### PR TITLE
Fixed autorotate interpolation

### DIFF
--- a/src/features/controls.ts
+++ b/src/features/controls.ts
@@ -306,7 +306,7 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
       const target = this.getCameraTarget();
       if (!this[$scene].pivotCenter.equals(target)) {
         this[$scene].pivotCenter.copy(target);
-        this[$scene].setRotation();
+        this[$scene].setRotation(this[$scene].pivot.rotation.y);
       }
     }
 

--- a/src/features/controls.ts
+++ b/src/features/controls.ts
@@ -277,6 +277,7 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
 
       this[$controls].setTarget(target);
       this[$scene].pivotCenter.copy(target);
+      this[$scene].setRotation(this[$scene].pivot.rotation.y);
     }
 
     [$tick](time: number, delta: number) {
@@ -302,6 +303,11 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
       }
 
       this[$controls].update(time, delta);
+      const target = this.getCameraTarget();
+      if (!this[$scene].pivotCenter.equals(target)) {
+        this[$scene].pivotCenter.copy(target);
+        this[$scene].setRotation();
+      }
     }
 
     [$deferInteractionPrompt]() {

--- a/src/three-components/ModelScene.ts
+++ b/src/three-components/ModelScene.ts
@@ -196,7 +196,7 @@ export default class ModelScene extends Scene {
   /**
    * Sets the rotation of the model's pivot, around its pivotCenter point.
    */
-  setRotation(radiansY: number) {
+  setRotation(radiansY: number = this.pivot.rotation.y) {
     this.pivot.rotation.y = radiansY;
     this.pivot.position.x = -this.pivotCenter.x;
     this.pivot.position.z = -this.pivotCenter.z;

--- a/src/three-components/ModelScene.ts
+++ b/src/three-components/ModelScene.ts
@@ -196,7 +196,7 @@ export default class ModelScene extends Scene {
   /**
    * Sets the rotation of the model's pivot, around its pivotCenter point.
    */
-  setRotation(radiansY: number = this.pivot.rotation.y) {
+  setRotation(radiansY: number) {
     this.pivot.rotation.y = radiansY;
     this.pivot.position.x = -this.pivotCenter.x;
     this.pivot.position.z = -this.pivotCenter.z;


### PR DESCRIPTION
Fixes #806 

The first fix was a one-liner to force the pivot to recalculate when the target changes. This caused me to also notice it wasn't smoothly interpolating along with the camera, so I fixed that too.
