### PR TITLE
Preserve query string when intenting

### DIFF
--- a/examples/augmented-reality.html
+++ b/examples/augmented-reality.html
@@ -59,7 +59,7 @@
         </div>
         <example-snippet stamp-to="demo-container-1" highlight-as="html">
           <template>
-<model-viewer src="assets/Astronaut.glb?link" ar camera-controls alt="A 3D model of an astronaut" background-color="#222" ios-src="assets/Astronaut.usdz" magic-leap unstable-webxr></model-viewer>
+<model-viewer src="assets/Astronaut.glb" ar camera-controls alt="A 3D model of an astronaut" background-color="#222" ios-src="assets/Astronaut.usdz" magic-leap unstable-webxr></model-viewer>
           </template>
         </example-snippet>
 

--- a/examples/augmented-reality.html
+++ b/examples/augmented-reality.html
@@ -59,7 +59,7 @@
         </div>
         <example-snippet stamp-to="demo-container-1" highlight-as="html">
           <template>
-<model-viewer src="assets/Astronaut.glb" ar camera-controls alt="A 3D model of an astronaut" background-color="#222" ios-src="assets/Astronaut.usdz" magic-leap unstable-webxr></model-viewer>
+<model-viewer src="assets/Astronaut.glb?link" ar camera-controls alt="A 3D model of an astronaut" background-color="#222" ios-src="assets/Astronaut.usdz" magic-leap unstable-webxr></model-viewer>
           </template>
         </example-snippet>
 

--- a/src/features/ar.ts
+++ b/src/features/ar.ts
@@ -205,7 +205,7 @@ export const ARMixin = <T extends Constructor<ModelViewerElementBase>>(
           await this[$enterARWithWebXR]();
           break;
         case ARMode.AR_VIEWER:
-          openARViewer(this.src!, this.alt || '');
+          openSceneViewer(this.src!, this.alt || '');
           break;
         default:
           console.warn(

--- a/src/features/ar.ts
+++ b/src/features/ar.ts
@@ -35,7 +35,11 @@ export const openIOSARQuickLook = (() => {
   };
 })();
 
-export const openARViewer = (() => {
+/**
+ * Takes a URL and a title string, and attempts to launch Scene Viewer on the
+ * current device.
+ */
+export const openSceneViewer = (() => {
   const anchor = document.createElement('a');
   const noArViewerSigil = '#model-viewer-no-ar-fallback';
   let fallbackInvoked = false;
@@ -56,9 +60,12 @@ export const openARViewer = (() => {
 
     title = encodeURIComponent(title);
     modelUrl.protocol = 'intent://';
+    // It's possible for a model URL to have meaningful query parameters
+    // already. Sure hope they aren't called 'link' or 'title' though 😅
+    modelUrl.search +=
+        (modelUrl.search ? '&' : '') + `link=${link}&title=${title}`;
 
-    const intent = `${modelUrl.toString()}?link=${link}&title=${
-        title}#Intent;scheme=${
+    const intent = `${modelUrl.toString()}#Intent;scheme=${
         scheme};package=com.google.ar.core;action=android.intent.action.VIEW;S.browser_fallback_url=${
         encodeURIComponent(locationUrl.toString())};end;`;
 

--- a/src/features/ar.ts
+++ b/src/features/ar.ts
@@ -41,6 +41,7 @@ export const openIOSARQuickLook = (() => {
  */
 export const openSceneViewer = (() => {
   const anchor = document.createElement('a');
+  const linkOrTitle = /(link|title)(=|&)|(\?|&)(link|title)$/;
   const noArViewerSigil = '#model-viewer-no-ar-fallback';
   let fallbackInvoked = false;
 
@@ -56,10 +57,19 @@ export const openSceneViewer = (() => {
     const link = encodeURIComponent(location);
     const scheme = modelUrl.protocol.replace(':', '');
 
+    if (modelUrl.search && modelUrl.search.match(linkOrTitle)) {
+      console.warn(`The model URL (${
+          modelUrl
+              .toString()}) contains a "link" and/or "title" query parameter.
+ These parameters are used to configure Scene Viewer and will be duplicated in the URL.
+ You should choose different query parameter names if possible!`);
+    }
+
     locationUrl.hash = noArViewerSigil;
 
     title = encodeURIComponent(title);
     modelUrl.protocol = 'intent://';
+
     // It's possible for a model URL to have meaningful query parameters
     // already. Sure hope they aren't called 'link' or 'title' though 😅
     modelUrl.search +=

--- a/src/test/features/ar-spec.ts
+++ b/src/test/features/ar-spec.ts
@@ -14,10 +14,10 @@
  */
 
 import {IS_IOS} from '../../constants.js';
-import {ARInterface, ARMixin} from '../../features/ar.js';
+import {ARInterface, ARMixin, openSceneViewer} from '../../features/ar.js';
 import ModelViewerElementBase from '../../model-viewer-base.js';
 import {Constructor} from '../../utilities.js';
-import {assetPath, timePasses, waitForEvent} from '../helpers.js';
+import {assetPath, spy, timePasses, waitForEvent} from '../helpers.js';
 import {BasicSpecTemplate} from '../templates.js';
 
 const expect = chai.expect;
@@ -40,6 +40,28 @@ suite('ModelViewerElementBase with ARMixin', () => {
     });
 
     BasicSpecTemplate(() => ModelViewerElement, () => tagName);
+
+    suite('openSceneViewer', () => {
+      test('preserves query parameters in model URLs', () => {
+        const intentUrls: Array<string> = [];
+        const restoreAnchorClick = spy(HTMLAnchorElement.prototype, 'click', {
+          value: function() {
+            intentUrls.push((this as HTMLAnchorElement).href);
+          }
+        });
+
+        openSceneViewer(
+            'https://example.com/model.gltf?token=foo', 'Example model');
+
+        expect(intentUrls.length).to.be.equal(1);
+
+        const url = new URL(intentUrls[0]);
+
+        expect(url.search).to.match(/[\?&]token=foo(&|$)/);
+
+        restoreAnchorClick();
+      });
+    });
 
     suite('quick-look-browsers', () => {
       // TODO(#624,#625): We cannot implement these tests without the ability


### PR DESCRIPTION
Although this is not currently a common case, we have been breaking Scene Viewer integration whenever the model URL contains sensitive query parameters. A common case for this is when models are hosted on static storage that allows token-based access. In such scenarios, the token is often added to the query string.

Fixes #742 