### PR TITLE
Fix progress state thrashing on first configuration

### DIFF
--- a/src/features/controls.ts
+++ b/src/features/controls.ts
@@ -292,7 +292,7 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
     }
 
     updated(changedProperties: Map<string|number|symbol, unknown>) {
-      super.updated(changedProperties as Map<string, any>);
+      super.updated(changedProperties);
 
       const controls = this[$controls];
       const scene = (this as any)[$scene];

--- a/src/features/environment.ts
+++ b/src/features/environment.ts
@@ -16,7 +16,7 @@
 import {property} from 'lit-element';
 import {Color, Texture} from 'three';
 
-import ModelViewerElementBase, {$container, $needsRender, $onModelLoad, $progressTracker, $renderer, $scene} from '../model-viewer-base.js';
+import ModelViewerElementBase, {$container, $isInRenderTree, $needsRender, $onModelLoad, $progressTracker, $renderer, $scene} from '../model-viewer-base.js';
 import {Constructor, deserializeUrl} from '../utilities.js';
 
 const DEFAULT_BACKGROUND_COLOR = '#ffffff';
@@ -70,7 +70,7 @@ export const EnvironmentMixin = <T extends Constructor<ModelViewerElementBase>>(
 
     private[$cancelEnvironmentUpdate]: ((...args: any[]) => any)|null = null;
 
-    updated(changedProperties: Map<string, any>) {
+    updated(changedProperties: Map<string|number|symbol, unknown>) {
       super.updated(changedProperties);
 
       if (changedProperties.has('shadowIntensity')) {
@@ -84,7 +84,8 @@ export const EnvironmentMixin = <T extends Constructor<ModelViewerElementBase>>(
       if (changedProperties.has('environmentImage') ||
           changedProperties.has('backgroundImage') ||
           changedProperties.has('backgroundColor') ||
-          changedProperties.has('experimentalPmrem')) {
+          changedProperties.has('experimentalPmrem') ||
+          changedProperties.has($isInRenderTree)) {
         this[$updateEnvironment]();
       }
     }
@@ -98,6 +99,10 @@ export const EnvironmentMixin = <T extends Constructor<ModelViewerElementBase>>(
     }
 
     async[$updateEnvironment]() {
+      if (!this[$isInRenderTree]) {
+        return;
+      }
+
       const {backgroundImage, environmentImage} = this;
       let {backgroundColor} = this;
 

--- a/src/features/loading.ts
+++ b/src/features/loading.ts
@@ -15,7 +15,7 @@
 
 import {property} from 'lit-element';
 
-import ModelViewerElementBase, {$ariaLabel, $canvas, $getLoaded, $getModelIsVisible, $progressTracker, $scene, $updateSource} from '../model-viewer-base.js';
+import ModelViewerElementBase, {$ariaLabel, $canvas, $getLoaded, $getModelIsVisible, $isInRenderTree, $progressTracker, $updateSource} from '../model-viewer-base.js';
 import {CachingGLTFLoader} from '../three-components/CachingGLTFLoader.js';
 import {Constructor, debounce, deserializeUrl, throttle} from '../utilities.js';
 
@@ -302,7 +302,7 @@ export const LoadingMixin = <T extends Constructor<ModelViewerElementBase>>(
       const {src} = this;
 
       return !!src && !CachingGLTFLoader.hasFinishedLoading(src) &&
-          (this.preload || this[$shouldRevealModel]) && this[$scene].isVisible;
+          (this.preload || this[$shouldRevealModel]) && this[$isInRenderTree];
     }
 
     async[$updateLoadingAndVisibility]() {

--- a/src/model-viewer-base.ts
+++ b/src/model-viewer-base.ts
@@ -219,8 +219,7 @@ export default class ModelViewerElementBase extends UpdatingElement {
         for (let entry of entries) {
           if (entry.target === this) {
             const oldValue = this[$isInRenderTree];
-            this[$isInRenderTree] = this[$scene].isVisible =
-                entry.isIntersecting;
+            this[$isInRenderTree] = this[$scene].visible = entry.isIntersecting;
             this.requestUpdate($isInRenderTree, oldValue);
 
             if (this[$isInRenderTree]) {
@@ -241,7 +240,7 @@ export default class ModelViewerElementBase extends UpdatingElement {
     } else {
       // If there is no intersection obsever, then all models should be visible
       // at all times:
-      this[$isInRenderTree] = this[$scene].isVisible = true;
+      this[$isInRenderTree] = this[$scene].visible = true;
       this.requestUpdate($isInRenderTree, false);
     }
   }

--- a/src/model-viewer-base.ts
+++ b/src/model-viewer-base.ts
@@ -44,6 +44,7 @@ const $clearModelTimeout = Symbol('clearModelTimeout');
 const $onContextLost = Symbol('onContextLost');
 const $contextLostHandler = Symbol('contextLostHandler');
 
+export const $isInRenderTree = Symbol('isInRenderTree');
 export const $resetRenderer = Symbol('resetRenderer');
 export const $ariaLabel = Symbol('ariaLabel');
 export const $loadedTime = Symbol('loadedTime');
@@ -99,8 +100,9 @@ export default class ModelViewerElementBase extends UpdatingElement {
   @property({converter: {fromAttribute: deserializeUrl}})
   src: string|null = null;
 
-  protected[$loaded]: boolean = false;
-  protected[$loadedTime]: number = 0;
+  protected[$isInRenderTree] = false;
+  protected[$loaded] = false;
+  protected[$loadedTime] = 0;
   protected[$scene]: ModelScene;
   protected[$container]: HTMLDivElement;
   protected[$canvas]: HTMLCanvasElement;
@@ -211,11 +213,24 @@ export default class ModelViewerElementBase extends UpdatingElement {
     }
 
     if (HAS_INTERSECTION_OBSERVER) {
+      const enterRenderTreeProgress = this[$progressTracker].beginActivity();
+
       this[$intersectionObserver] = new IntersectionObserver(entries => {
         for (let entry of entries) {
           if (entry.target === this) {
-            this[$scene].isVisible = entry.isIntersecting;
-            this.requestUpdate();
+            const oldValue = this[$isInRenderTree];
+            this[$isInRenderTree] = this[$scene].isVisible =
+                entry.isIntersecting;
+            this.requestUpdate($isInRenderTree, oldValue);
+
+            if (this[$isInRenderTree]) {
+              // Wait a microtask to give other properties a change to respond
+              // to the state change, then resolve progress on entering the
+              // rendre tree:
+              Promise.resolve().then(() => {
+                enterRenderTreeProgress(1);
+              });
+            }
           }
         }
       }, {
@@ -226,7 +241,8 @@ export default class ModelViewerElementBase extends UpdatingElement {
     } else {
       // If there is no intersection obsever, then all models should be visible
       // at all times:
-      this[$scene].isVisible = true;
+      this[$isInRenderTree] = this[$scene].isVisible = true;
+      this.requestUpdate($isInRenderTree, false);
     }
   }
 
@@ -281,7 +297,7 @@ export default class ModelViewerElementBase extends UpdatingElement {
     }, CLEAR_MODEL_TIMEOUT_MS);
   }
 
-  updated(changedProperties: Map<string, any>) {
+  updated(changedProperties: Map<string|number|symbol, any>) {
     super.updated(changedProperties);
 
     // NOTE(cdata): If a property changes from values A -> B -> A in the space

--- a/src/model-viewer-base.ts
+++ b/src/model-viewer-base.ts
@@ -226,7 +226,7 @@ export default class ModelViewerElementBase extends UpdatingElement {
             if (this[$isInRenderTree]) {
               // Wait a microtask to give other properties a change to respond
               // to the state change, then resolve progress on entering the
-              // rendre tree:
+              // render tree:
               Promise.resolve().then(() => {
                 enterRenderTreeProgress(1);
               });

--- a/src/model-viewer-base.ts
+++ b/src/model-viewer-base.ts
@@ -224,7 +224,7 @@ export default class ModelViewerElementBase extends UpdatingElement {
             this.requestUpdate($isInRenderTree, oldValue);
 
             if (this[$isInRenderTree]) {
-              // Wait a microtask to give other properties a change to respond
+              // Wait a microtask to give other properties a chance to respond
               // to the state change, then resolve progress on entering the
               // render tree:
               Promise.resolve().then(() => {

--- a/src/test/features/environment-spec.ts
+++ b/src/test/features/environment-spec.ts
@@ -329,7 +329,7 @@ suite('ModelViewerElementBase with EnvironmentMixin', () => {
       element.src = MODEL_URL;
       document.body.appendChild(element);
       await waitForEvent(element, 'load');
-      scene.isVisible = true;
+      scene.visible = true;
     });
 
     teardown(() => {

--- a/src/test/features/environment-spec.ts
+++ b/src/test/features/environment-spec.ts
@@ -20,7 +20,7 @@ import {EnvironmentInterface, EnvironmentMixin} from '../../features/environment
 import ModelViewerElementBase, {$resetRenderer, $scene} from '../../model-viewer-base.js';
 import Model from '../../three-components/Model.js';
 import ModelScene from '../../three-components/ModelScene.js';
-import {assetPath, textureMatchesMeta, timePasses, waitForEvent} from '../helpers.js';
+import {assetPath, rafPasses, textureMatchesMeta, timePasses, waitForEvent} from '../helpers.js';
 import {BasicSpecTemplate} from '../templates.js';
 
 const expect = chai.expect;
@@ -162,6 +162,20 @@ suite('ModelViewerElementBase with EnvironmentMixin', () => {
         await timePasses();
         expect(backgroundHasColor(scene, 'ffffff')).to.be.equal(true);
       });
+
+  test('only generates an environment when in the render tree', async () => {
+    let environmentChangeCount = 0;
+    const environmentChangeHandler = () => environmentChangeCount++;
+    element.addEventListener('environment-change', environmentChangeHandler);
+    element.style.display = 'none';
+    document.body.appendChild(element);
+    await rafPasses();
+    expect(environmentChangeCount).to.be.equal(0);
+    element.style.display = 'block';
+    await waitForEvent(element, 'environment-change');
+    expect(environmentChangeCount).to.be.equal(1);
+    element.addEventListener('environment-change', environmentChangeHandler);
+  });
 
   suite('with no background-image property', () => {
     let environmentChanges = 0;

--- a/src/test/features/environment-spec.ts
+++ b/src/test/features/environment-spec.ts
@@ -174,7 +174,7 @@ suite('ModelViewerElementBase with EnvironmentMixin', () => {
     element.style.display = 'block';
     await waitForEvent(element, 'environment-change');
     expect(environmentChangeCount).to.be.equal(1);
-    element.addEventListener('environment-change', environmentChangeHandler);
+    element.removeEventListener('environment-change', environmentChangeHandler);
   });
 
   suite('with no background-image property', () => {

--- a/src/test/model-viewer-base-spec.ts
+++ b/src/test/model-viewer-base-spec.ts
@@ -238,10 +238,10 @@ suite('ModelViewerElementBase', () => {
 
       test('sets a model within viewport to be visible', async () => {
         await until(() => {
-          return elements[0][$scene].isVisible;
+          return elements[0][$scene].visible;
         });
 
-        expect(elements[0][$scene].isVisible).to.be.true;
+        expect(elements[0][$scene].visible).to.be.true;
       });
 
       test.skip('only models visible in the viewport', async () => {
@@ -251,14 +251,14 @@ suite('ModelViewerElementBase', () => {
         await until(() => {
           return elements
               .map((element, index) => {
-                return (index === 0) === element[$scene].isVisible;
+                return (index === 0) === element[$scene].visible;
               })
               .reduce(((l, r) => l && r), true);
         });
 
-        expect(elements[0][$scene].isVisible).to.be.ok;
-        expect(elements[1][$scene].isVisible).to.not.be.ok;
-        expect(elements[2][$scene].isVisible).to.not.be.ok;
+        expect(elements[0][$scene].visible).to.be.ok;
+        expect(elements[1][$scene].visible).to.not.be.ok;
+        expect(elements[2][$scene].visible).to.not.be.ok;
       });
     });
   });

--- a/src/test/three-components/Renderer-spec.ts
+++ b/src/test/three-components/Renderer-spec.ts
@@ -41,7 +41,7 @@ function createScene(): ModelScene&TestScene {
     height: 100,
     renderer,
   });
-  scene.isVisible = true;
+  scene.visible = true;
 
   scene.renderCount = 0;
   const drawImage = scene.context.drawImage;
@@ -103,15 +103,15 @@ suite('Renderer', () => {
       expect(!scene.isDirty).to.be.ok;
     });
 
-    test('does not render scenes marked as !isVisible', async function() {
-      scene.isVisible = false;
+    test('does not render scenes marked as not visible', async function() {
+      scene.visible = false;
       scene.isDirty = true;
 
       renderer.render(performance.now());
       expect(scene.renderCount).to.be.equal(0);
       expect(scene.isDirty).to.be.ok;
 
-      scene.isVisible = true;
+      scene.visible = true;
 
       renderer.render(performance.now());
       expect(scene.renderCount).to.be.equal(1);

--- a/src/three-components/Renderer.ts
+++ b/src/three-components/Renderer.ts
@@ -179,7 +179,7 @@ export class Renderer extends EventDispatcher {
       const {element, width, height, context} = scene;
       element[$tick](t, delta);
 
-      if (!scene.isVisible || !scene.isDirty || scene.paused) {
+      if (!scene.visible || !scene.isDirty || scene.paused) {
         continue;
       }
 


### PR DESCRIPTION
When I implemented #833 I introduced the bug described in #847. We did defer loading models as intended, but since `IntersectionObserver` announces intersections somewhat late compared to property updates we were still performing other side-effects early. Among these effects was environment map generation.

With this change, environment map generation is also deferred until we are in the render tree. The rationale for this is that being `display: none` or outside of the viewport should be considered "no cost" in the typical case.

Also, a new, one-time progress activity has been introduced that measures the time before we get the first signal from `IntersectionObserver` that we are visible. This should account for any additional side-effects that measure progress early.

Fixes #847 