### PR TITLE
Implement toBlob function on ModelViewerElementBase

### DIFF
--- a/index.html
+++ b/index.html
@@ -475,8 +475,9 @@
               <p>Returns a promise that resolves into a Blob object in the format
               specified by the <i>mimeType</i> (defaults to image/png). A Blob object
               represents a file-like object of immutable, raw data. You can also
-              specify a value between 0 and 1 for <i>qualityArgument</i> which defaults
-              to 0.92 and 0.8 for image/png and image/webp respectively.</p>
+              specify a value between 0 and 1 for <i>qualityArgument</i> (Currently
+              only available on Chrome desktop and Firefox) which defaults to 0.92
+              and 0.8 for image/png and image/webp respectively.</p>
             </li>
           </ul>
 

--- a/index.html
+++ b/index.html
@@ -470,6 +470,14 @@
               value for <i>encoderOptions</i> between 0 and 1 (<i>encoderOptions</i>
               defaults to 0.92 otherwise).</p>
             </li>
+            <li>
+              <div>toBlob(mimeType, qualityArgument)</div>
+              <p>Returns a promise that resolves into a Blob object in the format
+              specified by the <i>mimeType</i> (defaults to image/png). A Blob object
+              represents a file-like object of immutable, raw data. You can also
+              specify a value between 0 and 1 for <i>qualityArgument</i> which defaults
+              to 0.92 and 0.8 for image/png and image/webp respectively.</p>
+            </li>
           </ul>
 
         </div>

--- a/src/model-viewer-base.ts
+++ b/src/model-viewer-base.ts
@@ -328,8 +328,17 @@ export default class ModelViewerElementBase extends UpdatingElement {
 
   async toBlob(mimeType?: string, qualityArgument?: number): Promise<Blob> {
     return new Promise(async (resolve, reject) => {
+      if ((this[$canvas] as any).msToBlob) {
+        // NOTE: msToBlob only returns image/png
+        // so ensure mimeType is not specified (defaults to image/png)
+        // or is image/png, otherwise fallback to using toDataURL on IE.
+        if (!mimeType || mimeType === 'image/png') {
+          return resolve((this[$canvas] as any).msToBlob());
+        }
+      }
+
       if (!this[$canvas].toBlob) {
-         return resolve(await dataUrlToBlob(this[$canvas].toDataURL(mimeType)));
+        return resolve(await dataUrlToBlob(this[$canvas].toDataURL(mimeType, qualityArgument)));
       }
 
       this[$canvas].toBlob((blob) => {

--- a/src/model-viewer-base.ts
+++ b/src/model-viewer-base.ts
@@ -24,7 +24,7 @@ import {ModelScene} from './three-components/ModelScene.js';
 import {ContextLostEvent, Renderer} from './three-components/Renderer.js';
 import {debounce, deserializeUrl, isDebugMode, resolveDpr} from './utilities.js';
 import {ProgressTracker} from './utilities/progress-tracker.js';
-import {dataURLToBlob} from './utilities/data-conversion.js';
+import {dataUrlToBlob} from './utilities/data-conversion.js';
 
 let renderer = new Renderer({debug: isDebugMode()});
 
@@ -329,7 +329,7 @@ export default class ModelViewerElementBase extends UpdatingElement {
   async toBlob(mimeType?: string, qualityArgument?: number): Promise<Blob> {
     return new Promise((resolve, reject) => {
       if (!this[$canvas].toBlob) {
-         return resolve(dataURLToBlob(this[$canvas].toDataURL(mimeType)));
+         return resolve(dataUrlToBlob(this[$canvas].toDataURL(mimeType)));
       }
 
       this[$canvas].toBlob((blob) => {

--- a/src/model-viewer-base.ts
+++ b/src/model-viewer-base.ts
@@ -24,6 +24,7 @@ import {ModelScene} from './three-components/ModelScene.js';
 import {ContextLostEvent, Renderer} from './three-components/Renderer.js';
 import {debounce, deserializeUrl, isDebugMode, resolveDpr} from './utilities.js';
 import {ProgressTracker} from './utilities/progress-tracker.js';
+import {dataURLToBlob} from './utilities/data-conversion.js';
 
 let renderer = new Renderer({debug: isDebugMode()});
 
@@ -323,6 +324,22 @@ export default class ModelViewerElementBase extends UpdatingElement {
 
   toDataURL(type?: string, encoderOptions?: number): string {
     return this[$canvas].toDataURL(type, encoderOptions);
+  }
+
+  async toBlob(mimeType?: string, qualityArgument?: number): Promise<Blob> {
+    return new Promise((resolve, reject) => {
+      if (!this[$canvas].toBlob) {
+         return resolve(dataURLToBlob(this[$canvas].toDataURL(mimeType)));
+      }
+
+      this[$canvas].toBlob((blob) => {
+        if (!blob) {
+          return reject(new Error('Unable to retrieve canvas blob'));
+        }
+
+        resolve(blob);
+      }, mimeType, qualityArgument);
+    });
   }
 
   get[$ariaLabel]() {

--- a/src/model-viewer-base.ts
+++ b/src/model-viewer-base.ts
@@ -327,9 +327,9 @@ export default class ModelViewerElementBase extends UpdatingElement {
   }
 
   async toBlob(mimeType?: string, qualityArgument?: number): Promise<Blob> {
-    return new Promise((resolve, reject) => {
+    return new Promise(async (resolve, reject) => {
       if (!this[$canvas].toBlob) {
-         return resolve(dataUrlToBlob(this[$canvas].toDataURL(mimeType)));
+         return resolve(await dataUrlToBlob(this[$canvas].toDataURL(mimeType)));
       }
 
       this[$canvas].toBlob((blob) => {

--- a/src/test/model-viewer-base-spec.ts
+++ b/src/test/model-viewer-base-spec.ts
@@ -17,7 +17,7 @@ import {IS_IE11} from '../constants.js';
 import ModelViewerElementBase, {$canvas, $renderer, $scene} from '../model-viewer-base.js';
 import {Constructor} from '../utilities.js';
 
-import {assetPath, timePasses, until, waitForEvent} from './helpers.js';
+import {assetPath, spy, timePasses, until, waitForEvent} from './helpers.js';
 import {BasicSpecTemplate} from './templates.js';
 
 
@@ -209,7 +209,7 @@ suite('ModelViewerElementBase', () => {
         });
       });
 
-      suite('toBlob', () => {
+      suite.only('toBlob', () => {
         test('produces a blob', async () => {
           const blob = await element.toBlob();
           expect(blob).to.not.be.null;
@@ -229,9 +229,23 @@ suite('ModelViewerElementBase', () => {
 
         test('uses fallbacks on unsupported browsers', async () => {
           // Emulate unsupported browser
+          const restoreCanvasToBlob = spy(HTMLCanvasElement.prototype, 'toBlob', { value: undefined });
 
           const blob = await element.toBlob();
           expect(blob).to.not.be.null;
+
+          restoreCanvasToBlob();
+        });
+
+        test('blobs on supported and unsupported browsers are equivalent', async () => {
+          const restoreCanvasToBlob = spy(HTMLCanvasElement.prototype, 'toBlob', { value: undefined });
+          const unsupportedBrowserBlob = await element.toBlob();
+
+          restoreCanvasToBlob();
+
+          const supportedBrowserBlob = await element.toBlob();
+
+          expect(unsupportedBrowserBlob).to.eql(supportedBrowserBlob)
         });
       });
     });

--- a/src/test/model-viewer-base-spec.ts
+++ b/src/test/model-viewer-base-spec.ts
@@ -245,7 +245,13 @@ suite('ModelViewerElementBase', () => {
 
           const supportedBrowserBlob = await element.toBlob();
 
-          expect(unsupportedBrowserBlob).to.eql(supportedBrowserBlob)
+          const supportedBrowserResponse = new Response(supportedBrowserBlob);
+          const unsupportedBrowserResponse = new Response(unsupportedBrowserBlob);
+
+          const supportedBrowserArrayBuffer = await supportedBrowserResponse.arrayBuffer();
+          const unsupportedBrowserArrayBuffer = await unsupportedBrowserResponse.arrayBuffer();
+
+          expect(unsupportedBrowserArrayBuffer).to.eql(supportedBrowserArrayBuffer);
         });
       });
     });

--- a/src/test/model-viewer-base-spec.ts
+++ b/src/test/model-viewer-base-spec.ts
@@ -243,6 +243,11 @@ suite('ModelViewerElementBase', () => {
         });
 
         test('blobs on supported and unsupported browsers are equivalent', async () => {
+          // Skip test on IE11 since it doesn't have Response to fetch arrayBuffer
+          if (IS_IE11) {
+            return;
+          }
+
           let restoreCanvasToBlob = () => {};
           try {
             restoreCanvasToBlob = spy(HTMLCanvasElement.prototype, 'toBlob', { value: undefined });
@@ -256,6 +261,8 @@ suite('ModelViewerElementBase', () => {
 
           const supportedBrowserBlob = await element.toBlob();
 
+          // Blob.prototype.arrayBuffer is not available in Edge / Safari
+          // Using Response to get arrayBuffer instead
           const supportedBrowserResponse = new Response(supportedBrowserBlob);
           const unsupportedBrowserResponse = new Response(unsupportedBrowserBlob);
 

--- a/src/test/model-viewer-base-spec.ts
+++ b/src/test/model-viewer-base-spec.ts
@@ -229,7 +229,12 @@ suite('ModelViewerElementBase', () => {
 
         test('uses fallbacks on unsupported browsers', async () => {
           // Emulate unsupported browser
-          const restoreCanvasToBlob = spy(HTMLCanvasElement.prototype, 'toBlob', { value: undefined });
+          let restoreCanvasToBlob = () => {};
+          try {
+            restoreCanvasToBlob = spy(HTMLCanvasElement.prototype, 'toBlob', { value: undefined });
+          } catch (error) {
+            // Ignored...
+          }
 
           const blob = await element.toBlob();
           expect(blob).to.not.be.null;
@@ -238,7 +243,13 @@ suite('ModelViewerElementBase', () => {
         });
 
         test('blobs on supported and unsupported browsers are equivalent', async () => {
-          const restoreCanvasToBlob = spy(HTMLCanvasElement.prototype, 'toBlob', { value: undefined });
+          let restoreCanvasToBlob = () => {};
+          try {
+            restoreCanvasToBlob = spy(HTMLCanvasElement.prototype, 'toBlob', { value: undefined });
+          } catch (error) {
+            // Ignored...
+          }
+
           const unsupportedBrowserBlob = await element.toBlob();
 
           restoreCanvasToBlob();

--- a/src/test/model-viewer-base-spec.ts
+++ b/src/test/model-viewer-base-spec.ts
@@ -209,7 +209,7 @@ suite('ModelViewerElementBase', () => {
         });
       });
 
-      suite.only('toBlob', () => {
+      suite('toBlob', () => {
         test('produces a blob', async () => {
           const blob = await element.toBlob();
           expect(blob).to.not.be.null;

--- a/src/test/model-viewer-base-spec.ts
+++ b/src/test/model-viewer-base-spec.ts
@@ -208,6 +208,32 @@ suite('ModelViewerElementBase', () => {
           expect(dataUrlMatcher.test(element.toDataURL())).to.be.true;
         });
       });
+
+      suite('toBlob', () => {
+        test('produces a blob', async () => {
+          const blob = await element.toBlob();
+          expect(blob).to.not.be.null;
+        });
+
+        test('can convert blob to object URL', async () => {
+          const blob = await element.toBlob();
+          const objectUrl = URL.createObjectURL(blob);
+          const objectUrlMatcher = /^blob\:https?:\//;
+          expect(objectUrlMatcher.test(objectUrl)).to.be.true;
+        });
+
+        test('has size', async () => {
+          const blob = await element.toBlob();
+          expect(blob.size).to.be.greaterThan(0);
+        });
+
+        test('uses fallbacks on unsupported browsers', async () => {
+          // Emulate unsupported browser
+
+          const blob = await element.toBlob();
+          expect(blob).to.not.be.null;
+        });
+      });
     });
 
     suite('orchestrates rendering', () => {

--- a/src/test/model-viewer-base-spec.ts
+++ b/src/test/model-viewer-base-spec.ts
@@ -218,7 +218,7 @@ suite('ModelViewerElementBase', () => {
         test('can convert blob to object URL', async () => {
           const blob = await element.toBlob();
           const objectUrl = URL.createObjectURL(blob);
-          const objectUrlMatcher = /^blob\:https?:\//;
+          const objectUrlMatcher = /^blob\:/;
           expect(objectUrlMatcher.test(objectUrl)).to.be.true;
         });
 

--- a/src/utilities/data-conversion.ts
+++ b/src/utilities/data-conversion.ts
@@ -1,0 +1,28 @@
+export function dataURLToBlob(base64DataURL: string) {
+  const sliceSize = 512;
+  const typeMatch = base64DataURL.match(/data:(.*);/);
+
+  if (!typeMatch) {
+    throw new Error(`${base64DataURL} is not a valid data URL`);
+  }
+
+  const type = typeMatch[1];
+  const base64 = base64DataURL.replace(/data:image\/\w+;base64,/, '');
+
+  const byteCharacters = atob(base64);
+  const byteArrays = [];
+
+  for (let offset = 0; offset < byteCharacters.length; offset += sliceSize) {
+    const slice = byteCharacters.slice(offset, offset + sliceSize);
+
+    const byteNumbers = new Array(slice.length);
+    for (let i = 0; i < slice.length; i++) {
+      byteNumbers[i] = slice.charCodeAt(i);
+    }
+
+    const byteArray = new Uint8Array(byteNumbers);
+    byteArrays.push(byteArray);
+  }
+
+  return new Blob(byteArrays, {type});
+}

--- a/src/utilities/data-conversion.ts
+++ b/src/utilities/data-conversion.ts
@@ -18,31 +18,33 @@
  * into a Blob of the same contents.
  */
 export const dataUrlToBlob =
-  (base64DataUrl: string) : Blob => {
-    const sliceSize = 512;
-    const typeMatch = base64DataUrl.match(/data:(.*);/);
+  async (base64DataUrl: string) : Promise<Blob> => {
+    return new Promise((resolve, reject) => {
+      const sliceSize = 512;
+      const typeMatch = base64DataUrl.match(/data:(.*);/);
 
-    if (!typeMatch) {
-      throw new Error(`${base64DataUrl} is not a valid data Url`);
-    }
-
-    const type = typeMatch[1];
-    const base64 = base64DataUrl.replace(/data:image\/\w+;base64,/, '');
-
-    const byteCharacters = atob(base64);
-    const byteArrays = [];
-
-    for (let offset = 0; offset < byteCharacters.length; offset += sliceSize) {
-      const slice = byteCharacters.slice(offset, offset + sliceSize);
-
-      const byteNumbers = new Array(slice.length);
-      for (let i = 0; i < slice.length; i++) {
-        byteNumbers[i] = slice.charCodeAt(i);
+      if (!typeMatch) {
+        return reject(new Error(`${base64DataUrl} is not a valid data Url`));
       }
 
-      const byteArray = new Uint8Array(byteNumbers);
-      byteArrays.push(byteArray);
-    }
+      const type = typeMatch[1];
+      const base64 = base64DataUrl.replace(/data:image\/\w+;base64,/, '');
 
-    return new Blob(byteArrays, {type});
+      const byteCharacters = atob(base64);
+      const byteArrays = [];
+
+      for (let offset = 0; offset < byteCharacters.length; offset += sliceSize) {
+        const slice = byteCharacters.slice(offset, offset + sliceSize);
+
+        const byteNumbers = new Array(slice.length);
+        for (let i = 0; i < slice.length; i++) {
+          byteNumbers[i] = slice.charCodeAt(i);
+        }
+
+        const byteArray = new Uint8Array(byteNumbers);
+        byteArrays.push(byteArray);
+      }
+
+      resolve(new Blob(byteArrays, {type}));
+    });
   };

--- a/src/utilities/data-conversion.ts
+++ b/src/utilities/data-conversion.ts
@@ -1,28 +1,48 @@
-export function dataUrlToBlob(base64DataUrl: string) {
-  const sliceSize = 512;
-  const typeMatch = base64DataUrl.match(/data:(.*);/);
+/* @license
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-  if (!typeMatch) {
-    throw new Error(`${base64DataUrl} is not a valid data Url`);
-  }
+/**
+ * Converts a base64 string which represents a data url
+ * into a Blob of the same contents.
+ */
+export const dataUrlToBlob =
+  (base64DataUrl: string) : Blob => {
+    const sliceSize = 512;
+    const typeMatch = base64DataUrl.match(/data:(.*);/);
 
-  const type = typeMatch[1];
-  const base64 = base64DataUrl.replace(/data:image\/\w+;base64,/, '');
-
-  const byteCharacters = atob(base64);
-  const byteArrays = [];
-
-  for (let offset = 0; offset < byteCharacters.length; offset += sliceSize) {
-    const slice = byteCharacters.slice(offset, offset + sliceSize);
-
-    const byteNumbers = new Array(slice.length);
-    for (let i = 0; i < slice.length; i++) {
-      byteNumbers[i] = slice.charCodeAt(i);
+    if (!typeMatch) {
+      throw new Error(`${base64DataUrl} is not a valid data Url`);
     }
 
-    const byteArray = new Uint8Array(byteNumbers);
-    byteArrays.push(byteArray);
-  }
+    const type = typeMatch[1];
+    const base64 = base64DataUrl.replace(/data:image\/\w+;base64,/, '');
 
-  return new Blob(byteArrays, {type});
-}
+    const byteCharacters = atob(base64);
+    const byteArrays = [];
+
+    for (let offset = 0; offset < byteCharacters.length; offset += sliceSize) {
+      const slice = byteCharacters.slice(offset, offset + sliceSize);
+
+      const byteNumbers = new Array(slice.length);
+      for (let i = 0; i < slice.length; i++) {
+        byteNumbers[i] = slice.charCodeAt(i);
+      }
+
+      const byteArray = new Uint8Array(byteNumbers);
+      byteArrays.push(byteArray);
+    }
+
+    return new Blob(byteArrays, {type});
+  };

--- a/src/utilities/data-conversion.ts
+++ b/src/utilities/data-conversion.ts
@@ -1,13 +1,13 @@
-export function dataURLToBlob(base64DataURL: string) {
+export function dataUrlToBlob(base64DataUrl: string) {
   const sliceSize = 512;
-  const typeMatch = base64DataURL.match(/data:(.*);/);
+  const typeMatch = base64DataUrl.match(/data:(.*);/);
 
   if (!typeMatch) {
-    throw new Error(`${base64DataURL} is not a valid data URL`);
+    throw new Error(`${base64DataUrl} is not a valid data Url`);
   }
 
   const type = typeMatch[1];
-  const base64 = base64DataURL.replace(/data:image\/\w+;base64,/, '');
+  const base64 = base64DataUrl.replace(/data:image\/\w+;base64,/, '');
 
   const byteCharacters = atob(base64);
   const byteArrays = [];


### PR DESCRIPTION
### Reference Issue
Fixes #858 

Adds `toBlob` to the `ModelViewerElementBase`.

https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob

### General Approach
The general approach was to delegate the `toBlob` on the model-viewer to the canvas. Instead of using callbacks like `HTMLCanvasElement` does with `toBlob`, I used promises so that it is possible to use `async/await` syntax. We can change this back if needed.