### PR TITLE
Use correct property name for source event

### DIFF
--- a/src/model-viewer-base.ts
+++ b/src/model-viewer-base.ts
@@ -402,7 +402,7 @@ export default class ModelViewerElementBase extends UpdatingElement {
   [$onContextLost](event: ContextLostEvent) {
     this.dispatchEvent(new CustomEvent(
         'error',
-        {detail: {type: 'webglcontextlost', sourceError: event.attachment}}));
+        {detail: {type: 'webglcontextlost', sourceError: event.sourceEvent}}));
   }
 
   /**


### PR DESCRIPTION
This came up when building in google3. I'm actually surprised we were allowed to compile in this case.