### PR TITLE
Introduce auto-rotate-delay attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,7 +131,12 @@
             </li>
             <li>
               <div>auto-rotate</div>
-              <p>Enables the auto rotation of the model.</p>
+              <p>Enables the auto-rotation of the model.</p>
+            </li>
+            <li>
+              <div>auto-rotate-delay</div>
+              <p>Sets the delay before auto-rotation begins. The format of the value
+              is a number in milliseconds. The default is 3000.</p>
             </li>
             <li>
               <div>autoplay</div>
@@ -438,6 +443,13 @@
               <p>Causes animations to be paused. If you want to reset the
               current animation to the beginning, you should also set the
               currentTime property to 0.</p>
+            </li>
+            <li>
+              <div>resetTurntableRotation()</div>
+              <p>Resets the turntable that rotates the model when auto-rotate
+              is enabled. The new value of the turntable rotation will be 0 after
+              this method is invoked, but the model may not update until the next
+              render frame.</p>
             </li>
             <li>
               <div>toDataURL(type, encoderOptions)</div>

--- a/src/features/staging.ts
+++ b/src/features/staging.ts
@@ -25,13 +25,11 @@ import {CameraChangeDetails} from './controls.js';
 // How much the model will rotate per
 // second in radians:
 const ROTATION_SPEED = Math.PI / 32;
-const AUTO_ROTATE_DELAY_AFTER_USER_INTERACTION = 3000;
+export const AUTO_ROTATE_DELAY_DEFAULT = 3000;
 
 const $autoRotateTimer = Symbol('autoRotateTimer');
 const $cameraChangeHandler = Symbol('cameraChangeHandler');
 const $onCameraChange = Symbol('onCameraChange');
-
-export {AUTO_ROTATE_DELAY_AFTER_USER_INTERACTION};
 
 export interface StagingInterface {
   autoRotate: boolean;
@@ -43,8 +41,10 @@ export const StagingMixin = <T extends Constructor<ModelViewerElementBase>>(
     @property({type: Boolean, attribute: 'auto-rotate'})
     autoRotate: boolean = false;
 
-    private[$autoRotateTimer]: Timer =
-        new Timer(AUTO_ROTATE_DELAY_AFTER_USER_INTERACTION);
+    @property({type: Number, attribute: 'auto-rotate-delay'})
+    autoRotateDelay: number = AUTO_ROTATE_DELAY_DEFAULT;
+
+    private[$autoRotateTimer]: Timer = new Timer(this.autoRotateDelay);
     private[$cameraChangeHandler] = (event: CustomEvent<CameraChangeDetails>) =>
         this[$onCameraChange](event);
 
@@ -66,8 +66,16 @@ export const StagingMixin = <T extends Constructor<ModelViewerElementBase>>(
       super.updated(changedProperties);
 
       if (changedProperties.has('autoRotate')) {
-        this[$scene].setRotation(0);
         this[$needsRender]();
+      }
+
+      if (changedProperties.has('autoRotateDelay')) {
+        const timer = new Timer(this.autoRotateDelay);
+        timer.tick(this[$autoRotateTimer].time);
+        if (timer.hasStopped) {
+          timer.reset();
+        }
+        this[$autoRotateTimer] = timer;
       }
     }
 
@@ -98,6 +106,10 @@ export const StagingMixin = <T extends Constructor<ModelViewerElementBase>>(
 
     get turntableRotation(): number {
       return this[$scene].pivot.rotation.y;
+    }
+
+    resetTurntableRotation() {
+      this[$scene].setRotation(0);
     }
   }
 


### PR DESCRIPTION
This change introduces an `auto-rotate-delay` attribute, which allows users to configure the a previously internal-only delay value that defaults to 3 seconds. After the delay has passed, the model will start rotating.

Additionally, this change revises our previous behavior for when `auto-rotate` is toggled. Previously, we would reset the "turntable" rotation when `auto-rotate` is disabled, causing the model to appear to jump back to its initial rotation. Now, the rotation is not reset when `auto-rotate` is disabled. In order to achieve the previous effect, a new `resetTurntableRotation` method has been introduced that sets the turntable's rotation back to 0.

Fixes #823 
Fixes #827 