### PR TITLE
Add CNAME pointing at modelviewer.dev to the root

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+modelviewer.dev


### PR DESCRIPTION
Per the docs, this needs to live in the root of our deployed source.

If we don't want to include the actual file here we could have it as a step in the deploy, but that seemed more complex.