### PR TITLE
Fixed shadow when updating src

### DIFF
--- a/examples/model-formats.html
+++ b/examples/model-formats.html
@@ -131,7 +131,7 @@
         </div>
         <example-snippet stamp-to="demo-container-5" highlight-as="html">
           <template>
-<model-viewer id="toggle-model" src="assets/shishkebab.glb" alt="A 3D model of a shishkebab" background-color="#222" camera-controls auto-rotate></model-viewer>
+<model-viewer id="toggle-model" src="assets/shishkebab.glb" alt="A 3D model of a shishkebab" background-color="#eee" shadow-intensity="1" camera-controls auto-rotate></model-viewer>
 <script>
     const models = ['shishkebab.glb', 'Astronaut.glb'];
     let i = 0;

--- a/examples/model-formats.html
+++ b/examples/model-formats.html
@@ -47,7 +47,7 @@
 </head>
 <body>
 
-  <div class="sample">
+  <!-- <div class="sample">
     <div id="demo-container-1" class="demo"></div>
     <div class="content">
       <div class="wrapper">
@@ -119,7 +119,7 @@
         </example-snippet>
       </div>
     </div>
-  </div>
+  </div> -->
 
   <div class="sample">
     <div id="demo-container-5" class="demo"></div>
@@ -135,7 +135,7 @@
 <script>
     const models = ['shishkebab.glb', 'Astronaut.glb'];
     let i = 0;
-    setInterval(() => $('#toggle-model').setAttribute('src', `assets/${models[i++ % 2]}`), 2000);
+    setInterval(() => $('#toggle-model').setAttribute('src', `assets/${models[i++ % 2]}`), 10000);
 </script>
           </template>
         </example-snippet>

--- a/examples/model-formats.html
+++ b/examples/model-formats.html
@@ -47,7 +47,7 @@
 </head>
 <body>
 
-  <!-- <div class="sample">
+  <div class="sample">
     <div id="demo-container-1" class="demo"></div>
     <div class="content">
       <div class="wrapper">
@@ -119,7 +119,7 @@
         </example-snippet>
       </div>
     </div>
-  </div> -->
+  </div>
 
   <div class="sample">
     <div id="demo-container-5" class="demo"></div>
@@ -135,7 +135,7 @@
 <script>
     const models = ['shishkebab.glb', 'Astronaut.glb'];
     let i = 0;
-    setInterval(() => $('#toggle-model').setAttribute('src', `assets/${models[i++ % 2]}`), 10000);
+    setInterval(() => $('#toggle-model').setAttribute('src', `assets/${models[i++ % 2]}`), 2000);
 </script>
           </template>
         </example-snippet>

--- a/src/features/controls.ts
+++ b/src/features/controls.ts
@@ -595,14 +595,12 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
 
       this.requestUpdate('maxFieldOfView', this.maxFieldOfView);
       this.requestUpdate('fieldOfView', this.fieldOfView);
-
-      controls.jumpToGoal();
+      this.jumpCameraToGoal();
     }
 
     [$onModelLoad](event: any) {
       super[$onModelLoad](event);
 
-      const controls = this[$controls];
       const {framedFieldOfView} = this[$scene];
       this[$zoomAdjustedFieldOfView] = framedFieldOfView;
 
@@ -610,7 +608,7 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
       this.requestUpdate('fieldOfView', this.fieldOfView);
       this.requestUpdate('cameraOrbit', this.cameraOrbit);
       this.requestUpdate('cameraTarget', this.cameraTarget);
-      controls.jumpToGoal();
+      this.jumpCameraToGoal();
     }
 
     [$onFocus]() {

--- a/src/features/loading.ts
+++ b/src/features/loading.ts
@@ -233,9 +233,12 @@ export const LoadingMixin = <T extends Constructor<ModelViewerElementBase>>(
       }
 
       if (changedProperties.has('src')) {
+        if (!this[$modelIsReadyForReveal]) {
+          this[$lastReportedProgress] = 0;
+        }
+
         this[$posterDismissalSource] = null;
         this[$preloadAttempted] = false;
-        this[$lastReportedProgress] = 0;
         this[$sourceUpdated] = false;
       }
 
@@ -327,10 +330,7 @@ export const LoadingMixin = <T extends Constructor<ModelViewerElementBase>>(
       }
 
       if (this[$modelIsReadyForReveal]) {
-        if (!this[$sourceUpdated]) {
-          this[$updateSource]();
-          this[$hidePoster]();
-        }
+        await this[$updateSource]();
       } else {
         this[$showPoster]();
       }
@@ -397,9 +397,10 @@ export const LoadingMixin = <T extends Constructor<ModelViewerElementBase>>(
     }
 
     async[$updateSource]() {
-      if (this[$modelIsReadyForReveal]) {
+      if (this[$modelIsReadyForReveal] && !this[$sourceUpdated]) {
         this[$sourceUpdated] = true;
         await super[$updateSource]();
+        this[$hidePoster]();
       }
     }
   }

--- a/src/model-viewer-base.ts
+++ b/src/model-viewer-base.ts
@@ -308,12 +308,7 @@ export default class ModelViewerElementBase extends UpdatingElement {
         (this.src == null || this.src !== this[$scene].model.url)) {
       this[$loaded] = false;
       this[$loadedTime] = 0;
-      (async () => {
-        const updateSourceProgress = this[$progressTracker].beginActivity();
-        await this[$updateSource](
-            (progress: number) => updateSourceProgress(progress * 0.9));
-        updateSourceProgress(1.0);
-      })();
+      this[$updateSource]();
     }
 
     if (changedProperties.has('alt')) {
@@ -457,16 +452,19 @@ export default class ModelViewerElementBase extends UpdatingElement {
    * sets the views to use the new model based off of the `preload`
    * attribute.
    */
-  async[$updateSource](
-      progressCallback: (progress: number) => void = () => {}) {
+  async[$updateSource]() {
+    const updateSourceProgress = this[$progressTracker].beginActivity();
     const source = this.src;
 
     try {
       this[$canvas].classList.add('show');
-      await this[$scene].setModelSource(source, progressCallback);
+      await this[$scene].setModelSource(
+          source, (progress: number) => updateSourceProgress(progress * 0.9));
     } catch (error) {
       this[$canvas].classList.remove('show');
       this.dispatchEvent(new CustomEvent('error', {detail: error}));
+    } finally {
+      updateSourceProgress(1.0);
     }
   }
 }

--- a/src/test/features/loading-spec.ts
+++ b/src/test/features/loading-spec.ts
@@ -102,6 +102,41 @@ suite('ModelViewerElementBase with LoadingMixin', () => {
         expect(preloadDispatched).to.be.false;
       });
 
+      suite('load', () => {
+        suite('when a model src changes after loading', () => {
+          setup(async () => {
+            element.src = ASTRONAUT_GLB_PATH;
+            await waitForEvent(element, 'load');
+          });
+
+          test('only dispatches load once per src change', async () => {
+            let loadCount = 0;
+            const onLoad = () => {
+              loadCount++;
+            };
+
+            element.addEventListener('load', onLoad);
+
+            try {
+              element.src = HORSE_GLB_PATH;
+
+              await waitForEvent(element, 'load');
+
+              element.src = ASTRONAUT_GLB_PATH;
+
+              await waitForEvent(element, 'load');
+
+              // Give any late-dispatching events a chance to dispatch
+              await timePasses(300);
+
+              expect(loadCount).to.be.equal(2);
+            } finally {
+              element.removeEventListener('load', onLoad);
+            }
+          });
+        });
+      });
+
       suite('preload', () => {
         suite('src changes quickly', () => {
           test(

--- a/src/three-components/ModelScene.ts
+++ b/src/three-components/ModelScene.ts
@@ -226,7 +226,7 @@ export class ModelScene extends Scene {
     this.frameModel();
     this.setShadowIntensity(this.shadowIntensity);
     if (this.shadow != null) {
-      this.shadow.updateModel(this.model, this.shadowSoftness);
+      this.shadow.setModel(this.model, this.shadowSoftness);
     }
     this.element[$needsRender]();
     this.dispatchEvent({type: 'model-load', url: event.url});

--- a/src/three-components/Shadow.ts
+++ b/src/three-components/Shadow.ts
@@ -59,9 +59,12 @@ export class Shadow extends DirectionalLight {
     this.castShadow = true;
 
     this.floor = new Mesh(new PlaneBufferGeometry, this.shadowMaterial);
+    this.floor.rotateX(-Math.PI / 2);
     this.floor.receiveShadow = true;
     this.floor.castShadow = false;
     this.add(this.floor);
+
+    this.up.set(0, 0, 1);
 
     this.target = target;
 
@@ -72,7 +75,6 @@ export class Shadow extends DirectionalLight {
     this.model = model;
     const {camera} = this.shadow;
 
-    this.floor.rotateX(-Math.PI / 2);
     this.boundingBox.copy(model.boundingBox);
     this.size.copy(model.size);
     const {boundingBox, size} = this;
@@ -93,7 +95,6 @@ export class Shadow extends DirectionalLight {
     // to stay inside the shadow camera.
     this.floor.position.y -= size.y / 2 + this.position.y - 2 * shadowOffset;
 
-    this.up.set(0, 0, 1);
     camera.near = 0;
     camera.far = size.y;
 
@@ -109,8 +110,13 @@ export class Shadow extends DirectionalLight {
   }
 
   setMapSize(maxMapSize: number) {
-    const {camera, mapSize} = this.shadow;
+    const {camera, mapSize, map} = this.shadow;
     const {boundingBox, size} = this;
+
+    if (map != null) {
+      (map as any).dispose();
+      (this.shadow.map as any) = null;
+    }
 
     if (this.model.animationNames.length > 0) {
       maxMapSize *= ANIMATION_SCALING;

--- a/src/three-components/Shadow.ts
+++ b/src/three-components/Shadow.ts
@@ -68,12 +68,6 @@ export class Shadow extends DirectionalLight {
     this.setModel(model, softness);
   }
 
-  updateModel(model: Model, softness: number) {
-    if (this.model !== model) {
-      this.setModel(model, softness);
-    }
-  }
-
   setModel(model: Model, softness: number) {
     this.model = model;
     const {camera} = this.shadow;


### PR DESCRIPTION
Fixes #891

I don't think we had an issue for this yet, but this fixes a problem @mrdoob found [here](https://model-viewer-tester.glitch.me/) when using a shadow and changing models. In addition to fixing this issue, we also uncovered a double load event, which @cdata was kind enough to fix and merge in here along with a resize jank fix.

I also updated our model-switching example to include a shadow to guard against regression.