### PR TITLE
Document errors, add error for lost context

### DIFF
--- a/index.html
+++ b/index.html
@@ -470,6 +470,18 @@
               have loaded by the time this event fires.</p>
             </li>
             <li>
+              <div>error</div>
+              <p>This event can be triggered for two reasons: a model has failed
+              to load or parse, or the WebGL context was lost. If the model failed
+              to load, event.detail.type will be 'loadfailure'. If the WebGL context
+              was lost, event.detail.type will be 'webglcontextlost'. In both cases,
+              recovery countermeasures are left as an exercise for the user. The
+              element will not make automatic attempts to re-load a model that has failed
+              to load. Nor will the element attempt to restore the GL context after
+              it has been lost. Error events also hold a reference to the originating
+              error event (when there is one) as event.detail.sourceEvent.</p>
+            </li>
+            <li>
               <div>load</div>
               <p>Fired when a model is loaded. Can fire multiple times per <span
               class="attribute">&lt;model-viewer&gt;</span> if the src attribute

--- a/src/features/loading.ts
+++ b/src/features/loading.ts
@@ -319,7 +319,7 @@ export const LoadingMixin = <T extends Constructor<ModelViewerElementBase>>(
           this.dispatchEvent(new CustomEvent('preload', {detail}));
         } catch (error) {
           this.dispatchEvent(new CustomEvent(
-              'error', {detail: {type: 'preload', sourceError: error}}));
+              'error', {detail: {type: 'loadfailure', sourceError: error}}));
         } finally {
           updatePreloadProgress(1.0);
           this.requestUpdate();

--- a/src/styles/conversions.ts
+++ b/src/styles/conversions.ts
@@ -27,7 +27,7 @@ import {NumberNode, ZERO} from './parsers';
 export const degreesToRadians =
     (numberNode: NumberNode, fallbackRadianValue: number = 0): NumberNode => {
       let {number, unit} = numberNode;
-      if (isNaN(number) || !isFinite(number)) {
+      if (!isFinite(number)) {
         number = fallbackRadianValue;
         unit = 'rad';
       } else if (numberNode.unit === 'rad' || numberNode.unit == null) {
@@ -54,7 +54,7 @@ export const radiansToDegrees =
     (numberNode: NumberNode, fallbackDegreeValue: number = 0): NumberNode => {
       let {number, unit} = numberNode;
 
-      if (isNaN(number) || !isFinite(number)) {
+      if (!isFinite(number)) {
         number = fallbackDegreeValue;
         unit = 'deg';
       } else if (numberNode.unit === 'deg') {
@@ -81,7 +81,7 @@ export const lengthToBaseMeters =
     (numberNode: NumberNode, fallbackMeterValue: number = 0): NumberNode => {
       let {number, unit} = numberNode;
 
-      if (isNaN(number) || !isFinite(number)) {
+      if (!isFinite(number)) {
         number = fallbackMeterValue;
         unit = 'm';
       } else if (numberNode.unit === 'm') {

--- a/src/test/three-components/ARRenderer-spec.ts
+++ b/src/test/three-components/ARRenderer-spec.ts
@@ -19,7 +19,7 @@ import {IS_WEBXR_AR_CANDIDATE} from '../../constants.js';
 import ModelViewerElementBase, {$renderer, $scene} from '../../model-viewer-base.js';
 import {ARRenderer} from '../../three-components/ARRenderer.js';
 import ModelScene from '../../three-components/ModelScene.js';
-import Renderer from '../../three-components/Renderer.js';
+import {Renderer} from '../../three-components/Renderer.js';
 import {assetPath, timePasses, waitForEvent} from '../helpers.js';
 
 

--- a/src/test/three-components/ModelScene-spec.ts
+++ b/src/test/three-components/ModelScene-spec.ts
@@ -18,7 +18,7 @@ import {Matrix4, Mesh, SphereBufferGeometry, Vector3} from 'three';
 import ModelViewerElementBase, {$canvas, $renderer} from '../../model-viewer-base.js';
 import {DEFAULT_FOV_DEG} from '../../three-components/Model.js';
 import ModelScene from '../../three-components/ModelScene.js';
-import Renderer from '../../three-components/Renderer.js';
+import {Renderer} from '../../three-components/Renderer.js';
 import {assetPath} from '../helpers.js';
 
 

--- a/src/test/three-components/Renderer-spec.ts
+++ b/src/test/three-components/Renderer-spec.ts
@@ -15,7 +15,7 @@
 
 import ModelViewerElementBase, {$canvas, $onResize, $renderer} from '../../model-viewer-base.js';
 import ModelScene from '../../three-components/ModelScene.js';
-import Renderer from '../../three-components/Renderer.js';
+import {Renderer} from '../../three-components/Renderer.js';
 
 const expect = chai.expect;
 

--- a/src/three-components/ARRenderer.ts
+++ b/src/three-components/ARRenderer.ts
@@ -16,7 +16,7 @@
 import {EventDispatcher, Matrix4, Object3D, PerspectiveCamera, Raycaster, Scene, Vector3, WebGLRenderer} from 'three';
 import {assertIsArCandidate} from '../utilities.js';
 import ModelScene from './ModelScene.js';
-import Renderer from './Renderer.js';
+import {Renderer} from './Renderer.js';
 import Reticle from './Reticle.js';
 import {assertContext} from './WebGLUtils.js';
 
@@ -106,9 +106,10 @@ export class ARRenderer extends EventDispatcher {
     // TODO: this method should be added to three.js's exported interface.
     (this.renderer as any)
         .setFramebuffer(session.renderState.baseLayer!.framebuffer);
-    this.renderer.setSize(session.renderState.baseLayer!.framebufferWidth,
-                          session.renderState.baseLayer!.framebufferHeight,
-                          false);
+    this.renderer.setSize(
+        session.renderState.baseLayer!.framebufferWidth,
+        session.renderState.baseLayer!.framebufferHeight,
+        false);
 
     return session;
   }
@@ -188,11 +189,11 @@ export class ARRenderer extends EventDispatcher {
     }
   }
 
-    [$postSessionCleanup]() {
-      // The offscreen WebXR framebuffer is now invalid, switch
-      // back to the default framebuffer for canvas output.
-      // TODO: this method should be added to three.js's exported interface.
-      (this.renderer as any).setFramebuffer(null);
+  [$postSessionCleanup]() {
+    // The offscreen WebXR framebuffer is now invalid, switch
+    // back to the default framebuffer for canvas output.
+    // TODO: this method should be added to three.js's exported interface.
+    (this.renderer as any).setFramebuffer(null);
 
     // Trigger a parent renderer update. TODO(klausw): are these all
     // necessary and sufficient?
@@ -325,7 +326,8 @@ export class ARRenderer extends EventDispatcher {
 
     for (const view of (frame as any).getViewerPose(this[$refSpace]).views) {
       const viewport = session.renderState.baseLayer!.getViewport(view);
-      this.renderer.setViewport(viewport.x, viewport.y, viewport.width, viewport.height);
+      this.renderer.setViewport(
+          viewport.x, viewport.y, viewport.width, viewport.height);
       this.camera.projectionMatrix.fromArray(view.projectionMatrix);
       const viewMatrix = matrix4.fromArray(view.transform.inverse.matrix);
 

--- a/src/three-components/ModelScene.ts
+++ b/src/three-components/ModelScene.ts
@@ -20,7 +20,7 @@ import ModelViewerElementBase from '../model-viewer-base.js';
 import {resolveDpr} from '../utilities.js';
 
 import Model from './Model.js';
-import Renderer from './Renderer.js';
+import {Renderer} from './Renderer.js';
 import {cubeUVChunk} from './shader-chunk/cube_uv_reflection_fragment.glsl.js';
 import StaticShadow from './StaticShadow.js';
 

--- a/src/three-components/Renderer.ts
+++ b/src/three-components/Renderer.ts
@@ -14,6 +14,7 @@
  */
 
 import {ACESFilmicToneMapping, EventDispatcher, WebGLRenderer} from 'three';
+import {Event} from 'three';
 
 import {IS_WEBXR_AR_CANDIDATE} from '../constants.js';
 import {$tick} from '../model-viewer-base.js';
@@ -24,7 +25,15 @@ import ModelScene from './ModelScene.js';
 import TextureUtils from './TextureUtils.js';
 import * as WebGLUtils from './WebGLUtils.js';
 
+export interface ContextLostEvent extends Event {
+  type: 'contextlost';
+  sourceEvent: WebGLContextEvent;
+}
+
 export const $arRenderer = Symbol('arRenderer');
+
+const $onWebGLContextLost = Symbol('onWebGLContextLost');
+const $webGLContextLostHandler = Symbol('webGLContextLostHandler');
 
 /**
  * Registers canvases with Canvas2DRenderingContexts and renders them
@@ -37,7 +46,7 @@ export const $arRenderer = Symbol('arRenderer');
  * Canvas2DRenderingContext if supported for cheaper transfering of
  * the texture.
  */
-export default class Renderer extends EventDispatcher {
+export class Renderer extends EventDispatcher {
   public renderer!: WebGLRenderer;
   public context!: WebGLRenderingContext|null;
   public canvas: HTMLCanvasElement;
@@ -48,6 +57,9 @@ export default class Renderer extends EventDispatcher {
   private[$arRenderer]: ARRenderer;
   private scenes: Set<ModelScene> = new Set();
   private lastTick: number;
+
+  private[$webGLContextLostHandler] = (event: WebGLContextEvent) =>
+      this[$onWebGLContextLost](event);
 
   get canRender() {
     return this.renderer != null && this.context != null;
@@ -64,6 +76,8 @@ export default class Renderer extends EventDispatcher {
     }
 
     this.canvas = document.createElement('canvas');
+    this.canvas.addEventListener(
+        'webglcontextlost', this[$webGLContextLostHandler] as EventListener);
     // Need to support both 'webgl' and 'experimental-webgl' (IE11).
     try {
       this.context = WebGLUtils.getContext(this.canvas, webGlOptions);
@@ -221,5 +235,13 @@ export default class Renderer extends EventDispatcher {
     (this as any).renderer = null;
 
     this.scenes.clear();
+
+    this.canvas.removeEventListener(
+        'webglcontextlost', this[$webGLContextLostHandler] as EventListener);
+  }
+
+  [$onWebGLContextLost](event: WebGLContextEvent) {
+    this.dispatchEvent(
+        {type: 'contextlost', sourceEvent: event} as ContextLostEvent);
   }
 }


### PR DESCRIPTION
This change introduces a new error event that is dispatched when we lose the WebGL context. It also changes the `type` of the previous error event from `"preload"` to `"loadfailure"`. Finally, it adds documentation for our error event, which was previously missing.

Some additional lingering cleanup intended for #739 has also been added. Also, the `Renderer` is no longer a "default" export as of this change. In general, "default" exports should be avoided (and technically are forbidden by the Google lint tools).

Fixes #801 
Fixes #816 