### PR TITLE
Fix wiggle in Safari and IE11

### DIFF
--- a/index.html
+++ b/index.html
@@ -249,7 +249,7 @@
               <div>interaction-prompt-style</div>
               <p>Configures the presentation style of the interaction-prompt when
               it is raised. The two allowed values are "wiggle" and "basic". When
-              set to "wiggle", the prompt will animated from horizontally and the
+              set to "wiggle", the prompt will animate from horizontally and the
               model will appear to be rotated as though the prompt is interacting
               with it. When set to "basic", the prompt is not animated, and instead
               simply appears until it is dismissed by user interaction.

--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
           <template>
 <!-- Import the component -->
 <script type="module" src="https://unpkg.com/@google/model-viewer/dist/model-viewer.js"></script>
-<script nomodule src="https://unpkg.com/@google/model-viewer/dist/model-viewer-legacy.js"></script>
+<script type="noexecute" nomodule src="https://unpkg.com/@google/model-viewer/dist/model-viewer-legacy.js"></script>
 <!-- Use it like any other HTML element -->
 <model-viewer src="examples/assets/Astronaut.glb" alt="A 3D model of an astronaut" auto-rotate camera-controls background-color="#455A64"></model-viewer>
           </template>
@@ -244,6 +244,16 @@
               prompt will only be activated if the element has first received
               focus. The interaction prompt will only display if camera-controls
               are enabled. Defaults to "auto".</p>
+            </li>
+            <li>
+              <div>interaction-prompt-style</div>
+              <p>Configures the presentation style of the interaction-prompt when
+              it is raised. The two allowed values are "wiggle" and "basic". When
+              set to "wiggle", the prompt will animated from horizontally and the
+              model will appear to be rotated as though the prompt is interacting
+              with it. When set to "basic", the prompt is not animated, and instead
+              simply appears until it is dismissed by user interaction.
+              Defaults to "wiggle".</p>
             </li>
             <li>
               <div>interaction-prompt-threshold</div>

--- a/src/documentation/components/example-snippet.ts
+++ b/src/documentation/components/example-snippet.ts
@@ -113,6 +113,8 @@ export class ExampleSnippet extends UpdatingElement {
 
       let snippet = template.innerHTML;
 
+      snippet.replace('type="noexecute" ', '');
+
       if (!this.preserveWhitespace) {
         snippet = snippet.trim();
       }

--- a/src/features/controls.ts
+++ b/src/features/controls.ts
@@ -388,23 +388,24 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
         }
       }
 
+
       if (isFinite(this[$promptElementVisibleTime]) &&
           this.interactionPromptStyle === InteractionPromptStyle.WIGGLE) {
         const scene = this[$scene];
         const animationTime =
-            ((time - this[$promptElementVisibleTime]) % PROMPT_ANIMATION_TIME) /
-            PROMPT_ANIMATION_TIME;
+            ((time - this[$promptElementVisibleTime]) / PROMPT_ANIMATION_TIME) %
+            1;
         const offset = wiggle(animationTime);
         const opacity = fade(animationTime);
 
         const xOffset = offset * scene.width * 0.05;
-        const deltaTheta = (offset - this[$lastPromptOffset]) * Math.PI / 8;
+        const deltaTheta = (offset - this[$lastPromptOffset]) * Math.PI / 16;
 
         this[$promptAnimatedContainer].style.transform =
             `translateX(${xOffset}px)`;
         this[$promptAnimatedContainer].style.opacity = `${opacity}`;
 
-        this[$controls].adjustOrbit(deltaTheta * Math.PI / 6, 0, 0, 0);
+        this[$controls].adjustOrbit(deltaTheta, 0, 0, 0);
 
         this[$lastPromptOffset] = offset;
         this[$needsRender]();
@@ -544,7 +545,8 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
       // camera controls (that is, we "should" prompt the user), we begin
       // the idle timer and indicate that we are waiting for it to cross the
       // prompt threshold:
-      if (this[$shouldPromptUserToInteract]) {
+      if (!isFinite(this[$promptElementVisibleTime]) &&
+          this[$shouldPromptUserToInteract]) {
         this[$waitingToPromptUser] = true;
       }
     }
@@ -552,6 +554,7 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
     [$onBlur]() {
       this[$waitingToPromptUser] = false;
       this[$promptElement].classList.remove('visible');
+
       this[$promptElementVisibleTime] = Infinity;
       this[$focusedTime] = Infinity;
     }

--- a/src/features/controls.ts
+++ b/src/features/controls.ts
@@ -32,6 +32,8 @@ import {timeline} from '../utilities/animation.js';
 // @see https://github.com/GoogleWebComponents/model-viewer/issues/839
 const PROMPT_ANIMATION_TIME = 5000;
 
+// For timing purposes, a "frame" is a timing agnostic relative unit of time
+// and a "value" is a target value for the keyframe.
 const wiggle = timeline(0, [
   {frames: 6, value: 0},
   {frames: 5, value: -1},

--- a/src/features/controls.ts
+++ b/src/features/controls.ts
@@ -24,6 +24,31 @@ import {IdentNode, NumberNode, numberNode, parseExpressions} from '../styles/par
 import {DEFAULT_FOV_DEG} from '../three-components/Model.js';
 import {ChangeEvent, ChangeSource, SmoothControls} from '../three-components/SmoothControls.js';
 import {Constructor} from '../utilities.js';
+import {timeline} from '../utilities/animation.js';
+
+// NOTE(cdata): The following "animation" timing functions are deliberately
+// being used in favor of CSS animations. In Safari 12.1 and 13, CSS animations
+// would cause the interaction prompt to glitch unexpectedly
+// @see https://github.com/GoogleWebComponents/model-viewer/issues/839
+const PROMPT_ANIMATION_TIME = 5000;
+
+const wiggle = timeline(0, [
+  {frames: 6, value: 0},
+  {frames: 5, value: -1},
+  {frames: 1, value: -1},
+  {frames: 8, value: 1},
+  {frames: 1, value: 1},
+  {frames: 5, value: 0},
+  {frames: 12, value: 0}
+]);
+
+const fade = timeline(0, [
+  {frames: 2, value: 0},
+  {frames: 1, value: 1},
+  {frames: 5, value: 1},
+  {frames: 1, value: 0},
+  {frames: 4, value: 0}
+]);
 
 export interface CameraChangeDetails {
   source: ChangeSource;
@@ -100,7 +125,6 @@ export const cameraTargetIntrinsics = (element: ModelViewerElementBase) => {
   };
 };
 
-const OFFSET_ROTATION_MULTIPLIER = 5;
 const HALF_FIELD_OF_VIEW_RADIANS = (DEFAULT_FOV_DEG / 2) * Math.PI / 180;
 const HALF_PI = Math.PI / 2.0;
 const THIRD_PI = Math.PI / 3.0;
@@ -135,8 +159,8 @@ const $onChange = Symbol('onChange');
 const $shouldPromptUserToInteract = Symbol('shouldPromptUserToInteract');
 const $waitingToPromptUser = Symbol('waitingToPromptUser');
 const $userPromptedOnce = Symbol('userPromptedOnce');
-const $promptElementVisible = Symbol('promptElementVisible');
-const $lastPromptOffset = Symbol('lastPromptOffste');
+const $promptElementVisibleTime = Symbol('promptElementVisibleTime');
+const $lastPromptOffset = Symbol('lastPromptOffset');
 const $focusedTime = Symbol('focusedTime');
 
 const $zoomAdjustedFieldOfView = Symbol('zoomAdjustedFieldOfView');
@@ -209,13 +233,14 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
     interactionPolicy: InteractionPolicy = InteractionPolicy.ALWAYS_ALLOW;
 
     protected[$promptElement] =
-        this.shadowRoot!.querySelector('.interaction-prompt')!;
-    protected[$promptAnimatedContainer] = this.shadowRoot!.querySelector(
-        '.interaction-prompt > .animated-container')!;
+        this.shadowRoot!.querySelector('.interaction-prompt') as HTMLElement;
+    protected[$promptAnimatedContainer] =
+        this.shadowRoot!.querySelector(
+            '.interaction-prompt > .animated-container') as HTMLElement;
 
     protected[$focusedTime] = Infinity;
     protected[$lastPromptOffset] = 0;
-    protected[$promptElementVisible] = false;
+    protected[$promptElementVisibleTime] = Infinity;
     protected[$userPromptedOnce] = false;
     protected[$waitingToPromptUser] = false;
     protected[$shouldPromptUserToInteract] = true;
@@ -345,6 +370,7 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
             this.interactionPrompt === InteractionPromptStrategy.AUTO ?
             this[$loadedTime] :
             this[$focusedTime];
+
         if (this.loaded &&
             time > thresholdTime + this.interactionPromptThreshold) {
           this[$scene].canvas.setAttribute('aria-label', INTERACTION_PROMPT);
@@ -356,32 +382,32 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
           // again for this particular <model-element> instance:
           this[$userPromptedOnce] = true;
           this[$waitingToPromptUser] = false;
-          this[$promptElementVisible] = true;
+          this[$promptElementVisibleTime] = time;
 
           this[$promptElement].classList.add('visible');
         }
       }
 
-      if (this[$promptElementVisible] &&
+      if (isFinite(this[$promptElementVisibleTime]) &&
           this.interactionPromptStyle === InteractionPromptStyle.WIGGLE) {
-        const transformString =
-            self.getComputedStyle(this[$promptAnimatedContainer])
-                .getPropertyValue('transform');
-        // Parse the fifth term of computed transform style
-        // which is in form of matrix(n0, n1, n2, n3, n4, n5)
-        // @see https://www.w3.org/TR/css-transforms-1/#serialization-of-the-computed-value
-        const offset = parseFloat(transformString.split(',')[4]);
-        const delta = offset - this[$lastPromptOffset];
+        const scene = this[$scene];
+        const animationTime =
+            ((time - this[$promptElementVisibleTime]) % PROMPT_ANIMATION_TIME) /
+            PROMPT_ANIMATION_TIME;
+        const offset = wiggle(animationTime);
+        const opacity = fade(animationTime);
 
-        if (isFinite(offset)) {
-          const scene = this[$scene];
+        const xOffset = offset * scene.width * 0.05;
+        const deltaTheta = (offset - this[$lastPromptOffset]) * Math.PI / 8;
 
-          this[$lastPromptOffset] = offset;
-          scene.setPivotRotation(
-              scene.getPivotRotation() +
-              delta / scene.width * OFFSET_ROTATION_MULTIPLIER);
-          this[$needsRender]();
-        }
+        this[$promptAnimatedContainer].style.transform =
+            `translateX(${xOffset}px)`;
+        this[$promptAnimatedContainer].style.opacity = `${opacity}`;
+
+        this[$controls].adjustOrbit(deltaTheta * Math.PI / 6, 0, 0, 0);
+
+        this[$lastPromptOffset] = offset;
+        this[$needsRender]();
       }
 
       this[$controls].update(time, delta);
@@ -396,7 +422,7 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
       // Effectively cancel the timer waiting for user interaction:
       this[$waitingToPromptUser] = false;
       this[$promptElement].classList.remove('visible');
-      this[$promptElementVisible] = false;
+      this[$promptElementVisibleTime] = Infinity;
 
       // Implicitly there was some reason to defer the prompt. If the user
       // has been prompted at least once already, we no longer need to
@@ -526,7 +552,7 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
     [$onBlur]() {
       this[$waitingToPromptUser] = false;
       this[$promptElement].classList.remove('visible');
-      this[$promptElementVisible] = false;
+      this[$promptElementVisibleTime] = Infinity;
       this[$focusedTime] = Infinity;
     }
 

--- a/src/features/staging.ts
+++ b/src/features/staging.ts
@@ -89,19 +89,20 @@ export const StagingMixin = <T extends Constructor<ModelViewerElementBase>>(
       this[$autoRotateTimer].tick(delta);
 
       if (this[$autoRotateTimer].hasStopped) {
-        const rotation =
-            this.turntableRotation + ROTATION_SPEED * delta * 0.001;
-        this[$scene].setPivotRotation(rotation);
+        this[$scene].setPivotRotation(
+            this[$scene].getPivotRotation() + ROTATION_SPEED * delta * 0.001);
         this[$needsRender]();
       }
     }
 
-    [$onCameraChange](_event: CustomEvent<CameraChangeDetails>) {
+    [$onCameraChange](event: CustomEvent<CameraChangeDetails>) {
       if (!this.autoRotate) {
         return;
       }
 
-      this[$autoRotateTimer].reset();
+      if (event.detail.source === 'user-interaction') {
+        this[$autoRotateTimer].reset();
+      }
     }
 
     get turntableRotation(): number {
@@ -110,6 +111,7 @@ export const StagingMixin = <T extends Constructor<ModelViewerElementBase>>(
 
     resetTurntableRotation() {
       this[$scene].setPivotRotation(0);
+      this[$needsRender]();
     }
   }
 

--- a/src/template.ts
+++ b/src/template.ts
@@ -19,293 +19,293 @@ import ARGlyph from './assets/view-in-ar-material-svg.js';
 
 const template = document.createElement('template');
 template.innerHTML = `
-  <style>
-    :host {
-      display: block;
-      position: relative;
-      contain: strict;
-      width: 300px;
-      height: 150px;
-    }
+<style>
+:host {
+  display: block;
+  position: relative;
+  contain: strict;
+  width: 300px;
+  height: 150px;
+}
 
-    /* NOTE: This ruleset is our integration surface area with the
-     * :focus-visible polyfill.
-     *
-     * @see https://github.com/WICG/focus-visible/pull/196 */
-    :host([data-js-focus-visible]:focus:not(.focus-visible)),
-    :host([data-js-focus-visible]) :focus:not(.focus-visible) {
-      outline: none;
-    }
+/* NOTE: This ruleset is our integration surface area with the
+ * :focus-visible polyfill.
+ *
+ * @see https://github.com/WICG/focus-visible/pull/196 */
+:host([data-js-focus-visible]:focus:not(.focus-visible)),
+:host([data-js-focus-visible]) :focus:not(.focus-visible) {
+  outline: none;
+}
 
-    .container {
-      position: relative;
-    }
+.container {
+  position: relative;
+}
 
-    canvas {
-      width: 100%;
-      height: 100%;
-      display: none;
-      /* NOTE(cdata): Chrome 76 and below apparently have a bug
-       * that causes our canvas not to display pixels unless it is
-       * on its own render layer
-       * @see https://github.com/GoogleWebComponents/model-viewer/pull/755#issuecomment-536597893
-       */
-      transform: translateZ(0);
-    }
+canvas {
+  width: 100%;
+  height: 100%;
+  display: none;
+  /* NOTE(cdata): Chrome 76 and below apparently have a bug
+   * that causes our canvas not to display pixels unless it is
+   * on its own render layer
+   * @see https://github.com/GoogleWebComponents/model-viewer/pull/755#issuecomment-536597893
+   */
+  transform: translateZ(0);
+}
 
-    canvas.show {
-      display: block;
-    }
+canvas.show {
+  display: block;
+}
 
-    /* Adapted from HTML5 Boilerplate
-     *
-     * @see https://github.com/h5bp/html5-boilerplate/blob/ceb4620c78fc82e13534fc44202a3f168754873f/dist/css/main.css#L122-L133 */
-    .screen-reader-only {
-      border: 0;
-      clip: rect(0, 0, 0, 0);
-      height: 1px;
-      margin: -1px;
-      overflow: hidden;
-      padding: 0;
-      position: absolute;
-      white-space: nowrap;
-      width: 1px;
-    }
+/* Adapted from HTML5 Boilerplate
+ *
+ * @see https://github.com/h5bp/html5-boilerplate/blob/ceb4620c78fc82e13534fc44202a3f168754873f/dist/css/main.css#L122-L133 */
+.screen-reader-only {
+  border: 0;
+  clip: rect(0, 0, 0, 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
 
-    .slot {
-      position: absolute;
-      pointer-events: none;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-    }
+.slot {
+  position: absolute;
+  pointer-events: none;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
 
-    .slot > * {
-      pointer-events: initial;
-    }
+.slot > * {
+  pointer-events: initial;
+}
 
-    .slot.poster {
-      opacity: 0;
-      transition: opacity 0.3s 0.3s;
-    }
+.slot.poster {
+  opacity: 0;
+  transition: opacity 0.3s 0.3s;
+}
 
-    .slot.poster.show {
-      opacity: 1;
-      transition: none;
-    }
+.slot.poster.show {
+  opacity: 1;
+  transition: none;
+}
 
-    .slot.poster > * {
-      pointer-events: initial;
-    }
+.slot.poster > * {
+  pointer-events: initial;
+}
 
-    .slot.poster:not(.show) > * {
-      pointer-events: none;
-    }
+.slot.poster:not(.show) > * {
+  pointer-events: none;
+}
 
-    #default-poster {
-      width: 100%;
-      height: 100%;
-      position: absolute;
-      background-size: cover;
-      background-position: center;
-      background-color: var(--poster-color, #fff);
-      background-image: var(--poster-image, none);
-    }
+#default-poster {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  background-size: cover;
+  background-position: center;
+  background-color: var(--poster-color, #fff);
+  background-image: var(--poster-image, none);
+}
 
-    #default-progress-bar {
-      display: block;
-      position: relative;
-      width: 100%;
-      height: 100%;
-      pointer-events: none;
-      overflow: hidden;
-    }
+#default-progress-bar {
+  display: block;
+  position: relative;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  overflow: hidden;
+}
 
-    #default-progress-bar > .mask {
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      background: var(--progress-mask, #fff);
-      transition: opacity 0.3s;
-      opacity: 0.2;
-    }
+#default-progress-bar > .mask {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: var(--progress-mask, #fff);
+  transition: opacity 0.3s;
+  opacity: 0.2;
+}
 
-    #default-progress-bar > .bar {
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: var(--progress-bar-height, 5px);
-      transition: transform 0.09s;
-      transform-origin: top left;
-      transform: scaleX(0);
-      overflow: hidden;
-    }
+#default-progress-bar > .bar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: var(--progress-bar-height, 5px);
+  transition: transform 0.09s;
+  transform-origin: top left;
+  transform: scaleX(0);
+  overflow: hidden;
+}
 
-    #default-progress-bar > .bar:before {
-      content: '';
-      display: block;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
+#default-progress-bar > .bar:before {
+  content: '';
+  display: block;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
 
-      background-color: var(--progress-bar-color, rgba(0, 0, 0, 0.4));
+  background-color: var(--progress-bar-color, rgba(0, 0, 0, 0.4));
 
-      transition: none;
-      transform-origin: top left;
-      transform: translateY(0);
-    }
+  transition: none;
+  transform-origin: top left;
+  transform: translateY(0);
+}
 
-    #default-progress-bar > .bar.hide:before {
-      transition: transform 0.3s 1s;
-      transform: translateY(-100%);
-    }
+#default-progress-bar > .bar.hide:before {
+  transition: transform 0.3s 1s;
+  transform: translateY(-100%);
+}
 
-    .slot.interaction-prompt {
-      display: var(--interaction-prompt-display, flex);
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      pointer-events: none;
-      align-items: center;
-      justify-content: center;
+.slot.interaction-prompt {
+  display: var(--interaction-prompt-display, flex);
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  align-items: center;
+  justify-content: center;
 
-      opacity: 0;
-      will-change: opacity;
-      overflow: hidden;
-      transition: opacity 0.3s;
-    }
+  opacity: 0;
+  will-change: opacity;
+  overflow: hidden;
+  transition: opacity 0.3s;
+}
 
-    .slot.interaction-prompt.visible {
-      opacity: 1;
-    }
+.slot.interaction-prompt.visible {
+  opacity: 1;
+}
 
-    .slot.interaction-prompt > .animated-container {
-      will-change: transform, opacity;
-    }
+.slot.interaction-prompt > .animated-container {
+  will-change: transform, opacity;
+}
 
-    .slot.interaction-prompt > * {
-      pointer-events: none;
-    }
+.slot.interaction-prompt > * {
+  pointer-events: none;
+}
 
-    .slot.ar-button {
-      -moz-user-select: none;
-      -webkit-tap-highlight-color: transparent;
-      user-select: none;
+.slot.ar-button {
+  -moz-user-select: none;
+  -webkit-tap-highlight-color: transparent;
+  user-select: none;
 
-      display: var(--ar-button-display, block);
-    }
+  display: var(--ar-button-display, block);
+}
 
-    .slot.ar-button:not(.enabled),
-    .fullscreen .slot.ar-button {
-      display: none;
-    }
+.slot.ar-button:not(.enabled),
+.fullscreen .slot.ar-button {
+  display: none;
+}
 
-    .fab {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      box-sizing: border-box;
-      width: 40px;
-      height: 40px;
-      cursor: pointer;
-      background-color: #fff;
-      box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.15);
-      border-radius: 100px;
-    }
+.fab {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  width: 40px;
+  height: 40px;
+  cursor: pointer;
+  background-color: #fff;
+  box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.15);
+  border-radius: 100px;
+}
 
-    .fab > * {
-      opacity: 0.87;
-    }
+.fab > * {
+  opacity: 0.87;
+}
 
-    #default-ar-button {
-      position: absolute;
-      bottom: 16px;
-      right: 16px;
-    }
+#default-ar-button {
+  position: absolute;
+  bottom: 16px;
+  right: 16px;
+}
 
-    :not(.fullscreen) .slot.exit-fullscreen-button {
-      display: none;
-    }
+:not(.fullscreen) .slot.exit-fullscreen-button {
+  display: none;
+}
 
-    #default-exit-fullscreen-button {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      position: absolute;
-      top: 16px;
-      left: 16px;
-      width: 40px;
-      height: 40px;
-      box-sizing: border-box;
-    }
+#default-exit-fullscreen-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  top: 16px;
+  left: 16px;
+  width: 40px;
+  height: 40px;
+  box-sizing: border-box;
+}
 
-    #default-exit-fullscreen-button > svg {
-      fill: #fff;
-    }
-  </style>
-  <div class="container">
-    <canvas tabindex="1"
-      aria-label="A depiction of a 3D model"
-      aria-live="polite">
-    </canvas>
+#default-exit-fullscreen-button > svg {
+  fill: #fff;
+}
+</style>
+<div class="container">
+  <canvas tabindex="1"
+    aria-label="A depiction of a 3D model"
+    aria-live="polite">
+  </canvas>
 
-    <!-- NOTE(cdata): We need to wrap slots because browsers without ShadowDOM
-         will have their <slot> elements removed by ShadyCSS -->
-    <div class="slot poster">
-      <slot name="poster">
-        <div id="default-poster" aria-hidden="true" aria-label="Activate to view in 3D!"></div>
-      </slot>
-    </div>
+  <!-- NOTE(cdata): We need to wrap slots because browsers without ShadowDOM
+        will have their <slot> elements removed by ShadyCSS -->
+  <div class="slot poster">
+    <slot name="poster">
+      <div id="default-poster" aria-hidden="true" aria-label="Activate to view in 3D!"></div>
+    </slot>
+  </div>
 
-    <div class="slot progress-bar">
-      <slot name="progress-bar">
-        <div id="default-progress-bar" aria-hidden="true">
-          <div class="mask"></div>
-          <div class="bar"></div>
-        </div>
-      </slot>
-    </div>
-
-    <div class="slot ar-button">
-      <slot name="ar-button">
-        <a id="default-ar-button" class="fab"
-            tabindex="2"
-            aria-label="View this 3D model up close">
-          ${ARGlyph}
-        </a>
-      </slot>
-    </div>
-
-    <div class="slot exit-fullscreen-button">
-      <slot name="exit-fullscreen-button">
-        <a id="default-exit-fullscreen-button"
-            tabindex="3"
-            aria-label="Exit fullscreen"
-            aria-hidden="true">
-          ${CloseIcon}
-        </a>
-      </slot>
-    </div>
-
-    <div class="slot interaction-prompt">
-      <div class="animated-container" part="interaction-prompt">
-        <slot name="interaction-prompt" aria-hidden="true">
-          ${ControlsPrompt}
-        </slot>
+  <div class="slot progress-bar">
+    <slot name="progress-bar">
+      <div id="default-progress-bar" aria-hidden="true">
+        <div class="mask"></div>
+        <div class="bar"></div>
       </div>
-    </div>
+    </slot>
+  </div>
 
-    <div class="slot default">
-      <slot></slot>
+  <div class="slot ar-button">
+    <slot name="ar-button">
+      <a id="default-ar-button" class="fab"
+          tabindex="2"
+          aria-label="View this 3D model up close">
+        ${ARGlyph}
+      </a>
+    </slot>
+  </div>
+
+  <div class="slot exit-fullscreen-button">
+    <slot name="exit-fullscreen-button">
+      <a id="default-exit-fullscreen-button"
+          tabindex="3"
+          aria-label="Exit fullscreen"
+          aria-hidden="true">
+        ${CloseIcon}
+      </a>
+    </slot>
+  </div>
+
+  <div class="slot interaction-prompt">
+    <div class="animated-container" part="interaction-prompt">
+      <slot name="interaction-prompt" aria-hidden="true">
+        ${ControlsPrompt}
+      </slot>
     </div>
-  </div>`;
+  </div>
+
+  <div class="slot default">
+    <slot></slot>
+  </div>
+</div>`;
 
 export default template;
 

--- a/src/template.ts
+++ b/src/template.ts
@@ -165,27 +165,6 @@ template.innerHTML = `
       transform: translateY(-100%);
     }
 
-    @keyframes wiggle {
-      10%, 12% {
-        transform: translateX(-5%);
-      }
-      30%, 32% {
-        transform: translateX(5%);
-      }
-      0%, 45%, 100% {
-        transform: translateX(0%);
-      }
-    }
-
-    @keyframes fade {
-      5%, 40% {
-        opacity: 1;
-      }
-      0%, 45%, 100% {
-        opacity: 0;
-      }
-    }
-
     .slot.interaction-prompt {
       display: var(--interaction-prompt-display, flex);
       position: absolute;
@@ -198,6 +177,7 @@ template.innerHTML = `
       justify-content: center;
 
       opacity: 0;
+      will-change: opacity;
       overflow: hidden;
       transition: opacity 0.3s;
     }
@@ -207,24 +187,7 @@ template.innerHTML = `
     }
 
     .slot.interaction-prompt > .animated-container {
-      display: flex;
-      flex-direction: row;
-      align-items: center;
-      justify-content: center;
-      width: 100%;
-      height: 100%;
-    }
-
-    .slot.interaction-prompt.wiggle > .animated-container {
-      animation-name: wiggle, fade;
-      animation-duration: 6s;
-      animation-iteration-count: infinite;
-      animation-timing-function: ease-in-out;
-      animation-play-state: paused;
-    }
-
-    .slot.interaction-prompt.wiggle.visible > .animated-container {
-      animation-play-state: running;
+      will-change: transform, opacity;
     }
 
     .slot.interaction-prompt > * {
@@ -332,7 +295,7 @@ template.innerHTML = `
     </div>
 
     <div class="slot interaction-prompt">
-      <div class="animated-container">
+      <div class="animated-container" part="interaction-prompt">
         <slot name="interaction-prompt" aria-hidden="true">
           ${ControlsPrompt}
         </slot>

--- a/src/test/features/controls-spec.ts
+++ b/src/test/features/controls-spec.ts
@@ -371,25 +371,6 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
               .to.be.equal(false);
         });
 
-        test('plays the css animation when threshold elapses', async () => {
-          element.interactionPrompt = 'auto';
-
-          const computedStyle =
-              getComputedStyle((element as any)[$promptAnimatedContainer]);
-          expect(computedStyle.animationPlayState)
-              .to.be.match(/^paused(\, paused)?$/);
-
-          await timePasses(element.interactionPromptThreshold + 100);
-          expect(computedStyle.animationPlayState)
-              .to.be.match(/^running(\, running)?$/);
-        });
-
-        test('has a css animation', () => {
-          const computedStyle =
-              getComputedStyle((element as any)[$promptAnimatedContainer]);
-          expect(computedStyle.animationName).to.not.be.equal('none');
-        });
-
         suite('when configured to be basic', () => {
           setup(async () => {
             element.interactionPromptStyle = 'basic';

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import './utils-spec.js';
+import './utilities-spec.js';
 import './styles/parsers-spec.js';
 import './styles/conversions-spec.js';
 import './styles/deserializers-spec.js';
@@ -28,6 +28,7 @@ import './three-components/SmoothControls-spec.js';
 import './three-components/TextureUtils-spec.js';
 import './three-components/CachingGLTFLoader-spec.js';
 import './three-components/ModelUtils-spec.js';
+import './utilities/animation-spec.js';
 import './utilities/cache-eviction-policy-spec.js';
 import './utilities/focus-visible-spec.js';
 import './utilities/progress-tracker-spec.js';

--- a/src/test/utilities-spec.ts
+++ b/src/test/utilities-spec.ts
@@ -14,7 +14,6 @@
  */
 
 import {clamp, deserializeUrl, resolveDpr, step} from '../utilities.js';
-import timerSpec from './utilities/timer-spec';
 
 const expect = chai.expect;
 
@@ -83,6 +82,4 @@ suite('utils', () => {
       expect(clamp(2.5, 2.0, 3.0)).to.be.equal(2.5);
     });
   });
-
-  timerSpec();
 });

--- a/src/test/utilities/animation-spec.ts
+++ b/src/test/utilities/animation-spec.ts
@@ -1,0 +1,75 @@
+/* @license
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {interpolate, sequence, timeline} from '../../utilities/animation.js';
+
+const expect = chai.expect;
+const easeLinear = (t: number) => t;
+const PRECISION = 0.000001;
+
+suite('animation', () => {
+  suite('interpolate', () => {
+    test('interpolates from start to end values', () => {
+      const timingForward = interpolate(0, 100, easeLinear);
+      const timingBackward = interpolate(100, 0, easeLinear);
+
+      for (let i = 0; i < 10; ++i) {
+        expect(timingForward(i / 10)).to.be.equal(i * 10);
+        expect(timingBackward(i / 10)).to.be.equal(100 - i * 10);
+      }
+    });
+  });
+
+  suite('sequence', () => {
+    test('interpolates across a sequence of timing functions', () => {
+      const timingForward = interpolate(0, 100, easeLinear);
+      const timingBackward = interpolate(100, 0, easeLinear);
+
+      const forwardBackward = sequence([timingForward, timingBackward], [1, 1]);
+
+      for (let i = 0; i < 10; ++i) {
+        expect(forwardBackward(i / 10))
+            .to.be.closeTo(i < 5 ? i * 20 : 100 - (i - 5) * 20, PRECISION);
+      }
+    });
+
+    test('allows for timing functions to be relatively weighted', () => {
+      const timingForward = interpolate(0, 100, easeLinear);
+      const timingBackward = interpolate(90, 0, easeLinear);
+
+      const forwardBackward = sequence([timingForward, timingBackward], [1, 9]);
+
+      for (let i = 0; i < 10; ++i) {
+        expect(forwardBackward(i / 10))
+            .to.be.closeTo(i < 2 ? i * 100 : (10 - i) * 10, PRECISION)
+      }
+    });
+  });
+
+  suite('timeline', () => {
+    test('creates a timing function sequence from keyframes', () => {
+      const forwardBackward = timeline(0, [
+        {frames: 5, value: 100, ease: easeLinear},
+        {frames: 5, value: 0, ease: easeLinear}
+      ]);
+      for (let i = 0; i < 10; ++i) {
+        for (let i = 0; i < 10; ++i) {
+          expect(forwardBackward(i / 10))
+              .to.be.closeTo(i < 5 ? i * 20 : 100 - (i - 5) * 20, PRECISION);
+        }
+      }
+    });
+  });
+});

--- a/src/test/utilities/timer-spec.ts
+++ b/src/test/utilities/timer-spec.ts
@@ -17,74 +17,72 @@ import {Timer} from '../../utilities/timer.js';
 
 const expect = chai.expect;
 
-export default () => {
-  suite('Timer', () => {
-    test('has not ended by default', () => {
-      const timer = new Timer(20);
+suite('Timer', () => {
+  test('has not ended by default', () => {
+    const timer = new Timer(20);
 
-      expect(timer.hasStopped).to.be.false;
-    });
-
-    test('can tick', () => {
-      const timer = new Timer(20);
-
-      expect(timer.hasStopped).to.be.false;
-
-      timer.tick(30);
-
-      expect(timer.hasStopped).to.be.true;
-    });
-
-    test('can reset', () => {
-      const timer = new Timer(20);
-
-      expect(timer.hasStopped).to.be.false;
-
-      timer.tick(30);
-
-      expect(timer.hasStopped).to.be.true;
-
-      timer.reset();
-
-      expect(timer.hasStopped).to.be.false;
-    });
-
-    test('can stop', () => {
-      const timer = new Timer(20);
-
-      expect(timer.hasStopped).to.be.false;
-
-      timer.stop();
-
-      expect(timer.hasStopped).to.be.true;
-      expect(timer.time).to.equal(20);
-      expect(timer.timeScale).to.equal(1);
-
-      timer.reset();
-
-      expect(timer.hasStopped).to.be.false;
-    });
-
-    test('can get time', () => {
-      const timer = new Timer(20);
-
-      expect(timer.time).to.equal(0);
-      expect(timer.timeScale).to.equal(0);
-
-      timer.tick(10);
-
-      expect(timer.time).to.equal(10);
-      expect(timer.timeScale).to.equal(0.5);
-
-      timer.tick(10);
-
-      expect(timer.time).to.equal(20);
-      expect(timer.timeScale).to.equal(1);
-
-      timer.tick(10);
-
-      expect(timer.time).to.equal(20);
-      expect(timer.timeScale).to.equal(1);
-    });
+    expect(timer.hasStopped).to.be.false;
   });
-};
+
+  test('can tick', () => {
+    const timer = new Timer(20);
+
+    expect(timer.hasStopped).to.be.false;
+
+    timer.tick(30);
+
+    expect(timer.hasStopped).to.be.true;
+  });
+
+  test('can reset', () => {
+    const timer = new Timer(20);
+
+    expect(timer.hasStopped).to.be.false;
+
+    timer.tick(30);
+
+    expect(timer.hasStopped).to.be.true;
+
+    timer.reset();
+
+    expect(timer.hasStopped).to.be.false;
+  });
+
+  test('can stop', () => {
+    const timer = new Timer(20);
+
+    expect(timer.hasStopped).to.be.false;
+
+    timer.stop();
+
+    expect(timer.hasStopped).to.be.true;
+    expect(timer.time).to.equal(20);
+    expect(timer.timeScale).to.equal(1);
+
+    timer.reset();
+
+    expect(timer.hasStopped).to.be.false;
+  });
+
+  test('can get time', () => {
+    const timer = new Timer(20);
+
+    expect(timer.time).to.equal(0);
+    expect(timer.timeScale).to.equal(0);
+
+    timer.tick(10);
+
+    expect(timer.time).to.equal(10);
+    expect(timer.timeScale).to.equal(0.5);
+
+    timer.tick(10);
+
+    expect(timer.time).to.equal(20);
+    expect(timer.timeScale).to.equal(1);
+
+    timer.tick(10);
+
+    expect(timer.time).to.equal(20);
+    expect(timer.timeScale).to.equal(1);
+  });
+});

--- a/src/three-components/SmoothControls.ts
+++ b/src/three-components/SmoothControls.ts
@@ -581,6 +581,11 @@ export class SmoothControls extends EventDispatcher {
         this.adjustOrbit(deltaTheta, deltaPhi, deltaRadius, deltaFov);
 
     this[$isUserChange] = true;
+    // Always make sure that an initial event is triggered in case there is
+    // contention between user interaction and imperative changes. This initial
+    // event will give external observers that chance to observe that
+    // interaction occurred at all:
+    this.dispatchEvent({type: 'change', source: ChangeSource.USER_INTERACTION});
 
     return handled;
   }

--- a/src/utilities/animation.ts
+++ b/src/utilities/animation.ts
@@ -1,3 +1,18 @@
+/* @license
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // Adapted from https://gist.github.com/gre/1650294
 export const easeInOutQuad: TimingFunction = (t: number) =>
     t < .5 ? 2 * t * t : -1 + (4 - 2 * t) * t;

--- a/src/utilities/animation.ts
+++ b/src/utilities/animation.ts
@@ -1,0 +1,85 @@
+// Adapted from https://gist.github.com/gre/1650294
+export const easeInOutQuad: TimingFunction = (t: number) =>
+    t < .5 ? 2 * t * t : -1 + (4 - 2 * t) * t;
+
+/**
+ * A TimingFunction accepts a value from 0-1 and returns a corresponding
+ * interpolated value
+ */
+export type TimingFunction = (time: number) => number;
+
+/**
+ * Creates a TimingFunction that uses a given ease to interpolate between
+ * two configured number values.
+ */
+export const interpolate =
+    (start: number, end: number, ease: TimingFunction = easeInOutQuad):
+        TimingFunction => (time: number) => start + (end - start) * ease(time);
+
+/**
+ * Creates a TimingFunction that interpolates through a weighted list
+ * of other TimingFunctions ("tracks"). Tracks are interpolated in order, and
+ * allocated a percentage of the total time based on their relative weight.
+ */
+export const sequence =
+    (tracks: Array<TimingFunction>, weights: Array<number>): TimingFunction => {
+      const totalWeight = weights.reduce((total, weight) => total + weight, 0);
+      const ratios: Array<number> = weights.map(weight => weight / totalWeight);
+
+      return (time: number) => {
+        let start: number = 0;
+        let ratio: number = Infinity;
+        let track: TimingFunction = () => 0;
+
+        for (let i = 0; i < ratios.length; ++i) {
+          ratio = ratios[i];
+          track = tracks[i];
+
+          if (time <= (start + ratio)) {
+            break;
+          }
+
+          start += ratio;
+        }
+
+        return track!((time - start) / ratio!);
+      }
+    };
+
+/**
+ * A Keyframe groups a target value, the number of frames to interpolate towards
+ * that value and an optional easing funnction to use for interpolation.
+ */
+export interface Keyframe {
+  value: number;
+  frames: number;
+  ease?: TimingFunction;
+}
+
+/**
+ * Creates a "timeline" TimingFunction out of an initial value and a series of
+ * Keyframes. The timeline function accepts value from 0-1 and returns the
+ * current value based on keyframe interpolation across the total number of
+ * frames. Frames are only used to indicate the relative length of each keyframe
+ * transition, so interpolated values will be computed for fractional frames.
+ */
+export const timeline =
+    (initialValue: number, keyframes: Array<Keyframe>): TimingFunction => {
+      const tracks: Array<TimingFunction> = [];
+      const weights: Array<number> = [];
+
+      let lastValue = initialValue;
+
+      for (let i = 0; i < keyframes.length; ++i) {
+        const keyframe = keyframes[i];
+        const {value, frames} = keyframe;
+        const ease = keyframe.ease || easeInOutQuad;
+        const track = interpolate(lastValue, value, ease);
+
+        tracks.push(track);
+        weights.push(frames);
+        lastValue = value;
+      }
+
+      return sequence(tracks, weights);
+    };


### PR DESCRIPTION
This change addresses messed up wiggling in Safari 13 (and similar glitches in IE11).

As of this change, we now orbit the camera rather than rotate the pivot node while wiggling. The upside of this is that it now looks more like what the user sees when they interact with the model. The possible downside is that the camera smoothing looks aesthetically different from the original implementation.

I tried "jumping" the camera to its goal when wiggling. This achieves a similar look to the original implementation, but also causes the wiggle effect to layer poorly with other effects that change the camera orbit (such as the recently added scroll position tracking in #739 ).

The new implementation was manually tested and is known to work as intended IE11 and Safari 13.

Fixes #839 
Fixes #842 