### PR TITLE
Add minimum viable debug mode

### DIFF
--- a/src/model-viewer-base.ts
+++ b/src/model-viewer-base.ts
@@ -22,10 +22,10 @@ import {makeTemplate} from './template.js';
 import {$evictionPolicy, CachingGLTFLoader} from './three-components/CachingGLTFLoader.js';
 import ModelScene from './three-components/ModelScene.js';
 import {ContextLostEvent, Renderer} from './three-components/Renderer.js';
-import {debounce, deserializeUrl, resolveDpr} from './utilities.js';
+import {debounce, deserializeUrl, isDebugMode, resolveDpr} from './utilities.js';
 import {ProgressTracker} from './utilities/progress-tracker.js';
 
-let renderer = new Renderer();
+let renderer = new Renderer({debug: isDebugMode()});
 
 const CLEAR_MODEL_TIMEOUT_MS = 1000;
 const FALLBACK_SIZE_UPDATE_THRESHOLD_MS = 50;

--- a/src/model-viewer-base.ts
+++ b/src/model-viewer-base.ts
@@ -20,7 +20,7 @@ import {Event as ThreeEvent} from 'three';
 import {HAS_INTERSECTION_OBSERVER, HAS_RESIZE_OBSERVER} from './constants.js';
 import {makeTemplate} from './template.js';
 import {$evictionPolicy, CachingGLTFLoader} from './three-components/CachingGLTFLoader.js';
-import ModelScene from './three-components/ModelScene.js';
+import {ModelScene} from './three-components/ModelScene.js';
 import {ContextLostEvent, Renderer} from './three-components/Renderer.js';
 import {debounce, deserializeUrl, isDebugMode, resolveDpr} from './utilities.js';
 import {ProgressTracker} from './utilities/progress-tracker.js';

--- a/src/test/features/environment-spec.ts
+++ b/src/test/features/environment-spec.ts
@@ -19,7 +19,7 @@ import {MeshStandardMaterial} from 'three';
 import {EnvironmentInterface, EnvironmentMixin} from '../../features/environment.js';
 import ModelViewerElementBase, {$resetRenderer, $scene} from '../../model-viewer-base.js';
 import Model from '../../three-components/Model.js';
-import ModelScene from '../../three-components/ModelScene.js';
+import {ModelScene} from '../../three-components/ModelScene.js';
 import {assetPath, rafPasses, textureMatchesMeta, timePasses, waitForEvent} from '../helpers.js';
 import {BasicSpecTemplate} from '../templates.js';
 

--- a/src/test/three-components/ARRenderer-spec.ts
+++ b/src/test/three-components/ARRenderer-spec.ts
@@ -18,7 +18,7 @@ import {Camera, Matrix4, Plane, Ray, Vector3} from 'three';
 import {IS_WEBXR_AR_CANDIDATE} from '../../constants.js';
 import ModelViewerElementBase, {$renderer, $scene} from '../../model-viewer-base.js';
 import {ARRenderer} from '../../three-components/ARRenderer.js';
-import ModelScene from '../../three-components/ModelScene.js';
+import {ModelScene} from '../../three-components/ModelScene.js';
 import {Renderer} from '../../three-components/Renderer.js';
 import {assetPath, timePasses, waitForEvent} from '../helpers.js';
 

--- a/src/test/three-components/ModelScene-spec.ts
+++ b/src/test/three-components/ModelScene-spec.ts
@@ -17,7 +17,7 @@ import {Matrix4, Mesh, SphereBufferGeometry, Vector3} from 'three';
 
 import ModelViewerElementBase, {$canvas, $renderer} from '../../model-viewer-base.js';
 import {DEFAULT_FOV_DEG} from '../../three-components/Model.js';
-import ModelScene from '../../three-components/ModelScene.js';
+import {ModelScene} from '../../three-components/ModelScene.js';
 import {Renderer} from '../../three-components/Renderer.js';
 import {assetPath} from '../helpers.js';
 

--- a/src/test/three-components/Renderer-spec.ts
+++ b/src/test/three-components/Renderer-spec.ts
@@ -14,7 +14,7 @@
  */
 
 import ModelViewerElementBase, {$canvas, $onResize, $renderer} from '../../model-viewer-base.js';
-import ModelScene from '../../three-components/ModelScene.js';
+import {ModelScene} from '../../three-components/ModelScene.js';
 import {Renderer} from '../../three-components/Renderer.js';
 
 const expect = chai.expect;

--- a/src/three-components/ARRenderer.ts
+++ b/src/three-components/ARRenderer.ts
@@ -15,7 +15,7 @@
 
 import {EventDispatcher, Matrix4, Object3D, PerspectiveCamera, Raycaster, Scene, Vector3, WebGLRenderer} from 'three';
 import {assertIsArCandidate} from '../utilities.js';
-import ModelScene from './ModelScene.js';
+import {ModelScene} from './ModelScene.js';
 import {Renderer} from './Renderer.js';
 import Reticle from './Reticle.js';
 import {assertContext} from './WebGLUtils.js';

--- a/src/three-components/Debugger.ts
+++ b/src/three-components/Debugger.ts
@@ -1,4 +1,4 @@
-import {Mesh, OrthographicCamera, PlaneBufferGeometry, ShaderMaterial, Texture, WebGLRenderTarget} from 'three';
+import {Mesh, OrthographicCamera, PlaneBufferGeometry, Scene, ShaderMaterial, Texture, WebGLRenderTarget} from 'three';
 
 import {Renderer} from './Renderer';
 
@@ -10,6 +10,7 @@ export interface ModelViewerRendererDebugDetails {
     OrthographicCamera: Constructor<OrthographicCamera>;
     WebGLRenderTarget: Constructor<WebGLRenderTarget>;
     Texture: Constructor<Texture>;
+    Scene: Constructor<Scene>;
     Mesh: Constructor<Mesh>;
   };
 }
@@ -25,7 +26,7 @@ export interface ModelViewerRendererDebugDetails {
  */
 export class Debugger {
   constructor(renderer: Renderer) {
-    renderer.renderer.debug = {checkShaderErrors: false};
+    renderer.renderer.debug = {checkShaderErrors: true};
     Promise.resolve().then(() => {
       self.dispatchEvent(new CustomEvent<ModelViewerRendererDebugDetails>(
           'model-viewer-renderer-debug', {
@@ -35,6 +36,7 @@ export class Debugger {
                 ShaderMaterial,
                 Texture,
                 Mesh,
+                Scene,
                 PlaneBufferGeometry,
                 OrthographicCamera,
                 WebGLRenderTarget

--- a/src/three-components/Debugger.ts
+++ b/src/three-components/Debugger.ts
@@ -1,0 +1,46 @@
+import {Mesh, OrthographicCamera, PlaneBufferGeometry, ShaderMaterial, Texture, WebGLRenderTarget} from 'three';
+
+import {Renderer} from './Renderer';
+
+export interface ModelViewerRendererDebugDetails {
+  renderer: Renderer;
+  THREE: {
+    ShaderMaterial: Constructor<ShaderMaterial>;
+    PlaneBufferGeometry: Constructor<PlaneBufferGeometry>;
+    OrthographicCamera: Constructor<OrthographicCamera>;
+    WebGLRenderTarget: Constructor<WebGLRenderTarget>;
+    Texture: Constructor<Texture>;
+    Mesh: Constructor<Mesh>;
+  };
+}
+
+/**
+ * This Debugger exposes internal details of the <model-viewer> rendering
+ * substructure so that external tools can more easily inspect and operate on
+ * them.
+ *
+ * It also activates shader debugging on the associated GL context. Shader
+ * debugging trades performance for useful error information, so it is not
+ * recommended to activate this unless needed.
+ */
+export class Debugger {
+  constructor(renderer: Renderer) {
+    renderer.renderer.debug = {checkShaderErrors: false};
+    Promise.resolve().then(() => {
+      self.dispatchEvent(new CustomEvent<ModelViewerRendererDebugDetails>(
+          'model-viewer-renderer-debug', {
+            detail: {
+              renderer,
+              THREE: {
+                ShaderMaterial,
+                Texture,
+                Mesh,
+                PlaneBufferGeometry,
+                OrthographicCamera,
+                WebGLRenderTarget
+              }
+            }
+          }));
+    });
+  }
+}

--- a/src/three-components/Debugger.ts
+++ b/src/three-components/Debugger.ts
@@ -1,5 +1,6 @@
 import {Mesh, OrthographicCamera, PlaneBufferGeometry, Scene, ShaderMaterial, Texture, WebGLRenderTarget} from 'three';
 
+import {ModelScene} from './ModelScene';
 import {Renderer} from './Renderer';
 
 export interface ModelViewerRendererDebugDetails {
@@ -15,6 +16,10 @@ export interface ModelViewerRendererDebugDetails {
   };
 }
 
+export interface ModelViewerSceneDetails {
+  scene: ModelScene
+}
+
 /**
  * This Debugger exposes internal details of the <model-viewer> rendering
  * substructure so that external tools can more easily inspect and operate on
@@ -26,7 +31,11 @@ export interface ModelViewerRendererDebugDetails {
  */
 export class Debugger {
   constructor(renderer: Renderer) {
+    // Force WebGL shader debugging on:
     renderer.renderer.debug = {checkShaderErrors: true};
+    // Announce debug details at microtask timing to give the `Renderer`
+    // constructor time to complete its initialization, just to be on the safe
+    // side:
     Promise.resolve().then(() => {
       self.dispatchEvent(new CustomEvent<ModelViewerRendererDebugDetails>(
           'model-viewer-renderer-debug', {
@@ -44,5 +53,15 @@ export class Debugger {
             }
           }));
     });
+  }
+
+  addScene(scene: ModelScene) {
+    self.dispatchEvent(new CustomEvent<ModelViewerSceneDetails>(
+        'model-viewer-scene-added-debug', {detail: {scene}}));
+  }
+
+  removeScene(scene: ModelScene) {
+    self.dispatchEvent(new CustomEvent<ModelViewerSceneDetails>(
+        'model-viewer-scene-removed-debug', {detail: {scene}}));
   }
 }

--- a/src/three-components/ModelScene.ts
+++ b/src/three-components/ModelScene.ts
@@ -13,8 +13,7 @@
  * limitations under the License.
  */
 
-import {BackSide, BoxBufferGeometry, Camera, Color, Event as ThreeEvent, Object3D, PerspectiveCamera, Scene, Shader, ShaderLib, ShaderMaterial, Vector3} from 'three';
-import {Mesh} from 'three';
+import {BackSide, BoxBufferGeometry, Camera, Color, Event as ThreeEvent, Mesh, Object3D, PerspectiveCamera, Scene, Shader, ShaderLib, ShaderMaterial, Vector3} from 'three';
 
 import ModelViewerElementBase from '../model-viewer-base.js';
 import {resolveDpr} from '../utilities.js';

--- a/src/three-components/ModelScene.ts
+++ b/src/three-components/ModelScene.ts
@@ -49,7 +49,7 @@ const $paused = Symbol('paused');
  * constructs a framed scene based off of the canvas dimensions.
  * Provides lights and cameras to be used in a renderer.
  */
-export default class ModelScene extends Scene {
+export class ModelScene extends Scene {
   private[$paused]: boolean = false;
 
   public aspect = 1;

--- a/src/three-components/Renderer.ts
+++ b/src/three-components/Renderer.ts
@@ -59,7 +59,7 @@ export class Renderer extends EventDispatcher {
   public width: number = 0;
   public height: number = 0;
 
-  private debugger: Debugger|null = null;
+  protected debugger: Debugger|null = null;
   private[$arRenderer]: ARRenderer;
   private scenes: Set<ModelScene> = new Set();
   private lastTick: number;

--- a/src/three-components/Renderer.ts
+++ b/src/three-components/Renderer.ts
@@ -22,7 +22,7 @@ import {resolveDpr} from '../utilities.js';
 
 import {ARRenderer} from './ARRenderer.js';
 import {Debugger} from './Debugger.js';
-import ModelScene from './ModelScene.js';
+import {ModelScene} from './ModelScene.js';
 import TextureUtils from './TextureUtils.js';
 import * as WebGLUtils from './WebGLUtils.js';
 
@@ -102,11 +102,9 @@ export class Renderer extends EventDispatcher {
       this.renderer.physicallyCorrectLights = true;
       this.renderer.setPixelRatio(resolveDpr());
 
-      if (options != null && options.debug) {
-        this.debugger = new Debugger(this);
-      } else {
-        this.renderer.debug = {checkShaderErrors: false};
-      }
+      this.debugger =
+          options != null && !!options.debug ? new Debugger(this) : null;
+      this.renderer.debug = {checkShaderErrors: !!this.debugger};
 
       // ACESFilmicToneMapping appears to be the most "saturated",
       // and similar to Filament's gltf-viewer.
@@ -137,12 +135,20 @@ export class Renderer extends EventDispatcher {
     if (this.canRender && this.scenes.size > 0) {
       this.renderer.setAnimationLoop((time: number) => this.render(time));
     }
+
+    if (this.debugger != null) {
+      this.debugger.addScene(scene);
+    }
   }
 
   unregisterScene(scene: ModelScene) {
     this.scenes.delete(scene);
     if (this.canRender && this.scenes.size === 0) {
       (this.renderer.setAnimationLoop as any)(null);
+    }
+
+    if (this.debugger != null) {
+      this.debugger.removeScene(scene);
     }
   }
 

--- a/src/three-components/Renderer.ts
+++ b/src/three-components/Renderer.ts
@@ -102,8 +102,10 @@ export class Renderer extends EventDispatcher {
       this.renderer.physicallyCorrectLights = true;
       this.renderer.setPixelRatio(resolveDpr());
 
-      if (options == null || options.debug === false) {
+      if (options != null && options.debug) {
         this.debugger = new Debugger(this);
+      } else {
+        this.renderer.debug = {checkShaderErrors: false};
       }
 
       // ACESFilmicToneMapping appears to be the most "saturated",

--- a/src/three-components/Renderer.ts
+++ b/src/three-components/Renderer.ts
@@ -21,9 +21,14 @@ import {$tick} from '../model-viewer-base.js';
 import {resolveDpr} from '../utilities.js';
 
 import {ARRenderer} from './ARRenderer.js';
+import {Debugger} from './Debugger.js';
 import ModelScene from './ModelScene.js';
 import TextureUtils from './TextureUtils.js';
 import * as WebGLUtils from './WebGLUtils.js';
+
+export interface RendererOptions {
+  debug?: boolean;
+}
 
 export interface ContextLostEvent extends Event {
   type: 'contextlost';
@@ -54,6 +59,7 @@ export class Renderer extends EventDispatcher {
   public width: number = 0;
   public height: number = 0;
 
+  private debugger: Debugger|null = null;
   private[$arRenderer]: ARRenderer;
   private scenes: Set<ModelScene> = new Set();
   private lastTick: number;
@@ -65,7 +71,7 @@ export class Renderer extends EventDispatcher {
     return this.renderer != null && this.context != null;
   }
 
-  constructor() {
+  constructor(options?: RendererOptions) {
     super();
 
     const webGlOptions = {alpha: false, antialias: true};
@@ -95,6 +101,10 @@ export class Renderer extends EventDispatcher {
       this.renderer.gammaFactor = 2.2;
       this.renderer.physicallyCorrectLights = true;
       this.renderer.setPixelRatio(resolveDpr());
+
+      if (options == null || options.debug === false) {
+        this.debugger = new Debugger(this);
+      }
 
       // ACESFilmicToneMapping appears to be the most "saturated",
       // and similar to Filament's gltf-viewer.

--- a/src/three-components/StaticShadow.ts
+++ b/src/three-components/StaticShadow.ts
@@ -15,7 +15,7 @@
 
 import {Mesh, MeshBasicMaterial, OrthographicCamera, PlaneGeometry, RGBAFormat, Vector3, WebGLRenderTarget} from 'three';
 import {WebGLRenderer} from 'three';
-import ModelScene from './ModelScene';
+import {ModelScene} from './ModelScene';
 
 export interface ShadowGenerationConfig {
   textureWidth?: number;

--- a/src/three-components/TextureUtils.ts
+++ b/src/three-components/TextureUtils.ts
@@ -56,6 +56,10 @@ const userData = {
 };
 
 export default class TextureUtils extends EventDispatcher {
+  get pmremGenerator() {
+    return this[$PMREMGenerator];
+  }
+
   private renderer: WebGLRenderer;
 
   private[$generatedEnvironmentMap]: WebGLRenderTarget|null = null;

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -181,6 +181,26 @@ export const resolveDpr: () => number = (() => {
 
 
 /**
+ * Debug mode is enabled when one of the two following conditions is true:
+ *
+ *  1. A 'model-viewer-debug-mode' query parameter is present in the current
+ *     search string
+ *  2. There is a global object ModelViewerElement with a debugMode property set
+ *     to true
+ */
+export const isDebugMode = (() => {
+  const debugQueryParameterName = 'model-viewer-debug-mode';
+  const debugQueryParameter =
+      new RegExp(`[\?&]${debugQueryParameterName}(&|$)`);
+
+  return () => ((self as any).ModelViewerElement &&
+                (self as any).ModelViewerElement.debugMode) ||
+      (self.location && self.location.search &&
+       self.location.search.match(debugQueryParameter));
+})();
+
+
+/**
  * Returns the first key in a Map in iteration order.
  *
  * NOTE(cdata): This is necessary because IE11 does not implement iterator


### PR DESCRIPTION
This change introduces a very light "debug" mode to `<model-viewer>`. Debug mode can be activated in two ways:

 1. By adding a query parameter to the URL:
    - `http://example.com/foo.html?model-viewer-debug-mode`
 2. By including a global signal on the page with script:
```html
<script>
ModelViewerElement = ModelViewerElement || {};
ModelViewerElement.debugMode = true;
</script>
```

Activating debug mode currently does two things:

 1. Enables verbose shader error messages on the GL context
 2. Exposes renderer internal details with a globally dispatched `model-viewer-renderer-debug` event

An example of using this event looks like:

```html
<!-- Before model-viewer.js is loaded: -->
<script>
self.addEventListener('model-viewer-renderer-debug', (event) => {
  const {
    THREE, // Limited subset of Three.js constructors
    renderer // The singleton instance of Renderer
  } = event.detail;

  // Do debugging stuff...
});
</script>
```

The `Debugger` will also advertise scenes as they are registered and unregistered. You can listen for global `model-viewer-scene-added-debug` and `model-viewer-scene-removed-debug` events, which contain a reference to the related scene as `event.detail.scene`. The scenes in this case will be instances of `ModelScene`.

If you wanted to turn on debugging for most tests, you could manually run them with a URL like: `http://localhost:8000/test/?model-viewer-debug-mode`.

Note that this will currently only enable debug mode for tests that create a `Renderer` via `ModelViewerElementBase`. Tests that instantiate a `Renderer` directly would need to pass a debug flag e.g., `new Renderer({ debug: true });`.