### PR TITLE
fix shadow Z-fight on mobile

### DIFF
--- a/src/three-components/StaticShadow.ts
+++ b/src/three-components/StaticShadow.ts
@@ -115,7 +115,7 @@ export default class StaticShadow extends Mesh {
     const modelCenter = boundingBox.getCenter(new Vector3);
     // Nothing within shadowOffset of the bottom of the model casts a shadow
     // (this is to avoid having a baked-in shadow plane cast its own shadow).
-    const shadowOffset = size.y * 0.0001;
+    const shadowOffset = size.y * 0.002;
 
     this[$camera].position.x = modelCenter.x;
     this[$camera].position.z = modelCenter.z;


### PR DESCRIPTION
This comes down to precision, which varies a lot by GPU, so while I've tested this on Pixel2 XL, we should ideally try to verify on a few more phones. I didn't want to make the gap any larger, because you can start to see it when you rotate to floor level. I suppose this is another reason to remove the baked-in shadow entirely, but I don't see a robust way to identify it in general.