### PR TITLE
Declare interfaces to prevent renaming

### DIFF
--- a/src/features/animation.ts
+++ b/src/features/animation.ts
@@ -23,7 +23,7 @@ const MILLISECONDS_PER_SECOND = 1000.0
 const $changeAnimation = Symbol('changeAnimation');
 const $paused = Symbol('paused');
 
-export interface AnimationInterface {
+export declare interface AnimationInterface {
   autoplay: boolean;
   animationName: string|void;
   animationCrossfadeDuration: number;

--- a/src/features/ar.ts
+++ b/src/features/ar.ts
@@ -135,7 +135,7 @@ const $onExitFullscreenButtonClick = Symbol('onExitFullscreenButtonClick');
 const $fullscreenchangeHandler = Symbol('fullscreenHandler');
 const $onFullscreenchange = Symbol('onFullscreen');
 
-export interface ARInterface {
+export declare interface ARInterface {
   ar: boolean;
   unstableWebxr: boolean;
   iosSrc: string|null;

--- a/src/features/controls.ts
+++ b/src/features/controls.ts
@@ -170,7 +170,7 @@ const $syncCameraOrbit = Symbol('syncCameraOrbit');
 const $syncFieldOfView = Symbol('syncFieldOfView');
 const $syncCameraTarget = Symbol('syncCameraTarget');
 
-export interface ControlsInterface {
+export declare interface ControlsInterface {
   cameraControls: boolean;
   cameraOrbit: string;
   cameraTarget: string;

--- a/src/features/environment.ts
+++ b/src/features/environment.ts
@@ -29,11 +29,12 @@ const $applyEnvironmentMap = Symbol('applyEnvironmentMap');
 const $updateEnvironment = Symbol('updateEnvironment');
 const $cancelEnvironmentUpdate = Symbol('cancelEnvironmentUpdate');
 
-export interface EnvironmentInterface {
+export declare interface EnvironmentInterface {
   environmentImage: string|null;
   backgroundImage: string|null;
   backgroundColor: string;
   shadowIntensity: number;
+  shadowSoftness: number;
   exposure: number;
 }
 

--- a/src/features/loading.ts
+++ b/src/features/loading.ts
@@ -76,7 +76,7 @@ const $onClick = Symbol('onClick');
 const $onKeydown = Symbol('onKeydown');
 const $onProgress = Symbol('onProgress');
 
-export interface LoadingInterface {
+export declare interface LoadingInterface {
   poster: string|null;
   reveal: RevealAttributeValue;
   preload: boolean;

--- a/src/features/magic-leap.ts
+++ b/src/features/magic-leap.ts
@@ -34,7 +34,7 @@ const DEFAULT_HOLOGRAM_INLINE_SCALE = 0.65;
 // should work:
 const DEFAULT_HOLOGRAM_Z_OFFSET = '500px';
 
-export interface MagicLeapInterface {
+export declare interface MagicLeapInterface {
   magicLeap: boolean;
 }
 

--- a/src/features/staging.ts
+++ b/src/features/staging.ts
@@ -31,8 +31,11 @@ const $autoRotateTimer = Symbol('autoRotateTimer');
 const $cameraChangeHandler = Symbol('cameraChangeHandler');
 const $onCameraChange = Symbol('onCameraChange');
 
-export interface StagingInterface {
+export declare interface StagingInterface {
   autoRotate: boolean;
+  autoRotateDelay: number;
+  readonly turntableRotation: number;
+  resetTurntableRotation(): void;
 }
 
 export const StagingMixin = <T extends Constructor<ModelViewerElementBase>>(

--- a/src/model-viewer-base.ts
+++ b/src/model-viewer-base.ts
@@ -23,8 +23,8 @@ import {$evictionPolicy, CachingGLTFLoader} from './three-components/CachingGLTF
 import {ModelScene} from './three-components/ModelScene.js';
 import {ContextLostEvent, Renderer} from './three-components/Renderer.js';
 import {debounce, deserializeUrl, isDebugMode, resolveDpr} from './utilities.js';
-import {ProgressTracker} from './utilities/progress-tracker.js';
 import {dataUrlToBlob} from './utilities/data-conversion.js';
+import {ProgressTracker} from './utilities/progress-tracker.js';
 
 let renderer = new Renderer({debug: isDebugMode()});
 
@@ -88,10 +88,12 @@ export default class ModelViewerElementBase extends UpdatingElement {
     return this[$template];
   }
 
+  /** @export */
   static set modelCacheSize(value: number) {
     CachingGLTFLoader[$evictionPolicy].evictionThreshold = value;
   }
 
+  /** @export */
   static get modelCacheSize(): number {
     return CachingGLTFLoader[$evictionPolicy].evictionThreshold
   }
@@ -124,6 +126,7 @@ export default class ModelViewerElementBase extends UpdatingElement {
   protected[$contextLostHandler] = (event: ContextLostEvent) =>
       this[$onContextLost](event);
 
+  /** @export */
   get loaded() {
     return this[$getLoaded]();
   }
@@ -132,6 +135,7 @@ export default class ModelViewerElementBase extends UpdatingElement {
     return renderer;
   }
 
+  /** @export */
   get modelIsVisible() {
     return this[$getModelIsVisible]();
   }
@@ -322,10 +326,12 @@ export default class ModelViewerElementBase extends UpdatingElement {
     }
   }
 
+  /** @export */
   toDataURL(type?: string, encoderOptions?: number): string {
     return this[$canvas].toDataURL(type, encoderOptions);
   }
 
+  /** @export */
   async toBlob(mimeType?: string, qualityArgument?: number): Promise<Blob> {
     return new Promise(async (resolve, reject) => {
       if ((this[$canvas] as any).msToBlob) {
@@ -338,7 +344,8 @@ export default class ModelViewerElementBase extends UpdatingElement {
       }
 
       if (!this[$canvas].toBlob) {
-        return resolve(await dataUrlToBlob(this[$canvas].toDataURL(mimeType, qualityArgument)));
+        return resolve(await dataUrlToBlob(
+            this[$canvas].toDataURL(mimeType, qualityArgument)));
       }
 
       this[$canvas].toBlob((blob) => {


### PR DESCRIPTION
This change "declares" our mixin interfaces to ensure that our public custom element API isn't renamed by closure compiler. Some of our interfaces were incomplete and have been updated. Also, `@export` annotations have been added to the public API of the base class, as this is the most succinct way I could come up with to prevent that part of the public API from being renamed.

Note: `@property`-decorated API automatically gets decorated with `@export` for our purposes thanks to compiler magic.  