### PR TITLE
Fix animated shadows with bounding box below zero

### DIFF
--- a/src/three-components/ModelScene.ts
+++ b/src/three-components/ModelScene.ts
@@ -14,9 +14,11 @@
  */
 
 import {BackSide, BoxBufferGeometry, Camera, Color, Event as ThreeEvent, Mesh, Object3D, PerspectiveCamera, Scene, Shader, ShaderLib, ShaderMaterial, Vector3} from 'three';
+import {CameraHelper} from 'three';
 
 import ModelViewerElementBase, {$needsRender, $renderer} from '../model-viewer-base.js';
 import {resolveDpr} from '../utilities.js';
+import {showShadowHelper} from '../utilities/debug.js';
 
 import Model, {DEFAULT_FOV_DEG} from './Model.js';
 import {cubeUVChunk} from './shader-chunk/cube_uv_reflection_fragment.glsl.js';
@@ -228,6 +230,9 @@ export class ModelScene extends Scene {
     if (this.shadow != null) {
       this.shadow.setModel(this.model, this.shadowSoftness);
     }
+    if (this.children.length > 1) {
+      (this.children[1] as CameraHelper).update();
+    }
     this.element[$needsRender]();
     this.dispatchEvent({type: 'model-load', url: event.url});
   }
@@ -241,7 +246,7 @@ export class ModelScene extends Scene {
       if (this.shadow == null) {
         this.shadow = new Shadow(this.model, this.pivot, this.shadowSoftness);
         this.pivot.add(this.shadow);
-        // showShadowHelper(this);
+        showShadowHelper(this);
       }
       this.shadow.setIntensity(shadowIntensity);
     }

--- a/src/three-components/ModelScene.ts
+++ b/src/three-components/ModelScene.ts
@@ -14,11 +14,9 @@
  */
 
 import {BackSide, BoxBufferGeometry, Camera, Color, Event as ThreeEvent, Mesh, Object3D, PerspectiveCamera, Scene, Shader, ShaderLib, ShaderMaterial, Vector3} from 'three';
-import {CameraHelper} from 'three';
 
 import ModelViewerElementBase, {$needsRender, $renderer} from '../model-viewer-base.js';
 import {resolveDpr} from '../utilities.js';
-import {showShadowHelper} from '../utilities/debug.js';
 
 import Model, {DEFAULT_FOV_DEG} from './Model.js';
 import {cubeUVChunk} from './shader-chunk/cube_uv_reflection_fragment.glsl.js';
@@ -230,9 +228,10 @@ export class ModelScene extends Scene {
     if (this.shadow != null) {
       this.shadow.setModel(this.model, this.shadowSoftness);
     }
-    if (this.children.length > 1) {
-      (this.children[1] as CameraHelper).update();
-    }
+    // Uncomment if using showShadowHelper below
+    // if (this.children.length > 1) {
+    //   (this.children[1] as CameraHelper).update();
+    // }
     this.element[$needsRender]();
     this.dispatchEvent({type: 'model-load', url: event.url});
   }
@@ -246,7 +245,7 @@ export class ModelScene extends Scene {
       if (this.shadow == null) {
         this.shadow = new Shadow(this.model, this.pivot, this.shadowSoftness);
         this.pivot.add(this.shadow);
-        showShadowHelper(this);
+        // showShadowHelper(this);
       }
       this.shadow.setIntensity(shadowIntensity);
     }

--- a/src/three-components/Shadow.ts
+++ b/src/three-components/Shadow.ts
@@ -20,7 +20,7 @@ import Model from './Model';
 // Nothing within Offset of the bottom of the model casts a shadow
 // (this is to avoid having a baked-in shadow plane cast its own shadow).
 const OFFSET = 0.001;
-const BASE_OPACITY = 0.1;
+const BASE_OPACITY = 1.0;
 // The softness [0, 1] of the shadow is mapped to a resolution between
 // 2^LOG_MAX_RESOLUTION and 2^LOG_MIN_RESOLUTION.
 const LOG_MAX_RESOLUTION = 9;
@@ -57,11 +57,13 @@ export class Shadow extends DirectionalLight {
     // We use the light only to cast a shadow, not to light the scene.
     this.intensity = 0;
     this.castShadow = true;
+    this.frustumCulled = false;
 
     this.floor = new Mesh(new PlaneBufferGeometry, this.shadowMaterial);
     this.floor.rotateX(-Math.PI / 2);
     this.floor.receiveShadow = true;
     this.floor.castShadow = false;
+    this.floor.frustumCulled = false;
     this.add(this.floor);
 
     this.shadow.camera.up.set(0, 0, 1);
@@ -138,6 +140,7 @@ export class Shadow extends DirectionalLight {
     camera.top = boundingBox.max.z + heightPad;
 
     this.updateMatrixWorld();
+    camera.updateProjectionMatrix();
     (this.shadow as any).updateMatrices(this);
 
     this.floor.scale.set(size.x + 2 * widthPad, size.z + 2 * heightPad, 1);

--- a/src/three-components/Shadow.ts
+++ b/src/three-components/Shadow.ts
@@ -20,7 +20,7 @@ import Model from './Model';
 // Nothing within Offset of the bottom of the model casts a shadow
 // (this is to avoid having a baked-in shadow plane cast its own shadow).
 const OFFSET = 0.001;
-const BASE_OPACITY = 1.0;
+const BASE_OPACITY = 0.1;
 // The softness [0, 1] of the shadow is mapped to a resolution between
 // 2^LOG_MAX_RESOLUTION and 2^LOG_MIN_RESOLUTION.
 const LOG_MAX_RESOLUTION = 9;
@@ -86,7 +86,7 @@ export class Shadow extends DirectionalLight {
       size.y = maxDimension;
       boundingBox.expandByVector(
           size.subScalar(maxDimension).multiplyScalar(-0.5));
-      boundingBox.max.y = maxDimension;
+      boundingBox.max.y = boundingBox.min.y + maxDimension;
       size.set(maxDimension, maxDimension, maxDimension);
     }
 

--- a/src/utilities/debug.ts
+++ b/src/utilities/debug.ts
@@ -25,6 +25,7 @@ import {Renderer} from '../three-components/Renderer';
 export const showShadowHelper = (scene: ModelScene) => {
   if (scene.shadow != null) {
     const helper = new CameraHelper(scene.shadow.shadow.camera);
+    helper.frustumCulled = false;
     scene.add(helper);
   }
 };


### PR DESCRIPTION
Fixes #939 

The actual fix is just a one-liner on the bounding box calculation. The other changes are to make the shadowHelper work better when it's being used for debug. 
