### PR TITLE
Fix double load and camera jank

### DIFF
--- a/src/features/controls.ts
+++ b/src/features/controls.ts
@@ -595,14 +595,12 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
 
       this.requestUpdate('maxFieldOfView', this.maxFieldOfView);
       this.requestUpdate('fieldOfView', this.fieldOfView);
-
-      controls.jumpToGoal();
+      this.jumpCameraToGoal();
     }
 
     [$onModelLoad](event: any) {
       super[$onModelLoad](event);
 
-      const controls = this[$controls];
       const {framedFieldOfView} = this[$scene];
       this[$zoomAdjustedFieldOfView] = framedFieldOfView;
 
@@ -610,7 +608,7 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
       this.requestUpdate('fieldOfView', this.fieldOfView);
       this.requestUpdate('cameraOrbit', this.cameraOrbit);
       this.requestUpdate('cameraTarget', this.cameraTarget);
-      controls.jumpToGoal();
+      this.jumpCameraToGoal();
     }
 
     [$onFocus]() {

--- a/src/features/loading.ts
+++ b/src/features/loading.ts
@@ -327,10 +327,7 @@ export const LoadingMixin = <T extends Constructor<ModelViewerElementBase>>(
       }
 
       if (this[$modelIsReadyForReveal]) {
-        if (!this[$sourceUpdated]) {
-          this[$updateSource]();
-          this[$hidePoster]();
-        }
+        this[$updateSource]();
       } else {
         this[$showPoster]();
       }
@@ -397,9 +394,10 @@ export const LoadingMixin = <T extends Constructor<ModelViewerElementBase>>(
     }
 
     async[$updateSource]() {
-      if (this[$modelIsReadyForReveal]) {
+      if (this[$modelIsReadyForReveal] && !this[$sourceUpdated]) {
         this[$sourceUpdated] = true;
         await super[$updateSource]();
+        this[$hidePoster]();
       }
     }
   }

--- a/src/features/loading.ts
+++ b/src/features/loading.ts
@@ -233,9 +233,12 @@ export const LoadingMixin = <T extends Constructor<ModelViewerElementBase>>(
       }
 
       if (changedProperties.has('src')) {
+        if (!this[$modelIsReadyForReveal]) {
+          this[$lastReportedProgress] = 0;
+        }
+
         this[$posterDismissalSource] = null;
         this[$preloadAttempted] = false;
-        this[$lastReportedProgress] = 0;
         this[$sourceUpdated] = false;
       }
 
@@ -327,7 +330,7 @@ export const LoadingMixin = <T extends Constructor<ModelViewerElementBase>>(
       }
 
       if (this[$modelIsReadyForReveal]) {
-        this[$updateSource]();
+        await this[$updateSource]();
       } else {
         this[$showPoster]();
       }

--- a/src/model-viewer-base.ts
+++ b/src/model-viewer-base.ts
@@ -308,6 +308,7 @@ export default class ModelViewerElementBase extends UpdatingElement {
         (this.src == null || this.src !== this[$scene].model.url)) {
       this[$loaded] = false;
       this[$loadedTime] = 0;
+      this[$updateSource]();
       (async () => {
         const updateSourceProgress = this[$progressTracker].beginActivity();
         await this[$updateSource](
@@ -457,16 +458,19 @@ export default class ModelViewerElementBase extends UpdatingElement {
    * sets the views to use the new model based off of the `preload`
    * attribute.
    */
-  async[$updateSource](
-      progressCallback: (progress: number) => void = () => {}) {
+  async[$updateSource]() {
+    const updateSourceProgress = this[$progressTracker].beginActivity();
     const source = this.src;
 
     try {
       this[$canvas].classList.add('show');
-      await this[$scene].setModelSource(source, progressCallback);
+      await this[$scene].setModelSource(
+          source, (progress: number) => updateSourceProgress(progress * 0.9));
     } catch (error) {
       this[$canvas].classList.remove('show');
       this.dispatchEvent(new CustomEvent('error', {detail: error}));
+    } finally {
+      updateSourceProgress(1.0);
     }
   }
 }

--- a/src/model-viewer-base.ts
+++ b/src/model-viewer-base.ts
@@ -309,12 +309,6 @@ export default class ModelViewerElementBase extends UpdatingElement {
       this[$loaded] = false;
       this[$loadedTime] = 0;
       this[$updateSource]();
-      (async () => {
-        const updateSourceProgress = this[$progressTracker].beginActivity();
-        await this[$updateSource](
-            (progress: number) => updateSourceProgress(progress * 0.9));
-        updateSourceProgress(1.0);
-      })();
     }
 
     if (changedProperties.has('alt')) {

--- a/src/test/features/loading-spec.ts
+++ b/src/test/features/loading-spec.ts
@@ -102,6 +102,41 @@ suite('ModelViewerElementBase with LoadingMixin', () => {
         expect(preloadDispatched).to.be.false;
       });
 
+      suite('load', () => {
+        suite('when a model src changes after loading', () => {
+          setup(async () => {
+            element.src = ASTRONAUT_GLB_PATH;
+            await waitForEvent(element, 'load');
+          });
+
+          test('only dispatches load once per src change', async () => {
+            let loadCount = 0;
+            const onLoad = () => {
+              loadCount++;
+            };
+
+            element.addEventListener('load', onLoad);
+
+            try {
+              element.src = HORSE_GLB_PATH;
+
+              await waitForEvent(element, 'load');
+
+              element.src = ASTRONAUT_GLB_PATH;
+
+              await waitForEvent(element, 'load');
+
+              // Give any late-dispatching events a chance to dispatch
+              await timePasses(300);
+
+              expect(loadCount).to.be.equal(2);
+            } finally {
+              element.removeEventListener('load', onLoad);
+            }
+          });
+        });
+      });
+
       suite('preload', () => {
         suite('src changes quickly', () => {
           test(


### PR DESCRIPTION
The core bug here is that `LoadingMixin` has very complex state and is rather difficult to reason about. It shares implementation details with the base class because it pertains to the only thing the base class does: load models given a `src`. `LoadingMixin` and related implementation in the base class deserve some refactoring to clean this up, but in the mean time I was able to do some light patching to ensure the state transitions work as intended.

This change also fixed some camera jank we had identified when resizing.