### PR TITLE
Fix shader compilation on some low-end phones

### DIFF
--- a/src/three-components/shader-chunk/encodings_pars_fragment.glsl.ts
+++ b/src/three-components/shader-chunk/encodings_pars_fragment.glsl.ts
@@ -57,7 +57,11 @@ vec4 RGBDToLinear( in vec4 value, in float maxRange ) {
 vec4 LinearToRGBD( in vec4 value, in float maxRange ) {
 	float maxRGB = max( value.r, max( value.g, value.b ) );
 	float D = max( maxRange / maxRGB, 1.0 );
-	D = min( floor( D ) / 255.0, 1.0 );
+	// NOTE: The implementation with min causes the shader to not compile on
+	// a common Alcatel A502DL in Chrome 78/Android 8.1. Some research suggests 
+	// that the chipset is Mediatek MT6739 w/ IMG PowerVR GE8100 GPU.
+	// D = min(floor(D)/255.0, 1.0);
+	D = clamp(floor(D)/255.0, 0.0, 1.0);
 	return vec4( value.rgb * ( D * ( 255.0 / maxRange ) ), D );
 }
 


### PR DESCRIPTION
Fix shader compilation error on a particular low-end device found at Target.

Follow-on work from this will include https://github.com/GoogleWebComponents/model-viewer/issues/921