### PR TITLE
Fix FOV intrinsics

### DIFF
--- a/src/test/features/controls-spec.ts
+++ b/src/test/features/controls-spec.ts
@@ -193,6 +193,14 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
         expect(element.getFieldOfView()).to.be.closeTo(nextFov, 0.00001);
       });
 
+      test('changes FOV basis when aspect ratio changes', async () => {
+        const fov = element.getFieldOfView();
+        element.setAttribute('style', 'width: 200px; height: 300px');
+
+        await until(() => element.getFieldOfView() !== fov);
+        expect(element.getFieldOfView()).to.be.greaterThan(fov);
+      });
+
       test('causes camera-change event to fire', async () => {
         const cameraChangeDispatches = waitForEvent(element, 'camera-change');
         const cameraOrbit = element.getCameraOrbit();


### PR DESCRIPTION
This change address an oversight from #739 , where intrinsics for `field-of-view` were not being updated appropriately.

Filed #835 for future refactor work here.