### PR TITLE
Units are hard

### DIFF
--- a/src/features/controls.ts
+++ b/src/features/controls.ts
@@ -106,7 +106,7 @@ const maxFieldOfViewIntrinsics = (element: ModelViewerElementBase) => {
 
   return {
     basis: [degreesToRadians(numberNode(45, 'deg')) as NumberNode<'rad'>],
-    keywords: {auto: [numberNode(scene.framedFieldOfView, 'rad')]}
+    keywords: {auto: [numberNode(scene.framedFieldOfView, 'deg')]}
   };
 };
 

--- a/src/features/controls.ts
+++ b/src/features/controls.ts
@@ -263,28 +263,32 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
       intrinsics: minCameraOrbitIntrinsics,
       updateHandler: $syncMinCameraOrbit
     })
-    @property({type: String, attribute: 'min-camera-orbit'})
+    @property(
+        {type: String, attribute: 'min-camera-orbit', hasChanged: () => true})
     minCameraOrbit: string = 'auto';
 
     @style({
       intrinsics: maxCameraOrbitIntrinsics,
       updateHandler: $syncMaxCameraOrbit
     })
-    @property({type: String, attribute: 'max-camera-orbit'})
+    @property(
+        {type: String, attribute: 'max-camera-orbit', hasChanged: () => true})
     maxCameraOrbit: string = 'auto';
 
     @style({
       intrinsics: minFieldOfViewIntrinsics,
       updateHandler: $syncMinFieldOfView
     })
-    @property({type: String, attribute: 'min-field-of-view'})
+    @property(
+        {type: String, attribute: 'min-field-of-view', hasChanged: () => true})
     minFieldOfView: string = 'auto';
 
     @style({
       intrinsics: maxFieldOfViewIntrinsics,
       updateHandler: $syncMaxFieldOfView
     })
-    @property({type: String, attribute: 'max-field-of-view'})
+    @property(
+        {type: String, attribute: 'max-field-of-view', hasChanged: () => true})
     maxFieldOfView: string = 'auto';
 
     @property({type: Number, attribute: 'interaction-prompt-threshold'})

--- a/src/test/features/controls-spec.ts
+++ b/src/test/features/controls-spec.ts
@@ -274,6 +274,16 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
           settleControls(controls);
         });
 
+        test('defaults maxFieldOfView to ideal value', async () => {
+          const scene = element[$scene];
+
+          element.fieldOfView = '180deg';
+          await timePasses();
+          settleControls(controls);
+          expect(element.getFieldOfView())
+              .to.be.closeTo(scene.framedFieldOfView, 0.001);
+        });
+
         test('jumps to maxCameraOrbit when outside', async () => {
           element.maxCameraOrbit = `-2rad 1rad 1m`;
           await timePasses();


### PR DESCRIPTION
Messed up a unit in #932 . This is the fix.

In fixing this, we also uncovered a bug that was causing another test to flake. Any `@property` member that also uses `@style` needs to have `hasChanged: () => true` configured for their `@property` decorator.