### PR TITLE
turned off glTF light shadows

### DIFF
--- a/src/three-components/CachingGLTFLoader.ts
+++ b/src/three-components/CachingGLTFLoader.ts
@@ -142,7 +142,6 @@ export class CachingGLTFLoader {
 
     if (gltf.scene != null) {
       gltf.scene.traverse((node: Object3D) => {
-        node.castShadow = true;
         // Three.js seems to cull some animated models incorrectly. Since we
         // expect to view our whole scene anyway, we turn off the frustum
         // culling optimization here.
@@ -156,6 +155,7 @@ export class CachingGLTFLoader {
         if (!(node as Mesh).isMesh) {
           return;
         }
+        node.castShadow = true;
         const mesh = node as Mesh;
         const materials =
             Array.isArray(mesh.material) ? mesh.material : [mesh.material];


### PR DESCRIPTION
Fixes #903 

Only meshes should cast shadows, not lights (our shadow light is added later). I believe this means when lights are included in the glTF they are still illuminating the model (in addition to our environment light). I assume this is expected behavior, but if anyone feels otherwise, this is the place to change it.