### PR TITLE
Clone tangents

### DIFF
--- a/src/three-components/ModelUtils.ts
+++ b/src/three-components/ModelUtils.ts
@@ -74,6 +74,9 @@ export const cloneGltf = (gltf: Gltf): Gltf => {
           specularGlossiness.cloneMaterial(material) :
           material.clone();
       clone.onBeforeCompile = updateShader;
+      // TODO(elalish): remove this when we upgrade three.js to a version with
+      // this fix: mrdoob/three.js#17795
+      clone.vertexTangents = material.vertexTangents;
       return clone;
     };
 


### PR DESCRIPTION
Fixes #848 

Quick fix, but we should remove it once we upgrade three.js, as the fix has already landed there.
