### PR TITLE
Fix max-fov race condition

### DIFF
--- a/src/features/controls.ts
+++ b/src/features/controls.ts
@@ -101,9 +101,13 @@ const minFieldOfViewIntrinsics = {
   keywords: {auto: [null]}
 };
 
-const maxFieldOfViewIntrinsics = {
-  basis: [degreesToRadians(numberNode(45, 'deg')) as NumberNode<'rad'>],
-  keywords: {auto: [null]}
+const maxFieldOfViewIntrinsics = (element: ModelViewerElementBase) => {
+  const scene = element[$scene];
+
+  return {
+    basis: [degreesToRadians(numberNode(45, 'deg')) as NumberNode<'rad'>],
+    keywords: {auto: [numberNode(scene.framedFieldOfView, 'rad')]}
+  };
 };
 
 export const cameraOrbitIntrinsics = (() => {
@@ -586,9 +590,12 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
       const newFramedFieldOfView = this[$scene].framedFieldOfView;
       const zoom = controls.getFieldOfView() / oldFramedFieldOfView;
       this[$zoomAdjustedFieldOfView] = newFramedFieldOfView * zoom;
-      controls.applyOptions({maximumFieldOfView: newFramedFieldOfView});
+
       controls.updateAspect(this[$scene].aspect);
+
+      this.requestUpdate('maxFieldOfView', this.maxFieldOfView);
       this.requestUpdate('fieldOfView', this.fieldOfView);
+
       controls.jumpToGoal();
     }
 
@@ -598,8 +605,8 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
       const controls = this[$controls];
       const {framedFieldOfView} = this[$scene];
       this[$zoomAdjustedFieldOfView] = framedFieldOfView;
-      controls.applyOptions({maximumFieldOfView: framedFieldOfView});
 
+      this.requestUpdate('maxFieldOfView', this.maxFieldOfView);
       this.requestUpdate('fieldOfView', this.fieldOfView);
       this.requestUpdate('cameraOrbit', this.cameraOrbit);
       this.requestUpdate('cameraTarget', this.cameraTarget);

--- a/src/test/features/controls-spec.ts
+++ b/src/test/features/controls-spec.ts
@@ -303,6 +303,42 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
           const fov = Math.round(element.getFieldOfView());
           expect(`${fov}deg`).to.equal(element.minFieldOfView);
         });
+
+        suite('when configured before model loads', () => {
+          let initiallyUnloadedElement: ModelViewerElementBase&
+              ControlsInterface;
+          let controls: SmoothControls;
+
+          setup(() => {
+            initiallyUnloadedElement = new ModelViewerElement();
+            controls =
+                (initiallyUnloadedElement as any)[$controls] as SmoothControls;
+          });
+
+          teardown(() => {
+            if (initiallyUnloadedElement.parentNode != null) {
+              initiallyUnloadedElement.parentNode.removeChild(
+                  initiallyUnloadedElement);
+            }
+          });
+
+          test('respects user-configured maxFieldOfView', async () => {
+            document.body.appendChild(initiallyUnloadedElement);
+
+            initiallyUnloadedElement.maxFieldOfView = '100deg';
+            initiallyUnloadedElement.src = ASTRONAUT_GLB_PATH;
+
+            await waitForEvent(initiallyUnloadedElement, 'load');
+
+            initiallyUnloadedElement.fieldOfView = '100deg';
+
+            await timePasses();
+            settleControls(controls);
+
+            expect(initiallyUnloadedElement.getFieldOfView())
+                .to.be.closeTo(100, 0.001);
+          });
+        });
       });
     });
 


### PR DESCRIPTION
This change fixes a small bug where a race condition could override a user-configured `max-field-of-view` if the configuration was made before the model is loaded, or before an impending resize.

@elalish I'm not sure if the fix appropriate conveys the semantics of the original implementation (particularly adjustments for zoom). Your feedback there would be very welcome 🙇 